### PR TITLE
feat: add missing RPC methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10057,7 +10057,6 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde",
  "alloy-signer",
  "jsonrpsee-types",
  "op-alloy-consensus",
@@ -10071,7 +10070,6 @@ dependencies = [
  "reth-storage-api",
  "revm-context",
  "serde",
- "serde_json",
  "thiserror 2.0.16",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10070,6 +10070,8 @@ dependencies = [
  "reth-primitives-traits",
  "reth-storage-api",
  "revm-context",
+ "serde",
+ "serde_json",
  "thiserror 2.0.16",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10057,6 +10057,7 @@ dependencies = [
  "alloy-network",
  "alloy-primitives",
  "alloy-rpc-types-eth",
+ "alloy-serde",
  "alloy-signer",
  "jsonrpsee-types",
  "op-alloy-consensus",

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -25,7 +25,6 @@ alloy-signer.workspace = true
 alloy-consensus.workspace = true
 alloy-network.workspace = true
 alloy-json-rpc.workspace = true
-alloy-serde.workspace = true
 
 # optimism
 op-alloy-consensus = { workspace = true, optional = true }
@@ -45,11 +44,10 @@ thiserror.workspace = true
 
 # serialization
 serde = { workspace = true, features = ["derive"], optional = true }
-serde_json = { workspace = true, optional = true }
 
 [features]
 default = ["serde"]
-serde = ["dep:serde", "dep:serde_json"]
+serde = ["dep:serde"]
 op = [
     "dep:serde",
     "dep:op-alloy-consensus",

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -42,9 +42,14 @@ jsonrpsee-types.workspace = true
 # error
 thiserror.workspace = true
 
+# serialization
+serde = { workspace = true, features = ["derive"], optional = true }
+
 [features]
-default = []
+default = ["serde"]
+serde = ["dep:serde"]
 op = [
+    "dep:serde",
     "dep:op-alloy-consensus",
     "dep:op-alloy-rpc-types",
     "dep:op-alloy-network",

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -25,6 +25,7 @@ alloy-signer.workspace = true
 alloy-consensus.workspace = true
 alloy-network.workspace = true
 alloy-json-rpc.workspace = true
+alloy-serde.workspace = true
 
 # optimism
 op-alloy-consensus = { workspace = true, optional = true }
@@ -44,10 +45,11 @@ thiserror.workspace = true
 
 # serialization
 serde = { workspace = true, features = ["derive"], optional = true }
+serde_json = { workspace = true, optional = true }
 
 [features]
 default = ["serde"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "dep:serde_json"]
 op = [
     "dep:serde",
     "dep:op-alloy-consensus",

--- a/crates/rpc/rpc-convert/src/custom_header.rs
+++ b/crates/rpc/rpc-convert/src/custom_header.rs
@@ -1,0 +1,195 @@
+//! Custom RPC header types with additional fields
+
+use alloy_primitives::{BlockHash, U256};
+use alloy_network::primitives::HeaderResponse;
+
+/// Custom RPC header that extends the standard header with additional fields
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct CustomRpcHeader<H = alloy_consensus::Header> {
+    /// Hash of the block
+    pub hash: BlockHash,
+    /// Inner consensus header.
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub inner: H,
+    /// Total difficulty
+    ///
+    /// Note: This field is now effectively deprecated: <https://github.com/ethereum/execution-apis/pull/570>
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub total_difficulty: Option<U256>,
+    /// Integer the size of this block in bytes.
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub size: Option<U256>,
+    /// Millisecond timestamp - custom field for BNB Chain
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Option::is_none"))]
+    pub milli_timestamp: Option<u64>,
+}
+
+impl<H> CustomRpcHeader<H> {
+    /// Create a new custom header from consensus header components
+    pub fn new(
+        hash: BlockHash,
+        inner: H,
+        total_difficulty: Option<U256>,
+        size: Option<U256>,
+        milli_timestamp: Option<u64>,
+    ) -> Self {
+        Self { hash, inner, total_difficulty, size, milli_timestamp }
+    }
+
+    /// Create a custom header from a consensus header
+    pub fn from_consensus(
+        header: alloy_consensus::Header,
+        total_difficulty: Option<U256>,
+        size: Option<U256>,
+    ) -> CustomRpcHeader<alloy_consensus::Header> {
+        let hash = header.hash_slow();
+        let milli_timestamp = Some(header.timestamp * 1000);
+
+        CustomRpcHeader { hash, inner: header, total_difficulty, size, milli_timestamp }
+    }
+
+    /// Create a custom header from any block header
+    pub fn from_header<T: reth_primitives_traits::BlockHeader>(
+        header: T,
+        hash: BlockHash,
+        total_difficulty: Option<U256>,
+        size: Option<U256>,
+    ) -> CustomRpcHeader<T> {
+        let milli_timestamp = Some(header.timestamp() * 1000);
+
+        CustomRpcHeader { hash, inner: header, total_difficulty, size, milli_timestamp }
+    }
+}
+
+impl<H> HeaderResponse for CustomRpcHeader<H>
+where
+    H: alloy_consensus::BlockHeader,
+{
+    fn hash(&self) -> BlockHash {
+        self.hash
+    }
+}
+
+impl<H> alloy_consensus::BlockHeader for CustomRpcHeader<H>
+where
+    H: alloy_consensus::BlockHeader,
+{
+    fn parent_hash(&self) -> alloy_primitives::B256 {
+        self.inner.parent_hash()
+    }
+
+    fn ommers_hash(&self) -> alloy_primitives::B256 {
+        self.inner.ommers_hash()
+    }
+
+    fn beneficiary(&self) -> alloy_primitives::Address {
+        self.inner.beneficiary()
+    }
+
+    fn state_root(&self) -> alloy_primitives::B256 {
+        self.inner.state_root()
+    }
+
+    fn transactions_root(&self) -> alloy_primitives::B256 {
+        self.inner.transactions_root()
+    }
+
+    fn receipts_root(&self) -> alloy_primitives::B256 {
+        self.inner.receipts_root()
+    }
+
+    fn withdrawals_root(&self) -> Option<alloy_primitives::B256> {
+        self.inner.withdrawals_root()
+    }
+
+    fn logs_bloom(&self) -> alloy_primitives::Bloom {
+        self.inner.logs_bloom()
+    }
+
+    fn difficulty(&self) -> alloy_primitives::U256 {
+        self.inner.difficulty()
+    }
+
+    fn number(&self) -> u64 {
+        self.inner.number()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.inner.gas_limit()
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.inner.gas_used()
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.inner.timestamp()
+    }
+
+    fn mix_hash(&self) -> Option<alloy_primitives::B256> {
+        self.inner.mix_hash()
+    }
+
+    fn nonce(&self) -> Option<alloy_primitives::FixedBytes<8>> {
+        self.inner.nonce()
+    }
+
+    fn base_fee_per_gas(&self) -> Option<u64> {
+        self.inner.base_fee_per_gas()
+    }
+
+    fn blob_gas_used(&self) -> Option<u64> {
+        self.inner.blob_gas_used()
+    }
+
+    fn excess_blob_gas(&self) -> Option<u64> {
+        self.inner.excess_blob_gas()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<alloy_primitives::B256> {
+        self.inner.parent_beacon_block_root()
+    }
+
+    fn requests_hash(&self) -> Option<alloy_primitives::B256> {
+        self.inner.requests_hash()
+    }
+
+    fn extra_data(&self) -> &alloy_primitives::Bytes {
+        self.inner.extra_data()
+    }
+}
+
+// RpcObject is automatically implemented via blanket impl for types that implement Serialize + Deserialize
+
+/// Type alias for the standard Ethereum custom header
+pub type EthereumCustomHeader = CustomRpcHeader<alloy_consensus::Header>;
+
+/// Custom header converter that creates CustomRpcHeader instances
+#[derive(Debug, Clone)]
+pub struct CustomHeaderConverter;
+
+impl<H> crate::transaction::HeaderConverter<H, CustomRpcHeader<H>> for CustomHeaderConverter
+where
+    H: reth_primitives_traits::BlockHeader + Clone,
+{
+    fn convert_header(
+        &self,
+        header: reth_primitives_traits::SealedHeader<H>,
+        block_size: usize,
+        td: Option<alloy_primitives::U256>,
+    ) -> CustomRpcHeader<H> {
+        let header_hash = header.hash();
+        let consensus_header = header.into_header();
+        let milli_timestamp = Some(consensus_header.timestamp() * 1000);
+
+        CustomRpcHeader {
+            hash: header_hash,
+            inner: consensus_header,
+            total_difficulty: td,
+            size: Some(alloy_primitives::U256::from(block_size)),
+            milli_timestamp,
+        }
+    }
+}

--- a/crates/rpc/rpc-convert/src/lib.rs
+++ b/crates/rpc/rpc-convert/src/lib.rs
@@ -18,7 +18,9 @@ mod rpc;
 pub mod transaction;
 
 pub use block::TryFromBlockResponse;
-pub use custom_header::{CustomHeaderConverter, CustomRpcHeader, EthereumCustomHeader};
+pub use custom_header::{
+    calculate_millisecond_timestamp, CustomHeaderConverter, CustomRpcHeader, EthereumCustomHeader,
+};
 pub use fees::{CallFees, CallFeesError};
 pub use receipt::TryFromReceiptResponse;
 pub use rpc::*;

--- a/crates/rpc/rpc-convert/src/lib.rs
+++ b/crates/rpc/rpc-convert/src/lib.rs
@@ -11,12 +11,14 @@
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
 pub mod block;
+pub mod custom_header;
 mod fees;
 pub mod receipt;
 mod rpc;
 pub mod transaction;
 
 pub use block::TryFromBlockResponse;
+pub use custom_header::{CustomHeaderConverter, CustomRpcHeader, EthereumCustomHeader};
 pub use fees::{CallFees, CallFeesError};
 pub use receipt::TryFromReceiptResponse;
 pub use rpc::*;

--- a/crates/rpc/rpc-convert/src/rpc.rs
+++ b/crates/rpc/rpc-convert/src/rpc.rs
@@ -26,7 +26,6 @@ impl<T> RpcTypes for T
 where
     T: Network<TransactionRequest: AsRef<TransactionRequest> + AsMut<TransactionRequest>> + Unpin,
 {
-    // type Header = T::HeaderResponse;
     type Header = crate::CustomRpcHeader<alloy_consensus::Header>;
     type Receipt = T::ReceiptResponse;
     type TransactionResponse = T::TransactionResponse;

--- a/crates/rpc/rpc-convert/src/rpc.rs
+++ b/crates/rpc/rpc-convert/src/rpc.rs
@@ -26,7 +26,8 @@ impl<T> RpcTypes for T
 where
     T: Network<TransactionRequest: AsRef<TransactionRequest> + AsMut<TransactionRequest>> + Unpin,
 {
-    type Header = T::HeaderResponse;
+    // type Header = T::HeaderResponse;
+    type Header = crate::CustomRpcHeader<alloy_consensus::Header>;
     type Receipt = T::ReceiptResponse;
     type TransactionResponse = T::TransactionResponse;
     type TransactionRequest = T::TransactionRequest;

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -88,18 +88,6 @@ pub trait FromConsensusHeader<T> {
     fn from_consensus_header(header: SealedHeader<T>, block_size: usize, td: Option<U256>) -> Self;
 }
 
-// impl<T: Sealable> FromConsensusHeader<T> for alloy_rpc_types_eth::Header<T> {
-//     fn from_consensus_header(header: SealedHeader<T>, block_size: usize, td: Option<U256>) -> Self {
-//         let header_hash = header.hash();
-//         Self {
-//             hash: header_hash,
-//             inner: header.into_header(),
-//             total_difficulty: td,
-//             size: Some(U256::from(block_size)),
-//         }
-//     }
-// }
-
 impl FromConsensusHeader<alloy_consensus::Header>
     for crate::CustomRpcHeader<alloy_consensus::Header>
 {

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -1,12 +1,11 @@
 //! Compatibility functions for rpc `Transaction` type.
 
 use crate::{
+    calculate_millisecond_timestamp,
     fees::{CallFees, CallFeesError},
     RpcHeader, RpcReceipt, RpcTransaction, RpcTxReq, RpcTypes,
 };
-use alloy_consensus::{
-    error::ValueError, transaction::Recovered, EthereumTxEnvelope, Sealable, TxEip4844,
-};
+use alloy_consensus::{error::ValueError, transaction::Recovered, EthereumTxEnvelope, TxEip4844};
 use alloy_network::Network;
 use alloy_primitives::{Address, TxKind, U256};
 use alloy_rpc_types_eth::{
@@ -111,7 +110,7 @@ impl FromConsensusHeader<alloy_consensus::Header>
     ) -> Self {
         let header_hash = header.hash();
         let consensus_header = header.into_header();
-        let milli_timestamp = Some(consensus_header.timestamp * 1000);
+        let milli_timestamp = Some(U256::from(calculate_millisecond_timestamp(&consensus_header)));
 
         Self {
             hash: header_hash,

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -17,6 +17,7 @@ use alloy_rpc_types_eth::{
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_rpc_convert::RpcTxReq;
+use reth_rpc_eth_types::TransactionDataAndReceipt;
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use tracing::trace;
 
@@ -121,6 +122,10 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
         index: Index,
     ) -> RpcResult<Option<B>>;
 
+    /// Returns pending transactions.
+    #[method(name = "pendingTransactions")]
+    async fn pending_transactions(&self) -> RpcResult<Option<Vec<T>>>;
+
     /// Returns the EIP-2718 encoded transaction if it exists.
     ///
     /// If this is a EIP-4844 transaction that is in the pool it will include the sidecar.
@@ -164,6 +169,17 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
         index: Index,
     ) -> RpcResult<Option<T>>;
 
+    /// Returns information about all transactions by block hash.
+    #[method(name = "getTransactionsByBlockHash")]
+    async fn transactions_by_block_hash(&self, hash: B256) -> RpcResult<Option<Vec<T>>>;
+
+    /// Returns information about all transactions by block number.
+    #[method(name = "getTransactionsByBlockNumber")]
+    async fn transactions_by_block_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<Option<Vec<T>>>;
+
     /// Returns information about a transaction by sender and nonce.
     #[method(name = "getTransactionBySenderAndNonce")]
     async fn transaction_by_sender_and_nonce(
@@ -175,6 +191,13 @@ pub trait EthApi<TxReq: RpcObject, T: RpcObject, B: RpcObject, R: RpcObject, H: 
     /// Returns the receipt of a transaction by transaction hash.
     #[method(name = "getTransactionReceipt")]
     async fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<R>>;
+
+    /// Returns the transaction data and receipt for a transaction by transaction hash.
+    #[method(name = "getTransactionDataAndReceipt")]
+    async fn transaction_data_and_receipt(
+        &self,
+        hash: B256,
+    ) -> RpcResult<Option<TransactionDataAndReceipt<T, R>>>;
 
     /// Returns the balance of the account of given address.
     #[method(name = "getBalance")]
@@ -519,6 +542,14 @@ where
         Ok(EthBlocks::ommer_by_block_and_index(self, number.into(), index).await?)
     }
 
+    /// Handler for: `eth_pendingTransactions`
+    async fn pending_transactions(
+        &self,
+    ) -> RpcResult<Option<Vec<RpcTransaction<T::NetworkTypes>>>> {
+        trace!(target: "rpc::eth", "Serving eth_pendingTransactions");
+        Ok(EthTransactions::pending_transactions(self).await?)
+    }
+
     /// Handler for: `eth_getRawTransactionByHash`
     async fn raw_transaction_by_hash(&self, hash: B256) -> RpcResult<Option<Bytes>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getRawTransactionByHash");
@@ -585,6 +616,24 @@ where
             .await?)
     }
 
+    /// Handler for: `eth_getTransactionsByBlockHash`
+    async fn transactions_by_block_hash(
+        &self,
+        hash: B256,
+    ) -> RpcResult<Option<Vec<RpcTransaction<T::NetworkTypes>>>> {
+        trace!(target: "rpc::eth", ?hash, "Serving eth_getTransactionsByBlockHash");
+        Ok(EthTransactions::transactions_by_block_id(self, hash.into()).await?)
+    }
+
+    /// Handler for: `eth_getTransactionsByBlockNumber`
+    async fn transactions_by_block_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<Option<Vec<RpcTransaction<T::NetworkTypes>>>> {
+        trace!(target: "rpc::eth", ?number, "Serving eth_getTransactionsByBlockNumber");
+        Ok(EthTransactions::transactions_by_block_id(self, number.into()).await?)
+    }
+
     /// Handler for: `eth_getTransactionBySenderAndNonce`
     async fn transaction_by_sender_and_nonce(
         &self,
@@ -603,6 +652,19 @@ where
     ) -> RpcResult<Option<RpcReceipt<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getTransactionReceipt");
         Ok(EthTransactions::transaction_receipt(self, hash).await?)
+    }
+
+    /// Handler for: `eth_getTransactionDataAndReceipt`
+    async fn transaction_data_and_receipt(
+        &self,
+        hash: B256,
+    ) -> RpcResult<
+        Option<
+            TransactionDataAndReceipt<RpcTransaction<T::NetworkTypes>, RpcReceipt<T::NetworkTypes>>,
+        >,
+    > {
+        trace!(target: "rpc::eth", ?hash, "Serving eth_getTransactionDataAndReceipt");
+        Ok(EthTransactions::transaction_data_and_receipt(self, hash).await?)
     }
 
     /// Handler for: `eth_getBalance`

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -49,6 +49,9 @@ pub type RpcHeader<T> = <T as RpcTypes>::Header;
 /// Adapter for network specific error type.
 pub type RpcError<T> = <T as EthApiTypes>::Error;
 
+// /// Adapter for network specific data and receipt type.
+// pub type RpcDataAndReceipt<T> = <T as RpcTypes>::DataAndReceipt;
+
 /// Helper trait holds necessary trait bounds on [`EthApiTypes`] to implement `eth` API.
 pub trait FullEthApiTypes
 where

--- a/crates/rpc/rpc-eth-api/src/types.rs
+++ b/crates/rpc/rpc-eth-api/src/types.rs
@@ -49,9 +49,6 @@ pub type RpcHeader<T> = <T as RpcTypes>::Header;
 /// Adapter for network specific error type.
 pub type RpcError<T> = <T as EthApiTypes>::Error;
 
-// /// Adapter for network specific data and receipt type.
-// pub type RpcDataAndReceipt<T> = <T as RpcTypes>::DataAndReceipt;
-
 /// Helper trait holds necessary trait bounds on [`EthApiTypes`] to implement `eth` API.
 pub trait FullEthApiTypes
 where

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -34,5 +34,5 @@ pub use gas_oracle::{
 };
 pub use id_provider::EthSubscriptionIdProvider;
 pub use pending_block::{PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
-pub use transaction::TransactionSource;
+pub use transaction::{TransactionDataAndReceipt, TransactionSource};
 pub use tx_forward::ForwardConfig;

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -256,7 +256,7 @@ where
     let block = block.into_rpc_block(
         txs_kind,
         |tx, tx_info| tx_resp_builder.fill(tx, tx_info),
-        |header, size| tx_resp_builder.convert_header(header, size),
+        |header, size| tx_resp_builder.convert_header(header, size, None),
     )?;
     Ok(SimulatedBlock { inner: block, calls })
 }

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -273,33 +273,43 @@ macro_rules! impl_compression_fixed_compact {
 
 impl_compression_fixed_compact!(B256, Address);
 
-// -----------------------------------------------------------------------------
-//  Parlia snapshot raw blob (BNB Smart Chain checkpoints)
-// -----------------------------------------------------------------------------
+/// Parlia snapshot raw blob (BNB Smart Chain checkpoints)
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ParliaSnapshotBlob(pub Vec<u8>);
 
 impl crate::table::Compress for ParliaSnapshotBlob {
     type Compressed = Vec<u8>;
-    fn uncompressable_ref(&self) -> Option<&[u8]> { Some(&self.0) }
-    fn compress(self) -> Self::Compressed { self.0 }
+    fn uncompressable_ref(&self) -> Option<&[u8]> {
+        Some(&self.0)
+    }
+    fn compress(self) -> Self::Compressed {
+        self.0
+    }
     fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
         buf.put_slice(&self.0);
     }
 }
 
 impl crate::table::Decompress for ParliaSnapshotBlob {
-    fn decompress(value: &[u8]) -> Result<Self, DatabaseError> { Ok(Self(value.to_vec())) }
+    fn decompress(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self(value.to_vec()))
+    }
 }
 
 impl crate::table::Encode for ParliaSnapshotBlob {
     type Encoded = Vec<u8>;
-    fn encode(self) -> Self::Encoded { self.0 }
+    fn encode(self) -> Self::Encoded {
+        self.0
+    }
 }
 
 impl crate::table::Decode for ParliaSnapshotBlob {
-    fn decode(value: &[u8]) -> Result<Self, DatabaseError> { Ok(Self(value.to_vec())) }
-    fn decode_owned(value: Vec<u8>) -> Result<Self, DatabaseError> { Ok(Self(value)) }
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self(value.to_vec()))
+    }
+    fn decode_owned(value: Vec<u8>) -> Result<Self, DatabaseError> {
+        Ok(Self(value))
+    }
 }
 
 /// Adds wrapper structs for some primitive types so they can use `StructFlags` from Compact, when


### PR DESCRIPTION
## Description

- add missing RPC methods: `eth_pendingTransactions/eth_getTransactionDataAndReceipt/eth_getTransactionsByBlockHash/eth_getTransactionsByBlockNumber`
- `eth_getHeaderByNumber/eth_getBlockByHash/eth_getBlockByNumber` add `milliTimestamp` and `totalDifficulty` fields: 
