### PR TITLE
fix: fix storage root in progress when livesync+parallel hash

### DIFF
--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -135,6 +135,7 @@ where
                         #[cfg(feature = "metrics")]
                         metrics,
                     )
+                    .with_no_threshold()
                     .calculate(retain_updates)?)
                 })();
                 let _ = tx.send(result);

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -193,6 +193,7 @@ where
                                 #[cfg(feature = "metrics")]
                                 self.metrics.storage_trie.clone(),
                             )
+                            .with_no_threshold()
                             .calculate(retain_updates)?
                         }
                     };


### PR DESCRIPTION
### Description

Fix storageroot inprogress.

### Rationale

In situations where a single block might update a large number of slots, we need this https://github.com/bnb-chain/reth/pull/36 or `--engine.disable-parallel-sparse-trie ` to avoid storage-root is not completed.

Also note that there have been significant changes to the concurrent hash calculation part of upstream reth. In the long run, we will merge the upstream code to maintain stability.

### Example

```
2025-11-04T03:25:30.114112Z DEBUG engine::tree: failed to connect buffered block to tree err=InsertBlockError { error: Other(StorageRoot(Database(Other("StorageRoot returned Progress variant in parallel trie calculation")))), hash: 0xe74bccae1280a0338facc02a6d4fdfd4d8570a132d1feed4960750f0aeb3b797, number: 10571139, parent_hash: 0x36adc3313425a5e7a9a7d978f43f88b7252c8064bf6885798413f1b14c0f84cd, num_txs: 3721, .. } 
2025-11-04T03:25:30.114936Z  WARN engine::tree: fatal error occurred while connecting buffered blocks fatal=StorageRoot returned Progress variant in parallel trie calculation
2025-11-04T03:25:30.115663Z ERROR engine::tree: insert block fatal error fatal=StorageRoot returned Progress variant in parallel trie calculation
2025-11-04T03:25:30.816636Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0x963f924a45cca840cae25d6074bd0b0279b160ff343e200e3d1515224e819151 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816674Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0x453b822a65ca83b56a6aa91724cc901f21dcb142228111669fa50ccdada0eed1 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816798Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xd1cd93052b08f471ffd543654e1db461ea09abe9244463d4c6437c9650680001 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816804Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0x2db5c296cb65f73932c230d54ec50d0fb5973da22dfb2b59759f9ed23ff22b17 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816816Z ERROR ChainOrchestrator::poll: engine::tree: Fatal error
2025-11-04T03:25:30.816824Z DEBUG reth::cli: Event: FatalError
2025-11-04T03:25:30.816828Z ERROR reth::cli: Fatal error in consensus engine
2025-11-04T03:25:30.816845Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xf82531a1e242df236b2bbd603931455501ffcc91e23013f1b8f40a8086099f0d error=beacon consensus engine task stopped
2025-11-04T03:25:30.816891Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xe5d7ebd9c7992a28d1a6da5194049345f58e3583e30a5b0bb5cc87ef15a20059 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816898Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xc49dac3c14c187a8e4b5b8cd1a4b22cdb247eb4c96efd8447e8650bf834840be error=beacon consensus engine task stopped
2025-11-04T03:25:30.816901Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xf58884abe463759515e54162074267d6326c8ecc191cc06b845a49a010f029ba error=beacon consensus engine task stopped
2025-11-04T03:25:30.816904Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0xee7f0c423199f62962cbe4e3088c69e601da2644940c6e0ccddba83109e3e252 error=beacon consensus engine task stopped
2025-11-04T03:25:30.816907Z  WARN bsc::block_import: Failed to trigger block download via FCU block_hash=0x0bb895ca28be80ac28e32598c7f1403c1a10305d041c42378fb641a9b54282e0 error=beacon consensus engine task stopped
2025-11-04T03:25:30.818124Z ERROR reth::cli: shutting down due to error

```

Key log is 
`2025-11-04T03:25:30.114744Z  WARN fatal error occurred while connecting buffered blocks fatal=StorageRoot returned Progress variant in parallel trie calculation`

### Changes

Notable changes: 
* parallel hash.

### Potential Impacts
N/A.
