### PR TITLE
fix: allow at most one in-flight tx

### DIFF
--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -827,9 +827,8 @@ impl<T: TransactionOrdering> TxPool<T> {
     /// This verifies that the transaction complies with code authorization
     /// restrictions brought by EIP-7702 transaction type:
     /// 1. Any account with a deployed delegation or an in-flight authorization to deploy a
-    ///    delegation will only be allowed a certain amount of transaction slots (default 1) instead
-    ///    of the standard limit. This is due to the possibility of the account being sweeped by an
-    ///    unrelated account.
+    ///    delegation will only be allowed a single transaction slot instead of the standard limit.
+    ///    This is due to the possibility of the account being sweeped by an unrelated account.
     /// 2. In case the pool is tracking a pending / queued transaction from a specific account, at
     ///    most one in-flight transaction is allowed; any additional delegated transactions from
     ///    that account will be rejected.
@@ -844,7 +843,6 @@ impl<T: TransactionOrdering> TxPool<T> {
 
         if let Some(authority_list) = &transaction.authority_ids {
             for sender_id in authority_list {
-                // Ensure authority has at most 1 inflight transaction.
                 if self.all_transactions.txs_iter(*sender_id).nth(1).is_some() {
                     return Err(PoolError::new(
                         *transaction.hash(),


### PR DESCRIPTION
This PR will align reth's 7702 auth checking logic with geth, picked from upstream.

ref: https://github.com/paradigmxyz/reth/pull/17960/files