### PR TITLE
fix: add ensure_canonical_block check in history_by_block_hash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,79 @@
-# Reth Development Guide for AI Agents
+# BNB Chain Reth (bnb-chain/reth) — Development Guide
 
-This guide provides comprehensive instructions for AI agents working on the Reth codebase. It covers the architecture, development workflows, and critical guidelines for effective contributions.
+This guide provides comprehensive instructions for AI agents working on the **BNB Chain fork** of the Reth codebase. This is a production-grade execution layer client specifically adapted for **BNB Smart Chain (BSC)**.
+
+**Repository**: `bnb-chain/reth` (https://github.com/bnb-chain/reth)
+**Upstream**: Fork of `paradigmxyz/reth` (v1.7.0 baseline)
+**Main branch**: `main`
+
+---
+
+## Relationship: reth-bsc and reth
+
+`bnb-chain/reth` (this repo) is the **core library layer** — a fork of upstream `paradigmxyz/reth` with BSC-specific modifications (Parlia consensus, TrieDB, system transactions, custom RPC, etc.).
+
+`bnb-chain/reth-bsc` is the **application layer** that depends on this repo. It is the actual BSC node binary that imports crates from `bnb-chain/reth` as git dependencies. Issues reported in `reth-bsc` (e.g., RPC returning wrong data during staged sync) often have root causes in this repo's provider/storage layer.
+
+When fixing issues from `reth-bsc`:
+1. Trace the call path from RPC through the provider layer in this repo
+2. Apply fixes here in `bnb-chain/reth`
+3. The `reth-bsc` project will pick up fixes via git dependency updates
+
+---
+
+## BSC Fork Summary
+
+This fork adapts the Ethereum-focused Reth client for BNB Smart Chain. Key differences from upstream:
+
+| Aspect | Upstream Reth | BSC Fork |
+|--------|--------------|----------|
+| Consensus | PoS (Beacon Chain) | **Parlia** (Validator-based PoSA) |
+| Finalized Block | Beacon Chain determined | Validator snapshot based |
+| State Backend | MDBX only | **MDBX + TrieDB** (dual backend) |
+| System Txs | Not supported | Supported (`gas_limit == u64::MAX/2`) |
+| P2P Peers | Standard | **Proxied peer** support |
+| Custom RPC | Standard Ethereum | `eth_getFinalizedBlock`, `eth_getFinalizedHeader` |
+| Hardforks | Ethereum only | Ethereum + BSC-specific (Ramanujan → Pascal) |
+
+### BSC-Specific Features
+
+1. **Parlia Consensus Engine**: BSC's Proof-of-Staked-Authority (PoSA) consensus replacing Ethereum's PoS. Implementation in `examples/bsc-p2p/src/block_import/parlia.rs`. Canonical head: highest block number wins; for equal heights, lower hash wins.
+
+2. **TrieDB State Storage Backend**: Alternative state database alongside MDBX. Configured via `StateDbConfig` in `crates/config/src/config.rs`. Supports genesis init, staged sync, live sync, and io-uring. Dependencies from `bnb-chain/reth-bsc-triedb`.
+
+3. **BSC System Transactions**: Special transactions identified by `gas_limit == u64::MAX/2 && caller == beneficiary`. Exempted from block gas limit validation. Handled across all RPC tracers via `handle_bsc_system_transaction()` in `crates/rpc/rpc/src/debug.rs`.
+
+4. **Custom RPC Methods**: `eth_getFinalizedBlock(verified_validator_num)` and `eth_getFinalizedHeader(verified_validator_num)` in `crates/rpc/rpc-eth-api/src/core.rs` and `helpers/block.rs`.
+
+5. **Proxied Peer Support**: Enhanced P2P networking with proxy peer definitions in `crates/net/network/` and `crates/net/eth-wire-types/`.
+
+6. **Validator Block Snapshot Table**: BSC validator support integrated into the engine with a dedicated database table.
+
+7. **Blob Fee Validation**: Enhanced blob storage with extended time support and fee checks for EIP-4844 compatibility on BSC.
+
+8. **BSC Hardforks**: Ramanujan, Niels, MirrorSync, Bruno, Euler, Nano, Moran, Gibbs, Planck, Luban, Plato, Hertz, HertzFix, Kepler, Feynman, FeynmanFix, Haber, HaberFix, Bohr, Pascal, Prague — defined in `examples/bsc-p2p/src/chainspec.rs`.
+
+### Key BSC Code Locations
+
+- `examples/bsc-p2p/` — Complete BSC P2P node example (Parlia consensus, chainspec, genesis)
+- `crates/config/src/config.rs` — `StateDbConfig` for TrieDB/MDBX selection
+- `crates/rpc/rpc/src/debug.rs` — BSC system transaction handling in tracers
+- `crates/rpc/rpc-eth-api/src/core.rs` — Custom `eth_getFinalizedBlock` / `eth_getFinalizedHeader`
+- `crates/rpc/rpc-eth-api/src/helpers/block.rs` — Finalized block logic with validator count
+- `crates/transaction-pool/src/validate/eth.rs` — Blob fee and EIP-1559 validation for BSC
+- `crates/net/network/` — Proxied peer support
+- `crates/storage/provider/` — TrieDB integration in state provider
+
+### Custom Dependencies
+
+```toml
+# In Cargo.toml — BSC TrieDB support
+rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.1" }
+rust-eth-triedb-common = { ... }
+rust-eth-triedb-state-trie = { ... }
+```
+
+---
 
 ## Project Overview
 
@@ -10,21 +83,22 @@ Reth is a high-performance Ethereum execution client written in Rust, focusing o
 
 ### Core Components
 
-1. **Consensus (`crates/consensus/`)**: Validates blocks according to Ethereum consensus rules
-2. **Storage (`crates/storage/`)**: Hybrid database using MDBX + static files for optimal performance
-3. **Networking (`crates/net/`)**: P2P networking stack with discovery, sync, and transaction propagation
-4. **RPC (`crates/rpc/`)**: JSON-RPC server supporting all standard Ethereum APIs
+1. **Consensus (`crates/consensus/`)**: Validates blocks according to consensus rules (Parlia for BSC)
+2. **Storage (`crates/storage/`)**: Hybrid database using MDBX + static files + TrieDB (BSC) for optimal performance
+3. **Networking (`crates/net/`)**: P2P networking stack with discovery, sync, transaction propagation, and proxied peer support
+4. **RPC (`crates/rpc/`)**: JSON-RPC server supporting standard Ethereum APIs + BSC custom methods
 5. **Execution (`crates/evm/`, `crates/ethereum/`)**: Transaction execution and state transitions
 6. **Pipeline (`crates/stages/`)**: Staged sync architecture for blockchain synchronization
 7. **Trie (`crates/trie/`)**: Merkle Patricia Trie implementation with parallel state root computation
 8. **Node Builder (`crates/node/`)**: High-level node orchestration and configuration
-9  **The Consensus Engine (`crates/engine/`)**: Handles processing blocks received from the consensus layer with the Engine API (newPayload, forkchoiceUpdated)
+9. **The Consensus Engine (`crates/engine/`)**: Handles processing blocks received from the consensus layer with the Engine API (newPayload, forkchoiceUpdated)
+10. **Configuration (`crates/config/`)**: Node configuration including StateDbConfig for TrieDB/MDBX backend selection
 
 ### Key Design Principles
 
 - **Modularity**: Each crate can be used as a standalone library
 - **Performance**: Extensive use of parallelism, memory-mapped I/O, and optimized data structures
-- **Extensibility**: Traits and generic types allow for different implementations (Ethereum, Optimism, etc.)
+- **Extensibility**: Traits and generic types allow for different implementations (Ethereum, BSC, Optimism, etc.)
 - **Type Safety**: Strong typing throughout with minimal use of dynamic dispatch
 
 ## Development Workflow
@@ -175,7 +249,7 @@ Before submitting changes, ensure:
 5. **Commit Messages**: Follow conventional format (feat:, fix:, chore:, etc.)
 
 
-### Opening PRs against <https://github.com/paradigmxyz/reth>
+### Opening PRs against <https://github.com/bnb-chain/reth>
 
 Label PRs appropriately, first check the available labels and then apply the relevant ones:
 * when changes are RPC related, add A-rpc label

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -131,7 +131,11 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
     /// [`BlockHashReader`]. This may fail if the inner read database transaction fails to open.
     #[track_caller]
     pub fn consistent_provider(&self) -> ProviderResult<ConsistentProvider<N>> {
-        ConsistentProvider::new(self.chain_spec(), self.database.clone(), self.canonical_in_memory_state())
+        ConsistentProvider::new(
+            self.chain_spec(),
+            self.database.clone(),
+            self.canonical_in_memory_state(),
+        )
     }
 
     /// This uses a given [`BlockState`] to initialize a state provider for that block.
@@ -560,7 +564,12 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
     fn history_by_block_hash(&self, block_hash: BlockHash) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", ?block_hash, "Getting history by block hash");
-        self.consistent_provider()?.into_state_provider_at_block_hash(block_hash)
+        let provider = self.consistent_provider()?;
+        let block_number = provider
+            .block_number(block_hash)?
+            .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        provider.ensure_canonical_block(block_number)?;
+        provider.into_state_provider_at_block_hash(block_hash)
     }
 
     fn state_by_block_hash(&self, hash: BlockHash) -> ProviderResult<StateProviderBox> {


### PR DESCRIPTION
## Summary

- Fix incorrect state data returned for unexecuted blocks during staged sync (bnb-chain/reth-bsc#273)
- `history_by_block_hash` was missing the `ensure_canonical_block` check that `history_by_block_number` correctly performs
- Added block number lookup and canonical block validation so unexecuted blocks return a proper error instead of stale/wrong state data

## Root Cause

During staged sync, headers are downloaded ahead of execution. When an RPC call like `eth_getBalance(addr, blockNum)` is made for a block whose header exists but hasn't been executed:

1. `state_by_block_number_or_tag(Number(n))` finds the block hash (header downloaded)
2. Calls `state_by_block_hash(hash)` → `history_by_block_hash(hash)`
3. `history_by_block_hash` had **no** `ensure_canonical_block` check
4. `HistoricalStateProvider` falls back to `PlainState` (last executed state), returning wrong data

## Fix

Added the same `ensure_canonical_block` guard to `history_by_block_hash` that already exists in `history_by_block_number`, ensuring consistency across both code paths.

## Test plan

- [x] `cargo check -p reth-provider` passes
- [ ] Verify during staged sync that querying unexecuted blocks returns proper error
- [ ] Verify that querying executed blocks still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)