### PR TITLE
feat: add geth-compatible p2p and blobpool metrics

### DIFF
--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -28,6 +28,16 @@ use tokio::time::timeout;
 use tokio_stream::Stream;
 use tracing::{debug, trace};
 
+/// Record per-protocol message metrics matching geth's `p2p/{direction}/eth/{version}/0x{code}`
+/// format. Also records packet counts as `p2p/{direction}/eth/{version}/0x{code}/packets`.
+fn record_eth_message_metric(direction: &str, version: EthVersion, msg_id: u8, bytes: usize) {
+    let version_num = version as u8;
+    let name = format!("p2p.{direction}.eth.{version_num}.0x{msg_id:02x}");
+    let packets_name = format!("p2p.{direction}.eth.{version_num}.0x{msg_id:02x}.packets");
+    reth_metrics::metrics::counter!(name).increment(bytes as u64);
+    reth_metrics::metrics::counter!(packets_name).increment(1);
+}
+
 /// [`MAX_MESSAGE_SIZE`] is the maximum cap on the size of a protocol message.
 // https://github.com/ethereum/go-ethereum/blob/30602163d5d8321fbc68afdcbbaf2362b2641bde/eth/protocols/eth/protocol.go#L50
 pub const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
@@ -256,7 +266,16 @@ where
         let res = ready!(this.inner.poll_next(cx));
 
         match res {
-            Some(Ok(bytes)) => Poll::Ready(Some(this.eth.decode_message(bytes))),
+            Some(Ok(bytes)) => {
+                // Record per-message ingress metrics before decoding
+                let byte_len = bytes.len();
+                let msg_code = if bytes.is_empty() { 0 } else { bytes[0] };
+                let result = this.eth.decode_message(bytes);
+                if result.is_ok() {
+                    record_eth_message_metric("ingress", this.eth.version(), msg_code, byte_len);
+                }
+                Poll::Ready(Some(result))
+            }
             Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
             None => Poll::Ready(None),
         }
@@ -280,16 +299,17 @@ where
             // Attempt to disconnect the peer for protocol breach when trying to send Status
             // message after handshake is complete
             let mut this = self.project();
-            // We can't await the disconnect future here since this is a synchronous method,
-            // but we can start the disconnect process. The actual disconnect will be handled
-            // asynchronously by the caller or the stream's poll methods.
             let _disconnect_future = this.inner.disconnect(DisconnectReason::ProtocolBreach);
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
         }
 
-        self.project()
-            .inner
-            .start_send(Bytes::from(alloy_rlp::encode(ProtocolMessage::from(item))))?;
+        // Record per-message egress metrics
+        let msg_id = item.message_id().to_u8();
+        let this = self.project();
+        let encoded = Bytes::from(alloy_rlp::encode(ProtocolMessage::from(item)));
+        record_eth_message_metric("egress", this.eth.version(), msg_id, encoded.len());
+
+        this.inner.start_send(encoded)?;
 
         Ok(())
     }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -13,7 +13,7 @@ use alloy_rlp::{Decodable, Encodable, Error as RlpError, EMPTY_LIST_CODE};
 use futures::{Sink, SinkExt, StreamExt};
 use pin_project::pin_project;
 use reth_codecs::add_arbitrary_tests;
-use reth_metrics::metrics::counter;
+use reth_metrics::metrics::{counter, Counter};
 use reth_primitives_traits::GotExpected;
 use std::{
     collections::VecDeque,
@@ -256,6 +256,12 @@ pub struct P2PStream<S> {
     /// Whether this stream is currently in the process of disconnecting by sending a disconnect
     /// message.
     disconnecting: bool,
+
+    /// Total ingress bytes counter (matches geth `p2p/ingress`).
+    ingress_bytes: Counter,
+
+    /// Total egress bytes counter (matches geth `p2p/egress`).
+    egress_bytes: Counter,
 }
 
 impl<S> P2PStream<S> {
@@ -272,6 +278,8 @@ impl<S> P2PStream<S> {
             outgoing_messages: VecDeque::new(),
             outgoing_message_buffer_capacity: MAX_P2P_CAPACITY,
             disconnecting: false,
+            ingress_bytes: counter!("p2p.ingress"),
+            egress_bytes: counter!("p2p.egress"),
         }
     }
 
@@ -411,6 +419,9 @@ where
                 // empty messages are not allowed
                 return Poll::Ready(Some(Err(P2PStreamError::EmptyProtocolMessage)))
             }
+
+            // Track ingress bytes (raw wire bytes, matches geth p2p/ingress)
+            this.ingress_bytes.increment(bytes.len() as u64);
 
             // first decode disconnect reasons, because they can be encoded in a variety of forms
             // over the wire, in both snappy compressed and uncompressed forms.
@@ -627,6 +638,8 @@ where
                     let Some(message) = this.outgoing_messages.pop_front() else {
                         break Poll::Ready(Ok(()))
                     };
+                    // Track egress bytes (wire bytes, matches geth p2p/egress)
+                    this.egress_bytes.increment(message.len() as u64);
                     if let Err(err) = this.inner.as_mut().start_send(message) {
                         break Poll::Ready(Err(err.into()))
                     }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1273,14 +1273,13 @@ where
     }
 
     fn update_blob_store_metrics(&self) {
-        if let Some(data_size) = self.blob_store.data_size_hint() {
-            self.blob_store_metrics.blobstore_byte_size.set(data_size as f64);
-            // geth-compatible blobpool metrics: dataused tracks actual blob data,
-            // datareal tracks total footprint (in reth both are the same since we don't
-            // have shelf-based storage with gaps like geth)
-            metrics::gauge!("blobpool.dataused").set(data_size as f64);
-            metrics::gauge!("blobpool.datareal").set(data_size as f64);
-        }
+        let data_size = self.blob_store.data_size_hint().unwrap_or(0);
+        self.blob_store_metrics.blobstore_byte_size.set(data_size as f64);
+        // geth-compatible blobpool metrics: dataused tracks actual blob data,
+        // datareal tracks total footprint (in reth both are the same since we don't
+        // have shelf-based storage with gaps like geth)
+        metrics::gauge!("blobpool.dataused").set(data_size as f64);
+        metrics::gauge!("blobpool.datareal").set(data_size as f64);
         self.blob_store_metrics.blobstore_entries.set(self.blob_store.blobs_len() as f64);
     }
 

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1275,6 +1275,11 @@ where
     fn update_blob_store_metrics(&self) {
         if let Some(data_size) = self.blob_store.data_size_hint() {
             self.blob_store_metrics.blobstore_byte_size.set(data_size as f64);
+            // geth-compatible blobpool metrics: dataused tracks actual blob data,
+            // datareal tracks total footprint (in reth both are the same since we don't
+            // have shelf-based storage with gaps like geth)
+            metrics::gauge!("blobpool.dataused").set(data_size as f64);
+            metrics::gauge!("blobpool.datareal").set(data_size as f64);
         }
         self.blob_store_metrics.blobstore_entries.set(self.blob_store.blobs_len() as f64);
     }


### PR DESCRIPTION
## Summary

Add missing geth-compatible metrics for p2p network traffic and blob pool monitoring. These metrics enable BSC nodes running reth to report the same metrics as geth/BSC nodes, ensuring dashboard compatibility.

## Metrics Implemented

| # | Geth Metric | Prometheus Name | Implementation Location | Type |
|---|---|---|---|---|
| 1 | `p2p/ingress` | `p2p_ingress` | `crates/net/eth-wire/src/p2pstream.rs` — `P2PStream::poll_next()`, tracks raw wire bytes on ingress | Counter |
| 2 | `p2p/egress` | `p2p_egress` | `crates/net/eth-wire/src/p2pstream.rs` — `P2PStream::poll_flush()`, tracks raw wire bytes on egress | Counter |
| 3 | `p2p/ingress/eth/{ver}/0x{code}` | `p2p_ingress_eth_{ver}_0x{code}` | `crates/net/eth-wire/src/ethstream.rs` — `EthStream::poll_next()`, per-message byte counter via `record_eth_message_metric()` | Counter |
| 4 | `p2p/egress/eth/{ver}/0x{code}` | `p2p_egress_eth_{ver}_0x{code}` | `crates/net/eth-wire/src/ethstream.rs` — `EthStream::start_send()`, per-message byte counter via `record_eth_message_metric()` | Counter |
| 5 | `p2p/ingress/eth/{ver}/0x{code}/packets` | `p2p_ingress_eth_{ver}_0x{code}_packets` | `crates/net/eth-wire/src/ethstream.rs` — `EthStream::poll_next()`, per-message packet counter | Counter |
| 6 | `p2p/egress/eth/{ver}/0x{code}/packets` | `p2p_egress_eth_{ver}_0x{code}_packets` | `crates/net/eth-wire/src/ethstream.rs` — `EthStream::start_send()`, per-message packet counter | Counter |
| 7 | `blobpool/dataused` | `blobpool_dataused` | `crates/transaction-pool/src/pool/mod.rs` — `update_blob_store_metrics()` | Gauge |
| 8 | `blobpool/datareal` | `blobpool_datareal` | `crates/transaction-pool/src/pool/mod.rs` — `update_blob_store_metrics()` (same value as dataused since reth lacks geth's shelf-based gap tracking) | Gauge |

### Geth Reference

- **p2p ingress/egress**: `p2p/metrics.go` — `meteredConn.Read()/Write()` tracks total bytes
- **Per-protocol messages**: `p2p/transport.go` (egress) and `p2p/peer.go` (ingress) — dynamically registered meters per `{proto}/{version}/{code}`
- **blobpool**: `core/txpool/blobpool/blobpool.go` — `updateStorageMetrics()` tracks shelf data usage

### Note on `txpool/bundles`

This metric was listed in `miss_metrics.txt` but was **not found** in the geth/BSC codebase. Skipped.

## Test plan

- [x] `cargo check -p reth-eth-wire -p reth-transaction-pool` — compiles cleanly, no warnings
- [x] `cargo test -p reth-eth-wire --lib` — all 48 existing tests pass
- [ ] Verify metrics appear in Prometheus output on a running node

🤖 Generated with [Claude Code](https://claude.com/claude-code)