### PR TITLE
fix(provider): reject stale InPlainState reads during pipeline sync

### DIFF
--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -105,13 +105,13 @@ pub enum ProviderError {
     #[error("state at block #{_0} is pruned")]
     StateAtBlockPruned(BlockNumber),
     /// Historical state at the requested block may be inconsistent because pipeline sync is in
-    /// progress. The Execution stage has advanced PlainState beyond the history index coverage,
+    /// progress. The Execution stage has advanced `PlainState` beyond the history index coverage,
     /// so the `InPlainState` fallback would return data from a future block.
     #[error("historical state at block #{block} is inconsistent during pipeline sync: execution tip is #{execution_tip} but history index only covers up to #{history_tip}")]
     HistoryStateInconsistent {
         /// The block number being queried.
         block: BlockNumber,
-        /// Block number up to which the Execution stage has committed PlainState.
+        /// Block number up to which the Execution stage has committed `PlainState`.
         execution_tip: BlockNumber,
         /// Block number up to which the history index has been built.
         history_tip: BlockNumber,

--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -104,6 +104,18 @@ pub enum ProviderError {
     /// State is not available for the given block number because it is pruned.
     #[error("state at block #{_0} is pruned")]
     StateAtBlockPruned(BlockNumber),
+    /// Historical state at the requested block may be inconsistent because pipeline sync is in
+    /// progress. The Execution stage has advanced PlainState beyond the history index coverage,
+    /// so the `InPlainState` fallback would return data from a future block.
+    #[error("historical state at block #{block} is inconsistent during pipeline sync: execution tip is #{execution_tip} but history index only covers up to #{history_tip}")]
+    HistoryStateInconsistent {
+        /// The block number being queried.
+        block: BlockNumber,
+        /// Block number up to which the Execution stage has committed PlainState.
+        execution_tip: BlockNumber,
+        /// Block number up to which the history index has been built.
+        history_tip: BlockNumber,
+    },
     /// Provider does not support this particular request.
     #[error("this provider does not support this request")]
     UnsupportedProvider,

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -20,9 +20,9 @@ pub use traits::*;
 pub mod providers;
 pub use providers::{
     DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
-    HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
-    SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder, StaticFileWriteCtx,
-    StaticFileWriter,
+    HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, PipelineConsistency,
+    ProviderFactory, SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder,
+    StaticFileWriteCtx, StaticFileWriter,
 };
 
 pub mod changeset_walker;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -251,7 +251,12 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         if block_number == self.best_block_number().unwrap_or_default() &&
             block_number == self.last_block_number().unwrap_or_default()
         {
-            return Ok(Box::new(LatestStateProviderRef::new(self)))
+            let pipeline_consistency = self.build_pipeline_consistency()?;
+            if pipeline_consistency.account_inconsistency().is_none() &&
+                pipeline_consistency.storage_inconsistency().is_none()
+            {
+                return Ok(Box::new(LatestStateProviderRef::new(self)))
+            }
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.
@@ -872,10 +877,17 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
         self,
         mut block_number: BlockNumber,
     ) -> ProviderResult<StateProviderBox> {
-        // if the block number is the same as the currently best block number on disk we can use the
-        // latest state provider here
+        // If the block number matches the best block on disk, we can normally use the latest
+        // state provider. However, during pipeline sync the Execution stage may have advanced
+        // PlainState beyond the Finish checkpoint, so LatestStateProvider would return data
+        // from a future block. Only take the fast path when there is no pipeline gap.
         if block_number == self.best_block_number().unwrap_or_default() {
-            return Ok(Box::new(LatestStateProvider::new(self)))
+            let pipeline_consistency = self.build_pipeline_consistency()?;
+            if pipeline_consistency.account_inconsistency().is_none() &&
+                pipeline_consistency.storage_inconsistency().is_none()
+            {
+                return Ok(Box::new(LatestStateProvider::new(self)))
+            }
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -248,10 +248,10 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     ) -> ProviderResult<Box<dyn StateProvider + 'a>> {
         let mut block_number =
             self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        let pipeline_consistency = self.build_pipeline_consistency()?;
         if block_number == self.best_block_number().unwrap_or_default() &&
             block_number == self.last_block_number().unwrap_or_default()
         {
-            let pipeline_consistency = self.build_pipeline_consistency()?;
             if pipeline_consistency.account_inconsistency().is_none() &&
                 pipeline_consistency.storage_inconsistency().is_none()
             {
@@ -266,8 +266,6 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
             self.get_prune_checkpoint(PruneSegment::AccountHistory)?;
         let storage_history_prune_checkpoint =
             self.get_prune_checkpoint(PruneSegment::StorageHistory)?;
-
-        let pipeline_consistency = self.build_pipeline_consistency()?;
 
         let mut state_provider = HistoricalStateProviderRef::new(self, block_number)
             .with_pipeline_consistency(pipeline_consistency);
@@ -881,8 +879,8 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
         // state provider. However, during pipeline sync the Execution stage may have advanced
         // PlainState beyond the Finish checkpoint, so LatestStateProvider would return data
         // from a future block. Only take the fast path when there is no pipeline gap.
+        let pipeline_consistency = self.build_pipeline_consistency()?;
         if block_number == self.best_block_number().unwrap_or_default() {
-            let pipeline_consistency = self.build_pipeline_consistency()?;
             if pipeline_consistency.account_inconsistency().is_none() &&
                 pipeline_consistency.storage_inconsistency().is_none()
             {
@@ -897,8 +895,6 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
             self.get_prune_checkpoint(PruneSegment::AccountHistory)?;
         let storage_history_prune_checkpoint =
             self.get_prune_checkpoint(PruneSegment::StorageHistory)?;
-
-        let pipeline_consistency = self.build_pipeline_consistency()?;
 
         let mut state_provider = HistoricalStateProvider::new(self, block_number)
             .with_pipeline_consistency(pipeline_consistency);

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -255,13 +255,11 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
             self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
         let pipeline_consistency = self.build_pipeline_consistency()?;
         if block_number == self.best_block_number().unwrap_or_default() &&
-            block_number == self.last_block_number().unwrap_or_default()
+            block_number == self.last_block_number().unwrap_or_default() &&
+            pipeline_consistency.account_inconsistency().is_none() &&
+            pipeline_consistency.storage_inconsistency().is_none()
         {
-            if pipeline_consistency.account_inconsistency().is_none() &&
-                pipeline_consistency.storage_inconsistency().is_none()
-            {
-                return Ok(Box::new(LatestStateProviderRef::new(self)))
-            }
+            return Ok(Box::new(LatestStateProviderRef::new(self)))
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.
@@ -885,12 +883,11 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
         // PlainState beyond the Finish checkpoint, so LatestStateProvider would return data
         // from a future block. Only take the fast path when there is no pipeline gap.
         let pipeline_consistency = self.build_pipeline_consistency()?;
-        if block_number == self.best_block_number().unwrap_or_default() {
-            if pipeline_consistency.account_inconsistency().is_none() &&
-                pipeline_consistency.storage_inconsistency().is_none()
-            {
-                return Ok(Box::new(LatestStateProvider::new(self)))
-            }
+        if block_number == self.best_block_number().unwrap_or_default() &&
+            pipeline_consistency.account_inconsistency().is_none() &&
+            pipeline_consistency.storage_inconsistency().is_none()
+        {
+            return Ok(Box::new(LatestStateProvider::new(self)))
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -14,9 +14,9 @@ use crate::{
     BlockReader, BlockWriter, BundleStateInit, ChainStateBlockReader, ChainStateBlockWriter,
     DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
     HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
-    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, ProviderError,
-    PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg,
-    RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
+    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, PipelineConsistency,
+    ProviderError, PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit,
+    RocksBatchArg, RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
     StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
     TransactionsProvider, TransactionsProviderExt, TrieWriter,
 };
@@ -227,6 +227,20 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         Box::new(LatestStateProviderRef::new(self))
     }
 
+    /// Reads pipeline stage checkpoints and builds [`PipelineConsistency`] info.
+    ///
+    /// During pipeline sync the Execution stage commits `PlainState` before the history index
+    /// stages run. This helper detects that gap so [`HistoricalStateProviderRef`] can reject
+    /// `InPlainState` reads that would return data from a future block.
+    fn build_pipeline_consistency(&self) -> ProviderResult<PipelineConsistency> {
+        let execution_tip = self.get_stage_checkpoint(StageId::Execution)?.map(|c| c.block_number);
+        let account_history_tip =
+            self.get_stage_checkpoint(StageId::IndexAccountHistory)?.map(|c| c.block_number);
+        let storage_history_tip =
+            self.get_stage_checkpoint(StageId::IndexStorageHistory)?.map(|c| c.block_number);
+        Ok(PipelineConsistency { execution_tip, account_history_tip, storage_history_tip })
+    }
+
     /// Storage provider for state at that given block hash
     pub fn history_by_block_hash<'a>(
         &'a self,
@@ -248,7 +262,10 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         let storage_history_prune_checkpoint =
             self.get_prune_checkpoint(PruneSegment::StorageHistory)?;
 
-        let mut state_provider = HistoricalStateProviderRef::new(self, block_number);
+        let pipeline_consistency = self.build_pipeline_consistency()?;
+
+        let mut state_provider = HistoricalStateProviderRef::new(self, block_number)
+            .with_pipeline_consistency(pipeline_consistency);
 
         // If we pruned account or storage history, we can't return state on every historical block.
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune segment.
@@ -869,7 +886,10 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
         let storage_history_prune_checkpoint =
             self.get_prune_checkpoint(PruneSegment::StorageHistory)?;
 
-        let mut state_provider = HistoricalStateProvider::new(self, block_number);
+        let pipeline_consistency = self.build_pipeline_consistency()?;
+
+        let mut state_provider = HistoricalStateProvider::new(self, block_number)
+            .with_pipeline_consistency(pipeline_consistency);
 
         // If we pruned account or storage history, we can't return state on every historical block.
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune segment.

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -221,7 +221,12 @@ impl<TX, N: NodeTypes> DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
-    /// State provider for latest state
+    /// State provider for latest state.
+    ///
+    /// No [`PipelineConsistency`] guard is needed here: `LatestStateProviderRef` reads
+    /// `PlainState` directly and always returns the Execution-stage tip. The guard only
+    /// protects historical providers whose `InPlainState` fallback would silently serve
+    /// future-block data when the history index lags behind.
     pub fn latest<'a>(&'a self) -> Box<dyn StateProvider + 'a> {
         trace!(target: "providers::db", "Returning latest state provider");
         Box::new(LatestStateProviderRef::new(self))

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -17,7 +17,7 @@ mod state;
 pub use state::{
     historical::{
         compute_history_rank, history_info, needs_prev_shard_check, HistoricalStateProvider,
-        HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks,
+        HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks, PipelineConsistency,
     },
     latest::{LatestStateProvider, LatestStateProviderRef},
     overlay::{OverlayStateProvider, OverlayStateProviderFactory},

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -108,7 +108,7 @@ pub struct HistoricalStateProviderRef<'b, Provider> {
     /// Lowest blocks at which different parts of the state are available.
     lowest_available_blocks: LowestAvailableBlocks,
     /// Cached pipeline consistency info. When the Execution stage checkpoint is ahead of the
-    /// history index checkpoint, PlainState has been advanced beyond history coverage and the
+    /// history index checkpoint, `PlainState` has been advanced beyond history coverage and the
     /// `InPlainState` fallback would return data from a future block.
     pipeline_consistency: PipelineConsistency,
 }
@@ -574,11 +574,11 @@ reth_storage_api::macros::delegate_provider_impls!(HistoricalStateProvider<Provi
 /// where `HistoricalStateProvider` would incorrectly fall back to `InPlainState` and return
 /// data from a future block.
 ///
-/// When the Execution checkpoint is ahead of the history index checkpoint, we know PlainState
+/// When the Execution checkpoint is ahead of the history index checkpoint, we know `PlainState`
 /// has been silently advanced and the `InPlainState` path must not be used.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct PipelineConsistency {
-    /// Block number up to which the Execution stage has committed PlainState.
+    /// Block number up to which the Execution stage has committed `PlainState`.
     pub execution_tip: Option<BlockNumber>,
     /// Block number up to which the account history index has been built.
     pub account_history_tip: Option<BlockNumber>,
@@ -587,7 +587,7 @@ pub struct PipelineConsistency {
 }
 
 impl PipelineConsistency {
-    /// Returns `Some((exec_tip, hist_tip))` if account history is inconsistent with PlainState,
+    /// Returns `Some((exec_tip, hist_tip))` if account history is inconsistent with `PlainState`,
     /// meaning the `InPlainState` fallback would return wrong data.
     ///
     /// A `None` history tip means the index stage has never run, which is equivalent to block 0.
@@ -599,7 +599,7 @@ impl PipelineConsistency {
         }
     }
 
-    /// Returns `Some((exec_tip, hist_tip))` if storage history is inconsistent with PlainState.
+    /// Returns `Some((exec_tip, hist_tip))` if storage history is inconsistent with `PlainState`.
     ///
     /// A `None` history tip means the index stage has never run, which is equivalent to block 0.
     pub const fn storage_inconsistency(&self) -> Option<(BlockNumber, BlockNumber)> {

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -581,17 +581,23 @@ pub struct PipelineConsistency {
 impl PipelineConsistency {
     /// Returns `Some((exec_tip, hist_tip))` if account history is inconsistent with PlainState,
     /// meaning the `InPlainState` fallback would return wrong data.
+    ///
+    /// A `None` history tip means the index stage has never run, which is equivalent to block 0.
     pub const fn account_inconsistency(&self) -> Option<(BlockNumber, BlockNumber)> {
         match (self.execution_tip, self.account_history_tip) {
             (Some(exec), Some(hist)) if exec > hist => Some((exec, hist)),
+            (Some(exec), None) => Some((exec, 0)),
             _ => None,
         }
     }
 
     /// Returns `Some((exec_tip, hist_tip))` if storage history is inconsistent with PlainState.
+    ///
+    /// A `None` history tip means the index stage has never run, which is equivalent to block 0.
     pub const fn storage_inconsistency(&self) -> Option<(BlockNumber, BlockNumber)> {
         match (self.execution_tip, self.storage_history_tip) {
             (Some(exec), Some(hist)) if exec > hist => Some((exec, hist)),
+            (Some(exec), None) => Some((exec, 0)),
             _ => None,
         }
     }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -132,9 +132,17 @@ impl<'b, Provider: DBProvider + ChangeSetReader + BlockNumReader>
         provider: &'b Provider,
         block_number: BlockNumber,
         lowest_available_blocks: LowestAvailableBlocks,
-        pipeline_consistency: PipelineConsistency,
     ) -> Self {
-        Self { provider, block_number, lowest_available_blocks, pipeline_consistency }
+        Self {
+            provider,
+            block_number,
+            lowest_available_blocks,
+            pipeline_consistency: PipelineConsistency {
+                execution_tip: None,
+                account_history_tip: None,
+                storage_history_tip: None,
+            },
+        }
     }
 
     /// Set the pipeline consistency info for detecting stale `InPlainState` reads during
@@ -550,8 +558,8 @@ impl<Provider: DBProvider + ChangeSetReader + BlockNumReader> HistoricalStatePro
             &self.provider,
             self.block_number,
             self.lowest_available_blocks,
-            self.pipeline_consistency,
         )
+        .with_pipeline_consistency(self.pipeline_consistency)
     }
 }
 
@@ -979,7 +987,6 @@ mod tests {
                 account_history_block_number: Some(3),
                 storage_history_block_number: Some(3),
             },
-            Default::default(),
         );
         assert!(matches!(
             provider.account_history_lookup(ADDRESS),
@@ -999,7 +1006,6 @@ mod tests {
                 account_history_block_number: Some(2),
                 storage_history_block_number: Some(2),
             },
-            Default::default(),
         );
         assert!(matches!(
             provider.account_history_lookup(ADDRESS),
@@ -1019,7 +1025,6 @@ mod tests {
                 account_history_block_number: Some(1),
                 storage_history_block_number: Some(1),
             },
-            Default::default(),
         );
         assert!(matches!(
             provider.account_history_lookup(ADDRESS),

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -107,6 +107,10 @@ pub struct HistoricalStateProviderRef<'b, Provider> {
     block_number: BlockNumber,
     /// Lowest blocks at which different parts of the state are available.
     lowest_available_blocks: LowestAvailableBlocks,
+    /// Cached pipeline consistency info. When the Execution stage checkpoint is ahead of the
+    /// history index checkpoint, PlainState has been advanced beyond history coverage and the
+    /// `InPlainState` fallback would return data from a future block.
+    pipeline_consistency: PipelineConsistency,
 }
 
 impl<'b, Provider: DBProvider + ChangeSetReader + BlockNumReader>
@@ -114,7 +118,12 @@ impl<'b, Provider: DBProvider + ChangeSetReader + BlockNumReader>
 {
     /// Create new `StateProvider` for historical block number
     pub fn new(provider: &'b Provider, block_number: BlockNumber) -> Self {
-        Self { provider, block_number, lowest_available_blocks: Default::default() }
+        Self {
+            provider,
+            block_number,
+            lowest_available_blocks: Default::default(),
+            pipeline_consistency: Default::default(),
+        }
     }
 
     /// Create new `StateProvider` for historical block number and lowest block numbers at which
@@ -123,8 +132,19 @@ impl<'b, Provider: DBProvider + ChangeSetReader + BlockNumReader>
         provider: &'b Provider,
         block_number: BlockNumber,
         lowest_available_blocks: LowestAvailableBlocks,
+        pipeline_consistency: PipelineConsistency,
     ) -> Self {
-        Self { provider, block_number, lowest_available_blocks }
+        Self { provider, block_number, lowest_available_blocks, pipeline_consistency }
+    }
+
+    /// Set the pipeline consistency info for detecting stale `InPlainState` reads during
+    /// pipeline sync.
+    pub const fn with_pipeline_consistency(
+        mut self,
+        pipeline_consistency: PipelineConsistency,
+    ) -> Self {
+        self.pipeline_consistency = pipeline_consistency;
+        self
     }
 
     /// Lookup an account in the `AccountsHistory` table using `EitherReader`.
@@ -262,6 +282,15 @@ impl<
                     .map(|account_before| account_before.info)
             }
             HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
+                if let Some((exec_tip, hist_tip)) =
+                    self.pipeline_consistency.account_inconsistency()
+                {
+                    return Err(ProviderError::HistoryStateInconsistent {
+                        block: self.block_number,
+                        execution_tip: exec_tip,
+                        history_tip: hist_tip,
+                    })
+                }
                 Ok(self.tx().get_by_encoded_key::<tables::PlainAccountState>(address)?)
             }
         }
@@ -430,13 +459,24 @@ impl<
                     })?
                     .value,
             )),
-            HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => Ok(self
-                .tx()
-                .cursor_dup_read::<tables::PlainStorageState>()?
-                .seek_by_key_subkey(address, storage_key)?
-                .filter(|entry| entry.key == storage_key)
-                .map(|entry| entry.value)
-                .or(Some(StorageValue::ZERO))),
+            HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
+                if let Some((exec_tip, hist_tip)) =
+                    self.pipeline_consistency.storage_inconsistency()
+                {
+                    return Err(ProviderError::HistoryStateInconsistent {
+                        block: self.block_number,
+                        execution_tip: exec_tip,
+                        history_tip: hist_tip,
+                    })
+                }
+                Ok(self
+                    .tx()
+                    .cursor_dup_read::<tables::PlainStorageState>()?
+                    .seek_by_key_subkey(address, storage_key)?
+                    .filter(|entry| entry.key == storage_key)
+                    .map(|entry| entry.value)
+                    .or(Some(StorageValue::ZERO)))
+            }
         }
     }
 }
@@ -460,12 +500,19 @@ pub struct HistoricalStateProvider<Provider> {
     block_number: BlockNumber,
     /// Lowest blocks at which different parts of the state are available.
     lowest_available_blocks: LowestAvailableBlocks,
+    /// Cached pipeline consistency info.
+    pipeline_consistency: PipelineConsistency,
 }
 
 impl<Provider: DBProvider + ChangeSetReader + BlockNumReader> HistoricalStateProvider<Provider> {
     /// Create new `StateProvider` for historical block number
     pub fn new(provider: Provider, block_number: BlockNumber) -> Self {
-        Self { provider, block_number, lowest_available_blocks: Default::default() }
+        Self {
+            provider,
+            block_number,
+            lowest_available_blocks: Default::default(),
+            pipeline_consistency: Default::default(),
+        }
     }
 
     /// Set the lowest block number at which the account history is available.
@@ -486,6 +533,16 @@ impl<Provider: DBProvider + ChangeSetReader + BlockNumReader> HistoricalStatePro
         self
     }
 
+    /// Set the pipeline consistency info for detecting stale `InPlainState` reads during
+    /// pipeline sync.
+    pub const fn with_pipeline_consistency(
+        mut self,
+        pipeline_consistency: PipelineConsistency,
+    ) -> Self {
+        self.pipeline_consistency = pipeline_consistency;
+        self
+    }
+
     /// Returns a new provider that takes the `TX` as reference
     #[inline(always)]
     const fn as_ref(&self) -> HistoricalStateProviderRef<'_, Provider> {
@@ -493,12 +550,52 @@ impl<Provider: DBProvider + ChangeSetReader + BlockNumReader> HistoricalStatePro
             &self.provider,
             self.block_number,
             self.lowest_available_blocks,
+            self.pipeline_consistency,
         )
     }
 }
 
 // Delegates all provider impls to [HistoricalStateProviderRef]
 reth_storage_api::macros::delegate_provider_impls!(HistoricalStateProvider<Provider> where [Provider: DBProvider + BlockNumReader + BlockHashReader + ChangeSetReader + StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider]);
+
+/// Cached pipeline stage checkpoint info used to detect inconsistent `InPlainState` reads.
+///
+/// During pipeline sync, the `ExecutionStage` commits `PlainAccountState` / `PlainStorageState`
+/// in its own MDBX write transaction **before** the `IndexAccountHistoryStage` and
+/// `IndexStorageHistoryStage` commit the corresponding history indices. This creates a window
+/// where `HistoricalStateProvider` would incorrectly fall back to `InPlainState` and return
+/// data from a future block.
+///
+/// When the Execution checkpoint is ahead of the history index checkpoint, we know PlainState
+/// has been silently advanced and the `InPlainState` path must not be used.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PipelineConsistency {
+    /// Block number up to which the Execution stage has committed PlainState.
+    pub execution_tip: Option<BlockNumber>,
+    /// Block number up to which the account history index has been built.
+    pub account_history_tip: Option<BlockNumber>,
+    /// Block number up to which the storage history index has been built.
+    pub storage_history_tip: Option<BlockNumber>,
+}
+
+impl PipelineConsistency {
+    /// Returns `Some((exec_tip, hist_tip))` if account history is inconsistent with PlainState,
+    /// meaning the `InPlainState` fallback would return wrong data.
+    pub const fn account_inconsistency(&self) -> Option<(BlockNumber, BlockNumber)> {
+        match (self.execution_tip, self.account_history_tip) {
+            (Some(exec), Some(hist)) if exec > hist => Some((exec, hist)),
+            _ => None,
+        }
+    }
+
+    /// Returns `Some((exec_tip, hist_tip))` if storage history is inconsistent with PlainState.
+    pub const fn storage_inconsistency(&self) -> Option<(BlockNumber, BlockNumber)> {
+        match (self.execution_tip, self.storage_history_tip) {
+            (Some(exec), Some(hist)) if exec > hist => Some((exec, hist)),
+            _ => None,
+        }
+    }
+}
 
 /// Lowest blocks at which different parts of the state are available.
 /// They may be [Some] if pruning is enabled.
@@ -876,6 +973,7 @@ mod tests {
                 account_history_block_number: Some(3),
                 storage_history_block_number: Some(3),
             },
+            Default::default(),
         );
         assert!(matches!(
             provider.account_history_lookup(ADDRESS),
@@ -895,6 +993,7 @@ mod tests {
                 account_history_block_number: Some(2),
                 storage_history_block_number: Some(2),
             },
+            Default::default(),
         );
         assert!(matches!(
             provider.account_history_lookup(ADDRESS),
@@ -914,6 +1013,7 @@ mod tests {
                 account_history_block_number: Some(1),
                 storage_history_block_number: Some(1),
             },
+            Default::default(),
         );
         assert!(matches!(
             provider.account_history_lookup(ADDRESS),


### PR DESCRIPTION
## Summary

Fixes a data consistency issue where `HistoricalStateProvider` returns stale data during pipeline sync.

- During pipeline sync, `ExecutionStage` commits `PlainAccountState` / `PlainStorageState` in its own MDBX write transaction **before** `IndexAccountHistoryStage` / `IndexStorageHistoryStage` commit history indices
- This creates a window where `HistoricalStateProvider` falls back to `InPlainState` and reads PlainState that has been silently advanced to a future block
- Affected RPCs: `eth_getBalance`, `eth_getStorageAt`, `trace_block`, `debug_traceBlockByNumber`, etc.

### Approach

Instead of rejecting **all** historical queries during pipeline sync (which would hurt RPC availability), this PR adds a targeted `PipelineConsistency` guard that only errors when the `InPlainState` / `MaybeInPlainState` fallback path would be used while the Execution checkpoint is ahead of the history index checkpoint. Queries that resolve via changeset lookups are unaffected.

### Changes

- **`ProviderError::HistoryStateInconsistent`** — new error variant with execution tip and history tip for debugging
- **`PipelineConsistency`** struct — caches Execution / IndexAccountHistory / IndexStorageHistory stage checkpoints at provider construction time (3 B-tree lookups, same transaction)
- **`HistoricalStateProviderRef::basic_account()`** and **`storage()`** — check `PipelineConsistency` before the `InPlainState` path; return error if inconsistent
- **`DatabaseProvider::build_pipeline_consistency()`** — reads stage checkpoints and injects into both `HistoricalStateProviderRef` and `HistoricalStateProvider`

Ref: bnb-chain/reth-bsc#273

## Test plan

- [ ] `cargo check -p reth-provider` passes
- [ ] Existing `history_provider_get_account`, `history_provider_get_storage`, `history_provider_unavailable` tests pass
- [ ] Manual testing: verify RPC returns `HistoryStateInconsistent` error (not wrong data) during pipeline sync catch-up
- [ ] Verify error auto-resolves once IndexAccountHistory + IndexStorageHistory stages complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)