### PR TITLE
fix: add WARN-level logging for ETH request handling bottlenecks

### DIFF
--- a/crates/net/network/src/eth_requests.rs
+++ b/crates/net/network/src/eth_requests.rs
@@ -150,22 +150,39 @@ where
 
     fn on_headers_request(
         &self,
-        _peer_id: PeerId,
+        peer_id: PeerId,
         request: GetBlockHeaders,
         response: oneshot::Sender<RequestResult<BlockHeaders<C::Header>>>,
     ) {
         self.metrics.eth_headers_requests_received_total.increment(1);
+        let start = std::time::Instant::now();
+        let start_block = request.start_block;
+        let limit = request.limit;
         let headers = self.get_headers_response(request);
+        let elapsed = start.elapsed();
+        if headers.is_empty() || elapsed > std::time::Duration::from_millis(100) {
+            tracing::warn!(
+                target: "net::eth",
+                ?peer_id,
+                ?start_block,
+                limit,
+                returned = headers.len(),
+                ?elapsed,
+                "GetBlockHeaders: slow or empty response",
+            );
+        }
         let _ = response.send(Ok(BlockHeaders(headers)));
     }
 
     fn on_bodies_request(
         &self,
-        _peer_id: PeerId,
+        peer_id: PeerId,
         request: GetBlockBodies,
         response: oneshot::Sender<RequestResult<BlockBodies<<C::Block as Block>::Body>>>,
     ) {
         self.metrics.eth_bodies_requests_received_total.increment(1);
+        let start = std::time::Instant::now();
+        let requested = request.0.len();
         let mut bodies = Vec::new();
 
         let mut total_bytes = 0;
@@ -184,6 +201,17 @@ where
             }
         }
 
+        let elapsed = start.elapsed();
+        if bodies.len() < requested || elapsed > std::time::Duration::from_millis(100) {
+            tracing::warn!(
+                target: "net::eth",
+                ?peer_id,
+                requested,
+                returned = bodies.len(),
+                ?elapsed,
+                "GetBlockBodies: incomplete or slow response",
+            );
+        }
         let _ = response.send(Ok(BlockBodies(bodies)));
     }
 

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -487,7 +487,7 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
         if let Some(ref reqs) = self.to_eth_request_handler {
             let _ = reqs.try_send(event).map_err(|e| {
                 if let TrySendError::Full(_) = e {
-                    debug!(target:"net", "EthRequestHandler channel is full!");
+                    warn!(target:"net", "EthRequestHandler channel is full! Request DROPPED — peer will never receive a response");
                     self.metrics.total_dropped_eth_requests_at_full_capacity.increment(1);
                 }
             });

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -42,7 +42,7 @@ use tokio::{
 };
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::PollSender;
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 /// The recommended interval at which to check if a new range update should be sent to the remote
 /// peer.
@@ -424,10 +424,11 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
         {
             Ok(_) => Ok(()),
             Err(err) => {
-                trace!(
-                    target: "net",
+                warn!(
+                    target: "net::session",
+                    remote_peer_id=?self.remote_peer_id,
                     %err,
-                    "no capacity for incoming request",
+                    "no capacity for incoming ETH request — session→manager channel full",
                 );
                 match err {
                     TrySendError::Full(msg) => Err(msg),
@@ -685,6 +686,12 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     //
                     // Note: we don't need to register the waker here because we polled the requests
                     // above
+                    warn!(
+                        target: "net::session",
+                        remote_peer_id=?this.remote_peer_id,
+                        pending_responses=this.received_requests_from_remote.len(),
+                        "throttling incoming messages — too many pending responses (>{MAX_QUEUED_OUTGOING_RESPONSES})",
+                    );
                     break 'receive
                 }
 
@@ -698,6 +705,13 @@ impl<N: NetworkPrimitives> Future for ActiveSession<N> {
                     // Note: we don't need to register the waker here because we still have
                     // queued messages and the sink impl registered the waker because we've
                     // already advanced it to `Pending` earlier
+                    warn!(
+                        target: "net::session",
+                        remote_peer_id=?this.remote_peer_id,
+                        queued_outgoing=this.queued_outgoing.messages.len(),
+                        queued_responses=this.queued_response_count(),
+                        "throttling incoming messages — outgoing queue congested (>{MAX_QUEUED_OUTGOING_RESPONSES})",
+                    );
                     break 'receive
                 }
 


### PR DESCRIPTION
## Summary

When sentry nodes restart and send sync requests (`GetBlockHeaders`/`GetBlockBodies`) to reth, the requests may fail silently due to channel backpressure or throttling. Sentries then consider reth "stalling" and drop the connection, but reth has no logs to diagnose the cause.

### Context

During a testnet incident (2026-03-19), all 3 sentries dropped reth-bsc after restarting. Geth sentry logs showed:

```
"Synchronisation failed, dropping peer" err="peer is stalling"
```

But reth-bsc had **zero logs** about the ETH request handling path — `EthRequestHandler` processes requests without any logging, and dropped requests in `delegate_eth_request` only log at DEBUG level.

### Changes

Add WARN-level logs at all critical points in the ETH request chain:

| File | Log | Trigger |
|------|-----|---------|
| `manager.rs` | `EthRequestHandler channel is full! Request DROPPED` | Channel (cap=256) full, request silently dropped |
| `session/active.rs` | `session→manager channel full` | Session→Manager channel (cap=260) full |
| `session/active.rs` | `throttling — too many pending responses` | >4 requests awaiting EthRequestHandler response |
| `session/active.rs` | `throttling — outgoing queue congested` | >4 messages queued (broadcasts competing with responses) |
| `eth_requests.rs` | `GetBlockHeaders: slow or empty response` | Response empty or processing >100ms |
| `eth_requests.rs` | `GetBlockBodies: incomplete or slow response` | Returned fewer bodies than requested, or >100ms |

## Test plan

- [ ] Deploy to testnet, restart a sentry, check reth logs for any WARN from `net::eth` or `net::session`
- [ ] If no WARN appears and sentry still drops reth, the bottleneck is outside these points (e.g., TCP-level issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)