### PR TITLE
feat: v0.0.9 - pipeline consistency guard, p2p/blobpool metrics, fastnode RPC guard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10690,6 +10690,7 @@ dependencies = [
  "parking_lot",
  "reth-chain-state",
  "reth-chainspec",
+ "reth-engine-primitives",
  "reth-errors",
  "reth-evm",
  "reth-network-api",

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -1,6 +1,27 @@
 //! Engine tree configuration.
 
 use alloy_eips::merge::EPOCH_SLOTS;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Global flag indicating whether the node is running in fastnode mode
+/// (i.e., `--engine.skip-state-root-validation` is enabled).
+///
+/// When active, trie-dependent RPC methods such as `eth_getProof` and `eth_getAccount`
+/// are unavailable because the hashing stages and state root computation are skipped,
+/// meaning the trie tables in the database are not kept up to date.
+static FASTNODE_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Activate fastnode mode globally.
+///
+/// This should be called once during node startup when `skip_state_root_validation` is enabled.
+pub fn activate_fastnode() {
+    FASTNODE_ACTIVE.store(true, Ordering::SeqCst);
+}
+
+/// Returns `true` if the node is running in fastnode mode.
+pub fn is_fastnode_active() -> bool {
+    FASTNODE_ACTIVE.load(Ordering::SeqCst)
+}
 
 /// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
 pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;

--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -446,8 +446,8 @@ pub(super) mod serde_bincode_compat {
 mod compact {
     use super::*;
     use reth_codecs::{
-        Compact,
         __private::{modular_bitfield::prelude::*, Buf},
+        Compact,
     };
 
     impl Receipt {

--- a/crates/ethereum/primitives/src/receipt.rs
+++ b/crates/ethereum/primitives/src/receipt.rs
@@ -446,8 +446,8 @@ pub(super) mod serde_bincode_compat {
 mod compact {
     use super::*;
     use reth_codecs::{
-        __private::{modular_bitfield::prelude::*, Buf},
         Compact,
+        __private::{modular_bitfield::prelude::*, Buf},
     };
 
     impl Receipt {

--- a/crates/net/eth-wire/src/ethstream.rs
+++ b/crates/net/eth-wire/src/ethstream.rs
@@ -28,6 +28,16 @@ use tokio::time::timeout;
 use tokio_stream::Stream;
 use tracing::{debug, trace};
 
+/// Record per-protocol message metrics matching geth's `p2p/{direction}/eth/{version}/0x{code}`
+/// format. Also records packet counts as `p2p/{direction}/eth/{version}/0x{code}/packets`.
+fn record_eth_message_metric(direction: &str, version: EthVersion, msg_id: u8, bytes: usize) {
+    let version_num = version as u8;
+    let name = format!("p2p.{direction}.eth.{version_num}.0x{msg_id:02x}");
+    let packets_name = format!("p2p.{direction}.eth.{version_num}.0x{msg_id:02x}.packets");
+    reth_metrics::metrics::counter!(name).increment(bytes as u64);
+    reth_metrics::metrics::counter!(packets_name).increment(1);
+}
+
 /// [`MAX_MESSAGE_SIZE`] is the maximum cap on the size of a protocol message.
 // https://github.com/ethereum/go-ethereum/blob/30602163d5d8321fbc68afdcbbaf2362b2641bde/eth/protocols/eth/protocol.go#L50
 pub const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024;
@@ -256,7 +266,16 @@ where
         let res = ready!(this.inner.poll_next(cx));
 
         match res {
-            Some(Ok(bytes)) => Poll::Ready(Some(this.eth.decode_message(bytes))),
+            Some(Ok(bytes)) => {
+                // Record per-message ingress metrics before decoding
+                let byte_len = bytes.len();
+                let msg_code = if bytes.is_empty() { 0 } else { bytes[0] };
+                let result = this.eth.decode_message(bytes);
+                if result.is_ok() {
+                    record_eth_message_metric("ingress", this.eth.version(), msg_code, byte_len);
+                }
+                Poll::Ready(Some(result))
+            }
             Some(Err(err)) => Poll::Ready(Some(Err(err.into()))),
             None => Poll::Ready(None),
         }
@@ -280,16 +299,17 @@ where
             // Attempt to disconnect the peer for protocol breach when trying to send Status
             // message after handshake is complete
             let mut this = self.project();
-            // We can't await the disconnect future here since this is a synchronous method,
-            // but we can start the disconnect process. The actual disconnect will be handled
-            // asynchronously by the caller or the stream's poll methods.
             let _disconnect_future = this.inner.disconnect(DisconnectReason::ProtocolBreach);
             return Err(EthStreamError::EthHandshakeError(EthHandshakeError::StatusNotInHandshake))
         }
 
-        self.project()
-            .inner
-            .start_send(Bytes::from(alloy_rlp::encode(ProtocolMessage::from(item))))?;
+        // Record per-message egress metrics
+        let msg_id = item.message_id().to_u8();
+        let this = self.project();
+        let encoded = Bytes::from(alloy_rlp::encode(ProtocolMessage::from(item)));
+        record_eth_message_metric("egress", this.eth.version(), msg_id, encoded.len());
+
+        this.inner.start_send(encoded)?;
 
         Ok(())
     }

--- a/crates/net/eth-wire/src/p2pstream.rs
+++ b/crates/net/eth-wire/src/p2pstream.rs
@@ -13,7 +13,7 @@ use alloy_rlp::{Decodable, Encodable, Error as RlpError, EMPTY_LIST_CODE};
 use futures::{Sink, SinkExt, StreamExt};
 use pin_project::pin_project;
 use reth_codecs::add_arbitrary_tests;
-use reth_metrics::metrics::counter;
+use reth_metrics::metrics::{counter, Counter};
 use reth_primitives_traits::GotExpected;
 use std::{
     collections::VecDeque,
@@ -256,6 +256,12 @@ pub struct P2PStream<S> {
     /// Whether this stream is currently in the process of disconnecting by sending a disconnect
     /// message.
     disconnecting: bool,
+
+    /// Total ingress bytes counter (matches geth `p2p/ingress`).
+    ingress_bytes: Counter,
+
+    /// Total egress bytes counter (matches geth `p2p/egress`).
+    egress_bytes: Counter,
 }
 
 impl<S> P2PStream<S> {
@@ -272,6 +278,8 @@ impl<S> P2PStream<S> {
             outgoing_messages: VecDeque::new(),
             outgoing_message_buffer_capacity: MAX_P2P_CAPACITY,
             disconnecting: false,
+            ingress_bytes: counter!("p2p.ingress"),
+            egress_bytes: counter!("p2p.egress"),
         }
     }
 
@@ -411,6 +419,9 @@ where
                 // empty messages are not allowed
                 return Poll::Ready(Some(Err(P2PStreamError::EmptyProtocolMessage)))
             }
+
+            // Track ingress bytes (raw wire bytes, matches geth p2p/ingress)
+            this.ingress_bytes.increment(bytes.len() as u64);
 
             // first decode disconnect reasons, because they can be encoded in a variety of forms
             // over the wire, in both snappy compressed and uncompressed forms.
@@ -627,6 +638,8 @@ where
                     let Some(message) = this.outgoing_messages.pop_front() else {
                         break Poll::Ready(Ok(()))
                     };
+                    // Track egress bytes (wire bytes, matches geth p2p/egress)
+                    this.egress_bytes.increment(message.len() as u64);
                     if let Err(err) = this.inner.as_mut().start_send(message) {
                         break Poll::Ready(Err(err.into()))
                     }

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -188,6 +188,7 @@ impl LaunchContext {
         if config.engine.skip_state_root_validation {
             info!(target: "reth::cli", "Fastnode mode enabled via --engine.skip-state-root-validation - disabling hashing stages and state root validation");
             toml_config.stages.disable_hashing_stages = true;
+            reth_engine_primitives::activate_fastnode();
         }
 
         Ok(toml_config)

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -25,6 +25,7 @@ reth-rpc-convert.workspace = true
 reth-tasks = { workspace = true, features = ["rayon"] }
 reth-transaction-pool.workspace = true
 reth-chainspec.workspace = true
+reth-engine-primitives.workspace = true
 reth-rpc-eth-types.workspace = true
 reth-rpc-server-types.workspace = true
 reth-network-api.workspace = true

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -9,6 +9,7 @@ use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_eth::{Account, AccountInfo, EIP1186AccountProofResponse};
 use alloy_serde::JsonStorageKey;
 use futures::Future;
+use reth_engine_primitives::is_fastnode_active;
 use reth_errors::RethError;
 use reth_evm::{ConfigureEvm, EvmEnvFor};
 use reth_primitives_traits::SealedHeaderFor;
@@ -20,7 +21,6 @@ use reth_storage_api::{
     BlockIdReader, BlockNumReader, BlockReaderIdExt, StateProvider, StateProviderBox,
     StateProviderFactory,
 };
-use reth_engine_primitives::is_fastnode_active;
 use reth_transaction_pool::TransactionPool;
 use rust_eth_triedb::triedb_manager::is_triedb_active;
 

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -20,6 +20,7 @@ use reth_storage_api::{
     BlockIdReader, BlockNumReader, BlockReaderIdExt, StateProvider, StateProviderBox,
     StateProviderFactory,
 };
+use reth_engine_primitives::is_fastnode_active;
 use reth_transaction_pool::TransactionPool;
 use rust_eth_triedb::triedb_manager::is_triedb_active;
 
@@ -103,6 +104,11 @@ pub trait EthState: LoadState + SpawnBlocking {
                 return Err(EthApiError::MethodNotAvailable("eth_getProof".to_string()).into())
             }
 
+            // In fastnode mode, trie tables are not maintained so proofs would be invalid
+            if is_fastnode_active() {
+                return Err(EthApiError::MethodNotAvailable("eth_getProof".to_string()).into())
+            }
+
             let _permit = self
                 .acquire_owned_tracing()
                 .await
@@ -144,6 +150,11 @@ pub trait EthState: LoadState + SpawnBlocking {
         self.spawn_blocking_io_fut(move |this| async move {
             // Check if TrieDB is active, return error if so
             if is_triedb_active() {
+                return Err(EthApiError::MethodNotAvailable("eth_getAccount".to_string()).into())
+            }
+
+            // In fastnode mode, trie tables are not maintained so storage root would be invalid
+            if is_fastnode_active() {
                 return Err(EthApiError::MethodNotAvailable("eth_getAccount".to_string()).into())
             }
 

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -727,7 +727,7 @@ where
 mod tests {
     use super::needs_prev_shard_check;
     use crate::{
-        providers::state::historical::{HistoryInfo, LowestAvailableBlocks},
+        providers::state::historical::{HistoryInfo, LowestAvailableBlocks, PipelineConsistency},
         test_utils::create_test_provider_factory,
         AccountReader, HistoricalStateProvider, HistoricalStateProviderRef, RocksDBProviderFactory,
         StateProvider,
@@ -1058,5 +1058,142 @@ mod tests {
         assert!(needs_prev_shard_check(0, None, 5));
         assert!(!needs_prev_shard_check(0, Some(5), 5)); // found_block == block_number
         assert!(!needs_prev_shard_check(1, Some(10), 5)); // rank > 0
+    }
+
+    #[test]
+    fn pipeline_consistency_unit_logic() {
+        // Consistent: execution == history
+        let pc = PipelineConsistency {
+            execution_tip: Some(100),
+            account_history_tip: Some(100),
+            storage_history_tip: Some(100),
+        };
+        assert!(pc.account_inconsistency().is_none());
+        assert!(pc.storage_inconsistency().is_none());
+
+        // Inconsistent: execution ahead of history
+        let pc = PipelineConsistency {
+            execution_tip: Some(200),
+            account_history_tip: Some(100),
+            storage_history_tip: Some(150),
+        };
+        assert_eq!(pc.account_inconsistency(), Some((200, 100)));
+        assert_eq!(pc.storage_inconsistency(), Some((200, 150)));
+
+        // History never ran (None) → treated as block 0
+        let pc = PipelineConsistency {
+            execution_tip: Some(50),
+            account_history_tip: None,
+            storage_history_tip: None,
+        };
+        assert_eq!(pc.account_inconsistency(), Some((50, 0)));
+        assert_eq!(pc.storage_inconsistency(), Some((50, 0)));
+
+        // Execution not run yet → consistent
+        let pc = PipelineConsistency {
+            execution_tip: None,
+            account_history_tip: None,
+            storage_history_tip: None,
+        };
+        assert!(pc.account_inconsistency().is_none());
+        assert!(pc.storage_inconsistency().is_none());
+    }
+
+    /// Verifies selective rejection during pipeline inconsistency:
+    /// - Accounts resolving via changeset path → return correct data (not blocked)
+    /// - Accounts resolving via InPlainState path → return HistoryStateInconsistent error
+    #[test]
+    fn pipeline_consistency_selective_rejection() {
+        let factory = create_test_provider_factory();
+        let tx = factory.provider_rw().unwrap().into_tx();
+
+        let no_history_addr = address!("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
+
+        // History index for ADDRESS: modified at blocks 3, 7, 10, 15
+        tx.put::<tables::AccountsHistory>(
+            ShardedKey { key: ADDRESS, highest_block_number: 7 },
+            BlockNumberList::new([3, 7]).unwrap(),
+        )
+        .unwrap();
+        tx.put::<tables::AccountsHistory>(
+            ShardedKey { key: ADDRESS, highest_block_number: u64::MAX },
+            BlockNumberList::new([10, 15]).unwrap(),
+        )
+        .unwrap();
+
+        // Changesets for ADDRESS
+        let acc_at7 = Account { nonce: 7, balance: U256::ZERO, bytecode_hash: None };
+        let acc_at10 = Account { nonce: 10, balance: U256::ZERO, bytecode_hash: None };
+        tx.put::<tables::AccountChangeSets>(
+            7,
+            AccountBeforeTx { address: ADDRESS, info: Some(acc_at7) },
+        )
+        .unwrap();
+        tx.put::<tables::AccountChangeSets>(
+            10,
+            AccountBeforeTx { address: ADDRESS, info: Some(acc_at10) },
+        )
+        .unwrap();
+
+        // PlainState
+        let acc_plain = Account { nonce: 100, balance: U256::ZERO, bytecode_hash: None };
+        let no_hist_plain = Account { nonce: 999, balance: U256::from(999), bytecode_hash: None };
+        tx.put::<tables::PlainAccountState>(ADDRESS, acc_plain).unwrap();
+        tx.put::<tables::PlainAccountState>(no_history_addr, no_hist_plain).unwrap();
+        tx.commit().unwrap();
+
+        let db = factory.provider().unwrap();
+
+        // Simulate inconsistency: Execution=200, HistoryIndex=15
+        let inconsistent = PipelineConsistency {
+            execution_tip: Some(200),
+            account_history_tip: Some(15),
+            storage_history_tip: Some(15),
+        };
+
+        // Test 1: ADDRESS at block 5 → history index finds block 7 → InChangeset → correct
+        let provider =
+            HistoricalStateProviderRef::new(&db, 5).with_pipeline_consistency(inconsistent);
+        let result = provider.basic_account(&ADDRESS);
+        assert!(result.is_ok(), "Changeset path should work during inconsistency: {result:?}");
+        assert_eq!(result.unwrap().unwrap().nonce, 7);
+
+        // Test 2: ADDRESS at block 16 → no entry after 16 → InPlainState → BLOCKED
+        let provider =
+            HistoricalStateProviderRef::new(&db, 16).with_pipeline_consistency(inconsistent);
+        let result = provider.basic_account(&ADDRESS);
+        assert!(
+            matches!(result, Err(ProviderError::HistoryStateInconsistent { .. })),
+            "InPlainState should be blocked: {result:?}"
+        );
+
+        // Test 3: no_history_addr at block 5 → never written to history → NotYetWritten → Ok(None)
+        // This is correct: accounts that never existed in history return None regardless of
+        // pipeline consistency, because they were never modified by any block.
+        let provider =
+            HistoricalStateProviderRef::new(&db, 5).with_pipeline_consistency(inconsistent);
+        let result = provider.basic_account(&no_history_addr);
+        assert!(
+            matches!(result, Ok(None)),
+            "Never-written account should return None: {result:?}"
+        );
+
+        // Test 4: Same queries with consistent pipeline → all succeed
+        let consistent = PipelineConsistency {
+            execution_tip: Some(200),
+            account_history_tip: Some(200),
+            storage_history_tip: Some(200),
+        };
+
+        let provider =
+            HistoricalStateProviderRef::new(&db, 16).with_pipeline_consistency(consistent);
+        let result = provider.basic_account(&ADDRESS);
+        assert!(result.is_ok(), "Should succeed when consistent: {result:?}");
+        assert_eq!(result.unwrap().unwrap().nonce, acc_plain.nonce);
+
+        let provider =
+            HistoricalStateProviderRef::new(&db, 5).with_pipeline_consistency(consistent);
+        let result = provider.basic_account(&no_history_addr);
+        assert!(result.is_ok(), "Should succeed when consistent: {result:?}");
     }
 }

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -1173,10 +1173,7 @@ mod tests {
         let provider =
             HistoricalStateProviderRef::new(&db, 5).with_pipeline_consistency(inconsistent);
         let result = provider.basic_account(&no_history_addr);
-        assert!(
-            matches!(result, Ok(None)),
-            "Never-written account should return None: {result:?}"
-        );
+        assert!(matches!(result, Ok(None)), "Never-written account should return None: {result:?}");
 
         // Test 4: Same queries with consistent pipeline → all succeed
         let consistent = PipelineConsistency {

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -1101,7 +1101,7 @@ mod tests {
 
     /// Verifies selective rejection during pipeline inconsistency:
     /// - Accounts resolving via changeset path → return correct data (not blocked)
-    /// - Accounts resolving via InPlainState path → return HistoryStateInconsistent error
+    /// - Accounts resolving via `InPlainState` path → return `HistoryStateInconsistent` error
     #[test]
     fn pipeline_consistency_selective_rejection() {
         let factory = create_test_provider_factory();

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1277,6 +1277,11 @@ where
     fn update_blob_store_metrics(&self) {
         if let Some(data_size) = self.blob_store.data_size_hint() {
             self.blob_store_metrics.blobstore_byte_size.set(data_size as f64);
+            // geth-compatible blobpool metrics: dataused tracks actual blob data,
+            // datareal tracks total footprint (in reth both are the same since we don't
+            // have shelf-based storage with gaps like geth)
+            metrics::gauge!("blobpool.dataused").set(data_size as f64);
+            metrics::gauge!("blobpool.datareal").set(data_size as f64);
         }
         self.blob_store_metrics.blobstore_entries.set(self.blob_store.blobs_len() as f64);
     }

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -1275,14 +1275,13 @@ where
     }
 
     fn update_blob_store_metrics(&self) {
-        if let Some(data_size) = self.blob_store.data_size_hint() {
-            self.blob_store_metrics.blobstore_byte_size.set(data_size as f64);
-            // geth-compatible blobpool metrics: dataused tracks actual blob data,
-            // datareal tracks total footprint (in reth both are the same since we don't
-            // have shelf-based storage with gaps like geth)
-            metrics::gauge!("blobpool.dataused").set(data_size as f64);
-            metrics::gauge!("blobpool.datareal").set(data_size as f64);
-        }
+        let data_size = self.blob_store.data_size_hint().unwrap_or(0);
+        self.blob_store_metrics.blobstore_byte_size.set(data_size as f64);
+        // geth-compatible blobpool metrics: dataused tracks actual blob data,
+        // datareal tracks total footprint (in reth both are the same since we don't
+        // have shelf-based storage with gaps like geth)
+        metrics::gauge!("blobpool.dataused").set(data_size as f64);
+        metrics::gauge!("blobpool.datareal").set(data_size as f64);
         self.blob_store_metrics.blobstore_entries.set(self.blob_store.blobs_len() as f64);
     }
 


### PR DESCRIPTION
## Summary

This PR bundles three features/fixes targeting v0.0.9:

### 1. Pipeline Sync Historical State Consistency Guard

Resolves [bnb-chain/reth-bsc#273 (comment)](https://github.com/bnb-chain/reth-bsc/issues/273#issuecomment-4062887292)

During pipeline sync, `ExecutionStage` commits `PlainAccountState`/`PlainStorageState` before `IndexAccountHistory`/`IndexStorageHistory` stages run. This creates a window where `HistoricalStateProvider` falls back to `InPlainState` and reads data from a **future block**, returning silently wrong results.

**Fix**: Added `PipelineConsistency` guard that detects when `execution_tip > history_index_tip` and rejects `InPlainState` reads with `HistoryStateInconsistent` error. Changeset-based reads (where history index points to a valid changeset entry) continue to work correctly.

**Key behavior**:
- Queries resolving via **changeset path** (account modified within indexed range) → **return correct data** (not blocked)
- Queries resolving via **InPlainState fallback** (no history index entry after queried block) → **return `HistoryStateInconsistent` error** during the inconsistency window
- After `IndexAccountHistory`/`IndexStorageHistory` stages complete → all queries return correct data

**Files changed**:
| File | Change |
|---|---|
| `crates/storage/provider/src/providers/state/historical.rs` | `PipelineConsistency` struct, `with_pipeline_consistency()`, guards on `InPlainState` path in `basic_account()` and `storage()` |
| `crates/storage/provider/src/providers/database/provider.rs` | `build_pipeline_consistency()` reads stage checkpoints; guards `LatestStateProvider` early-return path |
| `crates/storage/errors/src/provider.rs` | New `HistoryStateInconsistent` error variant with block, execution_tip, history_tip |

### 2. Geth-Compatible P2P and Blobpool Metrics

| File | Metric | Type |
|---|---|---|
| `crates/net/eth-wire/src/p2pstream.rs` | `p2p.ingress` / `p2p.egress` — total wire bytes | Counter |
| `crates/net/eth-wire/src/ethstream.rs` | `p2p.{direction}.eth.{version}.0x{code}` — per-message bytes; `...packets` — per-message packet count | Counter |
| `crates/transaction-pool/src/pool/mod.rs` | `blobpool.dataused` / `blobpool.datareal` — blob pool data usage | Gauge |

### 3. Fastnode RPC Guard

Rejects `eth_getProof` and `eth_getAccount` in fastnode mode (TrieDB backend does not support these).

| File | Change |
|---|---|
| `crates/rpc/rpc-eth-api/src/helpers/state.rs` | Return error for `eth_getProof` / `eth_getAccount` when `is_fast_node` |

## Test Plan

- [x] `cargo test -p reth-provider --lib --features test-utils -- pipeline_consistency` — 2 unit tests pass:
  - `pipeline_consistency_unit_logic`: 4 boundary conditions for `PipelineConsistency`
  - `pipeline_consistency_selective_rejection`: changeset path returns correct data while InPlainState path returns `HistoryStateInconsistent` error during inconsistency; all queries succeed when consistent
- [x] `cargo test -p reth-eth-wire --lib` — 48 tests pass
- [x] Local 5-node testnet (1 reth + 4 geth): pipeline sync completes correctly, no wrong data returned, post-sync balances match geth
- [ ] BSC testnet: verify `HistoryStateInconsistent` error captured during long pipeline sync (local chain too small — 1300 blocks syncs in <2s, inconsistency window ~34ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)