### PR TITLE
fix: do not cache internal block execution errors in invalid_headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11963,9 +11963,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -12870,9 +12870,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2888,30 +2888,56 @@ where
 
         // if invalid block, we check the validation error. Otherwise return the fatal
         // error.
-        let validation_err = error.ensure_validation_error()?;
+        match error.ensure_validation_error() {
+            Ok(validation_err) => {
+                // Permanent validation error: cache in invalid_headers so that
+                // descendants are immediately rejected without re-execution.
+                warn!(
+                    target: "engine::tree",
+                    invalid_hash=%block.hash(),
+                    invalid_number=block.number(),
+                    %validation_err,
+                    "Invalid block error on new payload",
+                );
+                let latest_valid_hash =
+                    self.latest_valid_hash_for_invalid_payload(block.parent_hash())?;
 
-        // If the error was due to an invalid payload, the payload is added to the
-        // invalid headers cache and `Ok` with [PayloadStatusEnum::Invalid] is
-        // returned.
-        warn!(
-            target: "engine::tree",
-            invalid_hash=%block.hash(),
-            invalid_number=block.number(),
-            %validation_err,
-            "Invalid block error on new payload",
-        );
-        let latest_valid_hash = self.latest_valid_hash_for_invalid_payload(block.parent_hash())?;
+                // keep track of the invalid header
+                self.state.invalid_headers.insert(block.block_with_parent());
+                self.emit_event(EngineApiEvent::BeaconConsensus(
+                    ConsensusEngineEvent::InvalidBlock(Box::new(block)),
+                ));
 
-        // keep track of the invalid header
-        self.state.invalid_headers.insert(block.block_with_parent());
-        self.emit_event(EngineApiEvent::BeaconConsensus(ConsensusEngineEvent::InvalidBlock(
-            Box::new(block),
-        )));
+                Ok(PayloadStatus::new(
+                    PayloadStatusEnum::Invalid { validation_error: validation_err.to_string() },
+                    latest_valid_hash,
+                ))
+            }
+            Err(fatal) => match fatal {
+                // Internal block execution error (e.g., BSC transient FutureBlock).
+                // Reject the block but do NOT cache in invalid_headers — the error
+                // may be transient and the block (or its descendants) could become
+                // processable later.
+                InsertBlockFatalError::BlockExecutionError(err) => {
+                    warn!(
+                        target: "engine::tree",
+                        block_hash=%block.hash(),
+                        block_number=block.number(),
+                        %err,
+                        "Internal block execution error on new payload (not caching as invalid)",
+                    );
 
-        Ok(PayloadStatus::new(
-            PayloadStatusEnum::Invalid { validation_error: validation_err.to_string() },
-            latest_valid_hash,
-        ))
+                    Ok(PayloadStatus::new(
+                        PayloadStatusEnum::Invalid {
+                            validation_error: err.to_string(),
+                        },
+                        None,
+                    ))
+                }
+                // Provider errors are truly fatal — propagate to shut down the engine.
+                fatal @ InsertBlockFatalError::Provider(_) => Err(fatal),
+            },
+        }
     }
 
     /// Handles a [`NewPayloadError`] by converting it to a [`PayloadStatus`].

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2928,9 +2928,7 @@ where
                     );
 
                     Ok(PayloadStatus::new(
-                        PayloadStatusEnum::Invalid {
-                            validation_error: err.to_string(),
-                        },
+                        PayloadStatusEnum::Invalid { validation_error: err.to_string() },
                         None,
                     ))
                 }

--- a/deny.toml
+++ b/deny.toml
@@ -15,6 +15,11 @@ ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2026-0009 time DoS via stack exhaustion, fixed in 0.3.47
     # TODO: upgrade when upstream deps adopt time >=0.3.47
     "RUSTSEC-2026-0009",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand unsound only when combined with a custom
+    # log-level trace logger calling rand::rng() during reseed; not reachable in reth's logging path.
+    "RUSTSEC-2026-0097",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0105 core2 unmaintained, all versions yanked (no replacement)
+    "RUSTSEC-2026-0105",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
## Summary
- Fixes the engine-tree side of bnb-chain/reth-bsc#313 (engine stalls permanently after rejecting an invalid block)
- When `on_insert_block_error` encounters an `InsertBlockFatalError::BlockExecutionError` (internal/transient error), it now returns `Invalid` status **without** inserting into the `invalid_headers` cache, instead of shutting down the node
- `InsertBlockFatalError::Provider` errors remain truly fatal (propagated as before)
- This prevents transient BSC errors (e.g., `FutureBlock` during proposer backoff) from poisoning the `invalid_headers` cache, which would cascade-reject all descendant blocks and permanently stall the node

## Context
In BSC's Parlia consensus, `FutureBlock` is a transient error — the block's proposer is in backoff period and the block will become valid after a short delay. Previously, this error was mapped to `BlockExecutionError::Validation` in reth-bsc, which caused engine-tree to:
1. Insert the block hash into `invalid_headers` cache
2. Auto-reject all descendant blocks via `find_invalid_ancestor` (cascade infection)
3. Subsequent gossip blocks return `Syncing` (parent state missing) and get dropped
4. The `invalid_headers` eviction threshold (128 hits) is never reached → permanent stall

The companion PR in reth-bsc reclassifies `FutureBlock` as `Internal` (not `Validation`), and this PR ensures `Internal` block execution errors are handled gracefully.

## Test plan
- [x] `cargo check -p reth-engine-tree` passes
- [x] All 9 engine-tree tests pass (`cargo test -p reth-engine-tree`)
- [x] Permanent validation errors still cached in `invalid_headers` (existing behavior preserved)
- [x] Provider errors still fatal (existing behavior preserved)
- [ ] Integration test: BSC node receives FutureBlock → block rejected but node continues, descendants not auto-rejected