### PR TITLE
perf: parallelize triedb flush and commit() fsync operations

### DIFF
--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -553,6 +553,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             let triedb_active = is_triedb_active();
             let mut triedb_opt = triedb_active.then(get_global_triedb);
 
+            // Collect pending TrieDB flushes to execute on a parallel thread.
+            // This avoids blocking MDBX writes with RocksDB I/O.
+            // Each entry: (block_number, state_root, difflayer_arc).
+            let mut pending_triedb_flushes = Vec::new();
+
             for (i, block) in blocks.iter().enumerate() {
                 let recovered_block = block.recovered_block();
                 let block_number = recovered_block.number();
@@ -590,18 +595,20 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
                         if let Some(ref difflayer) = block.difflayer {
                             // The difflayer was precomputed during validation (newPayload).
-                            // Root was already verified there, so just flush to disk.
+                            // Root was already verified there. Defer flush to parallel thread
+                            // so RocksDB I/O doesn't block MDBX writes.
                             debug!(
                                 target: "providers::db",
                                 block_number,
                                 state_root = ?state_root,
-                                "Flushing precomputed triedb difflayer in save_blocks",
+                                "Deferring precomputed triedb difflayer flush in save_blocks",
                             );
-                            triedb
-                                .flush(block_number, state_root, &Some(difflayer.clone()))
-                                .map_err(ProviderError::other)?;
+                            pending_triedb_flushes.push((block_number, state_root, difflayer.clone()));
                         } else {
                             // No precomputed difflayer; compute and commit from hashed state.
+                            // Flush synchronously because intermediate_and_commit reads
+                            // latest_persist_state() which requires prior flushes to have
+                            // updated RocksDB.
                             let (latest_block_number, latest_state_root) =
                                 triedb.latest_persist_state().map_err(ProviderError::other)?;
 
@@ -656,6 +663,24 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                     }
                 }
             }
+
+            // Spawn a parallel thread to flush deferred TrieDB difflayers to RocksDB.
+            // Runs concurrently with trie updates, history index updates, and pipeline
+            // stage updates below, reducing sequential I/O on the persistence thread.
+            let triedb_flush_handle = if !pending_triedb_flushes.is_empty() {
+                let mut flush_triedb = get_global_triedb();
+                Some(s.spawn(move || -> ProviderResult<std::time::Duration> {
+                    let start = Instant::now();
+                    for (block_number, state_root, difflayer) in pending_triedb_flushes {
+                        flush_triedb
+                            .flush(block_number, state_root, &Some(difflayer))
+                            .map_err(ProviderError::other)?;
+                    }
+                    Ok(start.elapsed())
+                }))
+            } else {
+                None
+            };
 
             // Write all trie updates in a single batch.
             // This reduces cursor open/close overhead from N calls to 1.
@@ -727,6 +752,14 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             #[cfg(all(unix, feature = "rocksdb"))]
             if let Some(handle) = rocksdb_handle {
                 timings.rocksdb = handle.join().expect("RocksDB thread panicked")?;
+            }
+
+            // Wait for TrieDB flush thread
+            if let Some(handle) = triedb_flush_handle {
+                let flush_elapsed = handle
+                    .join()
+                    .map_err(|_| ProviderError::Database(DatabaseError::Other("triedb flush thread panicked".to_string())))??;
+                timings.write_hashed_state += flush_elapsed;
             }
 
             timings.total = total_start.elapsed();
@@ -3670,26 +3703,55 @@ impl<TX: DbTx + 'static, N: NodeTypes + 'static> DBProvider for DatabaseProvider
 
             self.static_file_provider.commit()?;
         } else {
-            // Normal path: finalize() will call sync_all() if not already synced
+            // Normal path: run SF finalize, RocksDB commit, and MDBX commit in parallel.
+            // These are independent storage engines whose fsync operations can overlap,
+            // reducing wall-clock time from sum(sf + rocksdb + mdbx) to max(sf, rocksdb, mdbx).
             let mut timings = metrics::CommitTimings::default();
 
-            let start = Instant::now();
-            self.static_file_provider.finalize()?;
-            timings.sf = start.elapsed();
+            let sf_provider = &self.static_file_provider;
 
             #[cfg(all(unix, feature = "rocksdb"))]
-            {
-                let start = Instant::now();
-                let batches = std::mem::take(&mut *self.pending_rocksdb_batches.lock());
-                for batch in batches {
-                    self.rocksdb_provider.commit_batch(batch)?;
-                }
-                timings.rocksdb = start.elapsed();
-            }
+            let batches = std::mem::take(&mut *self.pending_rocksdb_batches.lock());
+            #[cfg(all(unix, feature = "rocksdb"))]
+            let rocksdb_provider = &self.rocksdb_provider;
 
-            let start = Instant::now();
-            self.tx.commit()?;
-            timings.mdbx = start.elapsed();
+            thread::scope(|s| {
+                // Static file finalize (fsync) in parallel
+                let sf_handle = s.spawn(|| {
+                    let start = Instant::now();
+                    sf_provider.finalize()?;
+                    Ok::<_, ProviderError>(start.elapsed())
+                });
+
+                // RocksDB batch commits in parallel
+                #[cfg(all(unix, feature = "rocksdb"))]
+                let rocksdb_handle = s.spawn(move || {
+                    let start = Instant::now();
+                    for batch in batches {
+                        rocksdb_provider.commit_batch(batch)?;
+                    }
+                    Ok::<_, ProviderError>(start.elapsed())
+                });
+
+                // MDBX commit (fsync) on main thread
+                let start = Instant::now();
+                self.tx.commit()?;
+                timings.mdbx = start.elapsed();
+
+                // Collect parallel results
+                timings.sf = sf_handle
+                    .join()
+                    .map_err(|_| ProviderError::Database(DatabaseError::Other("static file commit thread panicked".to_string())))??;
+
+                #[cfg(all(unix, feature = "rocksdb"))]
+                {
+                    timings.rocksdb = rocksdb_handle
+                        .join()
+                        .map_err(|_| ProviderError::Database(DatabaseError::Other("rocksdb commit thread panicked".to_string())))??;
+                }
+
+                Ok::<_, ProviderError>(())
+            })?;
 
             self.metrics.record_commit(&timings);
         }


### PR DESCRIPTION
## Summary

- **save_blocks**: Defer precomputed TrieDB difflayer flushes to a parallel thread within `thread::scope`. The RocksDB WriteBatch now runs concurrently with history index/pipeline stage updates instead of blocking the MDBX write path
- **commit()**: Run static file finalize (`sync_all`), RocksDB batch commits, and MDBX transaction commit concurrently via `thread::scope`, reducing wall-clock time from `sum(sf+rocksdb+mdbx)` to `max(sf, rocksdb, mdbx)`

## Background

When TrieDB is active, `save_blocks` + `commit()` performs sequential I/O across three storage engines (TrieDB/RocksDB, MDBX, Static Files). On EC2 EBS volumes, this sequential I/O burst can exhaust IOPS burst credits, triggering 3+ second system-level stalls that block all threads — including tokio timer tasks responsible for miner block submission.

In a QA environment, this caused a validator's last-turn block (timeout=90ms) to miss its broadcast window: the block was built on time but the `tokio::time::sleep(355ms)` delayed submission was caught in an I/O stall, arriving 2.7 seconds late. An off-turn validator produced the block instead and slashed the inturn validator, which was subsequently jailed at the next epoch boundary.

## Changes

### 1. Parallel TrieDB flush in save_blocks

| Path | Before | After |
|------|--------|-------|
| Path 1 (precomputed difflayer) | `triedb.flush()` inline in per-block loop | Collected into Vec, flushed on parallel thread |
| Path 2 (compute-from-scratch) | Synchronous flush | Unchanged (reads `latest_persist_state()`) |

The parallel flush thread runs within the existing `thread::scope`, concurrent with history index updates and pipeline stage updates.

### 2. Parallel commit() fsync

| Before (sequential) | After (parallel via thread::scope) |
|---------------------|-------------------------------------|
| SF finalize (fsync) → RocksDB commit → MDBX commit | SF finalize ∥ RocksDB commit ∥ MDBX commit |

## Test plan

- [ ] `cargo check -p reth-provider` passes
- [ ] `cargo test -p reth-provider` passes
- [ ] `cargo test -p reth-engine-tree` passes
- [ ] Deploy to QA validator and monitor `save_blocks` duration metrics
- [ ] Verify no 3+ second log gaps during persistence under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)