### PR TITLE
feat: port develop commits to develop-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ This project based on the excellent community versions as foundation, We extend 
   - [@loocapro](https://github.com/loocapro)
   - All contributors on reth for reth-bsc
 
+
 ## Warning
 
 The `NippyJar` and `Compact` encoding formats and their implementations are designed for storing and retrieving data internally. They are not hardened to safely read potentially malicious data.

--- a/crates/storage/db-api/src/models/mod.rs
+++ b/crates/storage/db-api/src/models/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     DatabaseError,
 };
 use alloy_primitives::{Address, B256, U256};
-use reth_codecs::{add_arbitrary_tests, impl_compression_for_compact, Compact};
+use reth_codecs::{add_arbitrary_tests, impl_compression_for_compact, Compact, DecompressError};
 use reth_prune_types::PruneSegment;
 use reth_trie_common::{StoredNibbles, StoredNibblesSubKey, *};
 use serde::{Deserialize, Serialize};
@@ -208,6 +208,54 @@ impl Decode for ClientVersion {
 }
 
 impl_compression_for_compact!(StoredBlockOmmers<H>, CompactU256);
+
+// -----------------------------------------------------------------------------
+//  Parlia snapshot raw blob (BNB Smart Chain checkpoints)
+// -----------------------------------------------------------------------------
+
+/// Raw binary blob storing a Parlia consensus snapshot for BNB Smart Chain checkpoints.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ParliaSnapshotBlob(pub Vec<u8>);
+
+impl crate::table::Compress for ParliaSnapshotBlob {
+    type Compressed = Vec<u8>;
+
+    fn uncompressable_ref(&self) -> Option<&[u8]> {
+        Some(&self.0)
+    }
+
+    fn compress(self) -> Self::Compressed {
+        self.0
+    }
+
+    fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
+        buf.put_slice(&self.0);
+    }
+}
+
+impl crate::table::Decompress for ParliaSnapshotBlob {
+    fn decompress(value: &[u8]) -> Result<Self, DecompressError> {
+        Ok(Self(value.to_vec()))
+    }
+}
+
+impl crate::table::Encode for ParliaSnapshotBlob {
+    type Encoded = Vec<u8>;
+
+    fn encode(self) -> Self::Encoded {
+        self.0
+    }
+}
+
+impl crate::table::Decode for ParliaSnapshotBlob {
+    fn decode(value: &[u8]) -> Result<Self, DatabaseError> {
+        Ok(Self(value.to_vec()))
+    }
+
+    fn decode_owned(value: Vec<u8>) -> Result<Self, DatabaseError> {
+        Ok(Self(value))
+    }
+}
 
 /// Adds wrapper structs for some primitive types so they can use `StructFlags` from Compact, when
 /// used as pure table values.

--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -537,6 +537,13 @@ tables! {
         type Key = String;
         type Value = Vec<u8>;
     }
+
+    /// Stores BSC Parlia checkpoint snapshots (compressed CBOR bytes).
+    /// Defined here for schema registration and database initialization.
+    table ParliaSnapshots {
+        type Key = BlockNumber;
+        type Value = crate::models::ParliaSnapshotBlob;
+    }
 }
 
 /// Packed-encoding view of the [`AccountsTrie`] table.

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,8 @@ ignore = [
     "RUSTSEC-2023-0089",
     # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru upgrade requires a discv5 bump first
     "RUSTSEC-2026-0002",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand unsoundness with custom logger, no fix available yet
+    "RUSTSEC-2026-0097",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Cherry-picks custom BSC/fork commits from `develop` onto `develop-v2`.

## Commits included

- `87b636891` doc: update README for acknowledgements
- `04685c5f9` feat: add parlia snapshot (#14)

## Remaining commits

To be cherry-picked in follow-up:
- `dea96c49c` feat: add missing RPC methods (#15) ← has conflicts
- and all subsequent commits from `develop`