### PR TITLE
feat: add missing RPC methods (#15)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,51 +1,45 @@
-*                           @gakonst
-crates/chain-state/         @fgimenez @mattsse
-crates/chainspec/           @Rjected @joshieDo @mattsse
-crates/cli/                 @mattsse @Rjected
-crates/config/              @shekhirin @mattsse @Rjected 
-crates/consensus/           @mattsse @Rjected
-crates/e2e-test-utils/      @mattsse @Rjected @klkvr @fgimenez
-crates/engine/              @mattsse @Rjected @mediocregopher @yongkangc
-crates/era/                 @mattsse
-crates/era-downloader/      @mattsse
-crates/era-utils/           @mattsse
-crates/errors/              @mattsse
-crates/ethereum/            @mattsse @Rjected
-crates/etl/                 @joshieDo @shekhirin
-crates/evm/                 @mattsse @Rjected @klkvr
-crates/exex/                @shekhirin
-crates/fs-util/             @mattsse
-crates/metrics/             @mattsse @Rjected 
-crates/net/                 @mattsse @Rjected
-crates/net/downloaders/     @Rjected
-crates/node/                @mattsse @Rjected @klkvr
-crates/payload/             @mattsse @Rjected
-crates/primitives-traits/   @Rjected @mattsse @klkvr
-crates/primitives/          @Rjected @mattsse @klkvr
-crates/prune/               @shekhirin @joshieDo
-crates/ress/                @shekhirin @Rjected
-crates/revm/                @mattsse
-crates/rpc/                 @mattsse @Rjected
-crates/stages/              @shekhirin @mediocregopher
-crates/static-file/         @joshieDo @shekhirin
-crates/stateless/           @mattsse
-crates/storage/codecs/      @joshieDo
-crates/storage/db-api/      @joshieDo
-crates/storage/db-common/   @Rjected
-crates/storage/db/          @joshieDo
-crates/storage/errors/      @joshieDo
-crates/storage/libmdbx-rs/  @shekhirin
-crates/storage/nippy-jar/   @joshieDo @shekhirin
-crates/storage/provider/    @joshieDo @shekhirin @yongkangc
-crates/storage/storage-api/ @joshieDo
-crates/tasks/               @mattsse @DaniPopes
-crates/tokio-util/          @mattsse 
-crates/tracing/             @mattsse @shekhirin
-crates/tracing-otlp/        @mattsse @Rjected 
-crates/transaction-pool/    @mattsse @yongkangc
-crates/trie/                @Rjected @shekhirin @mediocregopher @yongkangc
-bin/reth/                   @mattsse @shekhirin @Rjected 
-bin/reth-bench/             @mattsse @Rjected @shekhirin @yongkangc 
-bin/reth-bench-compare/     @mediocregopher @shekhirin @yongkangc
-etc/                        @Rjected @shekhirin
-.github/                    @gakonst @DaniPopes
+*                           @joey0612
+crates/blockchain-tree-api/ @graceharuki @joey0612
+crates/blockchain-tree/     @graceharuki @joey0612
+crates/chain-state/         @graceharuki @joey0612
+crates/chainspec/           @graceharuki @joey0612
+crates/cli/                 @graceharuki @joey0612
+crates/consensus/           @graceharuki @joey0612
+crates/e2e-test-utils/      @graceharuki @joey0612
+crates/engine               @graceharuki @joey0612
+crates/engine/              @graceharuki @joey0612
+crates/era/                 @graceharuki @joey0612
+crates/errors/              @graceharuki @joey0612
+crates/ethereum-forks/      @graceharuki @joey0612
+crates/ethereum/            @graceharuki @joey0612
+crates/etl/                 @graceharuki @joey0612
+crates/evm/                 @graceharuki @joey0612
+crates/exex/                @graceharuki @joey0612
+crates/net/                 @graceharuki @joey0612
+crates/net/downloaders/     @graceharuki @joey0612
+crates/node/                @graceharuki @joey0612
+crates/optimism/            @graceharuki @joey0612
+crates/payload/             @graceharuki @joey0612
+crates/primitives-traits/   @graceharuki @joey0612
+crates/primitives/          @graceharuki @joey0612
+crates/prune/               @graceharuki @joey0612
+crates/ress                 @graceharuki @joey0612
+crates/revm/                @graceharuki @joey0612
+crates/rpc/                 @graceharuki @joey0612
+crates/stages/              @graceharuki @joey0612
+crates/static-file/         @graceharuki @joey0612
+crates/storage/codecs/      @graceharuki @joey0612
+crates/storage/db-api/      @graceharuki @joey0612
+crates/storage/db-common/   @graceharuki @joey0612
+crates/storage/db/          @graceharuki @joey0612
+crates/storage/errors/      @graceharuki @joey0612
+crates/storage/libmdbx-rs/  @graceharuki @joey0612
+crates/storage/nippy-jar/   @graceharuki @joey0612
+crates/storage/provider/    @graceharuki @joey0612
+crates/storage/storage-api/ @graceharuki @joey0612
+crates/tasks/               @graceharuki @joey0612
+crates/tokio-util/          @graceharuki @joey0612
+crates/transaction-pool/    @graceharuki @joey0612
+crates/trie/                @graceharuki @joey0612
+etc/                        @graceharuki @joey0612
+.github/                    @joey0612

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9866,6 +9866,7 @@ dependencies = [
  "reth-evm",
  "reth-primitives-traits",
  "reth-rpc-traits",
+ "serde",
  "serde_json",
  "thiserror 2.0.18",
 ]

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ This project based on the excellent community versions as foundation, We extend 
   - [@loocapro](https://github.com/loocapro)
   - All contributors on reth for reth-bsc
 
+## Acknowledgements from BNBChain team
+
+This project based on the excellent community versions as foundation, We extend our sincere appreciation to the teams below:
+- [Reth](https://github.com/paradigmxyz/reth) - The reth project
+- [Reth-bsc](https://github.com/loocapro/reth-bsc) - The BSC Reth implementation from community
+- Especially thanks to:
+  - [@mattsse](https://github.com/mattsse)
+  - [@klkvr](https://github.com/klkvr)
+  - [@loocapro](https://github.com/loocapro)
+  - All contributors on reth for reth-bsc
 
 ## Warning
 

--- a/crates/ethereum/node/tests/e2e/dev.rs
+++ b/crates/ethereum/node/tests/e2e/dev.rs
@@ -68,6 +68,7 @@ async fn can_run_dev_node_custom_attributes() -> eyre::Result<()> {
             .unwrap()
             .unwrap()
             .header
+            .inner
             .beneficiary ==
             fee_recipient
     );

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -34,6 +34,9 @@ thiserror.workspace = true
 auto_impl.workspace = true
 dyn-clone.workspace = true
 
+# serialization
+serde = { workspace = true, features = ["derive"] }
+
 [dev-dependencies]
 serde_json.workspace = true
 

--- a/crates/rpc/rpc-convert/src/custom_header.rs
+++ b/crates/rpc/rpc-convert/src/custom_header.rs
@@ -1,0 +1,242 @@
+//! Custom RPC header types with additional fields
+
+use alloy_network::primitives::HeaderResponse;
+use alloy_primitives::{BlockHash, U256};
+
+/// Custom RPC header that extends the standard header with additional fields
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomRpcHeader<H = alloy_consensus::Header> {
+    /// Hash of the block
+    pub hash: BlockHash,
+    /// Inner consensus header.
+    #[serde(flatten)]
+    pub inner: H,
+    /// Total difficulty
+    ///
+    /// Note: This field is now effectively deprecated: <https://github.com/ethereum/execution-apis/pull/570>
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_difficulty: Option<U256>,
+    /// Integer the size of this block in bytes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<U256>,
+    /// Millisecond timestamp - custom field for BNB Chain
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub milli_timestamp: Option<U256>,
+}
+
+impl<H> CustomRpcHeader<H> {
+    /// Create a new custom header from consensus header components
+    pub const fn new(
+        hash: BlockHash,
+        inner: H,
+        total_difficulty: Option<U256>,
+        size: Option<U256>,
+        milli_timestamp: Option<U256>,
+    ) -> Self {
+        Self { hash, inner, total_difficulty, size, milli_timestamp }
+    }
+
+    /// Create a custom header from a consensus header
+    pub fn from_consensus(
+        header: alloy_consensus::Header,
+        total_difficulty: Option<U256>,
+        size: Option<U256>,
+    ) -> CustomRpcHeader<alloy_consensus::Header> {
+        let hash = header.hash_slow();
+        let milli_timestamp = Some(U256::from(calculate_millisecond_timestamp(&header)));
+
+        CustomRpcHeader { hash, inner: header, total_difficulty, size, milli_timestamp }
+    }
+
+    /// Create a custom header from any block header
+    pub fn from_header<T: reth_primitives_traits::BlockHeader>(
+        header: T,
+        hash: BlockHash,
+        total_difficulty: Option<U256>,
+        size: Option<U256>,
+    ) -> CustomRpcHeader<T> {
+        let milli_timestamp = Some(U256::from(calculate_millisecond_timestamp(&header)));
+
+        CustomRpcHeader { hash, inner: header, total_difficulty, size, milli_timestamp }
+    }
+}
+
+impl<H> HeaderResponse for CustomRpcHeader<H>
+where
+    H: alloy_consensus::BlockHeader,
+{
+    fn hash(&self) -> BlockHash {
+        self.hash
+    }
+}
+
+impl<H> alloy_consensus::BlockHeader for CustomRpcHeader<H>
+where
+    H: alloy_consensus::BlockHeader,
+{
+    fn parent_hash(&self) -> alloy_primitives::B256 {
+        self.inner.parent_hash()
+    }
+
+    fn ommers_hash(&self) -> alloy_primitives::B256 {
+        self.inner.ommers_hash()
+    }
+
+    fn beneficiary(&self) -> alloy_primitives::Address {
+        self.inner.beneficiary()
+    }
+
+    fn state_root(&self) -> alloy_primitives::B256 {
+        self.inner.state_root()
+    }
+
+    fn transactions_root(&self) -> alloy_primitives::B256 {
+        self.inner.transactions_root()
+    }
+
+    fn receipts_root(&self) -> alloy_primitives::B256 {
+        self.inner.receipts_root()
+    }
+
+    fn withdrawals_root(&self) -> Option<alloy_primitives::B256> {
+        self.inner.withdrawals_root()
+    }
+
+    fn logs_bloom(&self) -> alloy_primitives::Bloom {
+        self.inner.logs_bloom()
+    }
+
+    fn difficulty(&self) -> alloy_primitives::U256 {
+        self.inner.difficulty()
+    }
+
+    fn number(&self) -> u64 {
+        self.inner.number()
+    }
+
+    fn gas_limit(&self) -> u64 {
+        self.inner.gas_limit()
+    }
+
+    fn gas_used(&self) -> u64 {
+        self.inner.gas_used()
+    }
+
+    fn timestamp(&self) -> u64 {
+        self.inner.timestamp()
+    }
+
+    fn mix_hash(&self) -> Option<alloy_primitives::B256> {
+        self.inner.mix_hash()
+    }
+
+    fn nonce(&self) -> Option<alloy_primitives::FixedBytes<8>> {
+        self.inner.nonce()
+    }
+
+    fn base_fee_per_gas(&self) -> Option<u64> {
+        self.inner.base_fee_per_gas()
+    }
+
+    fn blob_gas_used(&self) -> Option<u64> {
+        self.inner.blob_gas_used()
+    }
+
+    fn excess_blob_gas(&self) -> Option<u64> {
+        self.inner.excess_blob_gas()
+    }
+
+    fn parent_beacon_block_root(&self) -> Option<alloy_primitives::B256> {
+        self.inner.parent_beacon_block_root()
+    }
+
+    fn requests_hash(&self) -> Option<alloy_primitives::B256> {
+        self.inner.requests_hash()
+    }
+
+    fn extra_data(&self) -> &alloy_primitives::Bytes {
+        self.inner.extra_data()
+    }
+}
+
+// RpcObject is automatically implemented via blanket impl for types that implement Serialize +
+// Deserialize
+
+impl<H> reth_rpc_traits::FromConsensusHeader<H> for CustomRpcHeader<H>
+where
+    H: reth_primitives_traits::BlockHeader + Clone,
+{
+    fn from_consensus_header(
+        header: reth_primitives_traits::SealedHeader<H>,
+        block_size: usize,
+    ) -> Self {
+        let header_hash = header.hash();
+        let consensus_header = header.into_header();
+        let milli_timestamp = Some(U256::from(calculate_millisecond_timestamp(&consensus_header)));
+
+        Self {
+            hash: header_hash,
+            inner: consensus_header,
+            total_difficulty: None,
+            size: Some(U256::from(block_size)),
+            milli_timestamp,
+        }
+    }
+}
+
+/// Type alias for the standard Ethereum custom header
+pub type EthereumCustomHeader = CustomRpcHeader<alloy_consensus::Header>;
+
+/// Custom header converter that creates `CustomRpcHeader` instances
+#[derive(Debug, Clone)]
+pub struct CustomHeaderConverter;
+
+impl<H> crate::transaction::HeaderConverter<H, CustomRpcHeader<H>> for CustomHeaderConverter
+where
+    H: reth_primitives_traits::BlockHeader + Clone,
+{
+    fn convert_header(
+        &self,
+        header: reth_primitives_traits::SealedHeader<H>,
+        block_size: usize,
+        td: Option<alloy_primitives::U256>,
+    ) -> CustomRpcHeader<H> {
+        let header_hash = header.hash();
+        let consensus_header = header.into_header();
+        let milli_timestamp = Some(U256::from(calculate_millisecond_timestamp(&consensus_header)));
+
+        CustomRpcHeader {
+            hash: header_hash,
+            inner: consensus_header,
+            total_difficulty: td,
+            size: Some(alloy_primitives::U256::from(block_size)),
+            milli_timestamp,
+        }
+    }
+}
+
+/// Calculate millisecond timestamp from header `mix_hash` for any `BlockHeader` type.
+pub fn calculate_millisecond_timestamp<T: reth_primitives_traits::BlockHeader>(header: &T) -> u64 {
+    let seconds = header.timestamp();
+    let mix_hash = header.mix_hash();
+
+    let ms_part = if let Some(mix_hash) = mix_hash {
+        if mix_hash.is_zero() {
+            0
+        } else {
+            let bytes = mix_hash.as_slice();
+            // Convert last 8 bytes to u64 (big-endian), equivalent to Go's
+            // uint256.SetBytes32().Uint64()
+            let mut result = 0u64;
+            for &byte in bytes.iter().skip(24).take(8) {
+                result = (result << 8) | u64::from(byte);
+            }
+            result
+        }
+    } else {
+        0
+    };
+
+    seconds * 1000 + ms_part
+}

--- a/crates/rpc/rpc-convert/src/lib.rs
+++ b/crates/rpc/rpc-convert/src/lib.rs
@@ -10,9 +10,13 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+pub mod custom_header;
 mod rpc;
 pub mod transaction;
 
+pub use custom_header::{
+    calculate_millisecond_timestamp, CustomHeaderConverter, CustomRpcHeader, EthereumCustomHeader,
+};
 pub use rpc::*;
 pub use transaction::{RpcConvert, RpcConverter, TransactionConversionError};
 

--- a/crates/rpc/rpc-convert/src/rpc.rs
+++ b/crates/rpc/rpc-convert/src/rpc.rs
@@ -22,7 +22,7 @@ impl<T> RpcTypes for T
 where
     T: Network<TransactionRequest: AsRef<TransactionRequest> + AsMut<TransactionRequest>> + Unpin,
 {
-    type Header = T::HeaderResponse;
+    type Header = crate::CustomRpcHeader<alloy_consensus::Header>;
     type Receipt = T::ReceiptResponse;
     type TransactionResponse = T::TransactionResponse;
     type TransactionRequest = T::TransactionRequest;

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -3,7 +3,7 @@ use crate::{
     RpcHeader, RpcReceipt, RpcTransaction, RpcTxReq, RpcTypes, SignableTxRequest, TryIntoTxEnv,
 };
 use alloy_consensus::{error::ValueError, transaction::Recovered};
-use alloy_primitives::Address;
+use alloy_primitives::{Address, U256};
 use alloy_rpc_types_eth::TransactionInfo;
 use core::error;
 use dyn_clone::DynClone;
@@ -13,7 +13,7 @@ use reth_primitives_traits::{
     TxTy,
 };
 use reth_rpc_traits::{FromConsensusHeader, FromConsensusTx, TryIntoSimTx, TxInfoMapper};
-use std::{convert::Infallible, error::Error, fmt, fmt::Debug, marker::PhantomData};
+use std::{error::Error, fmt, fmt::Debug, marker::PhantomData};
 
 /// Input for [`RpcConvert::convert_receipts`].
 #[derive(Debug, Clone)]
@@ -58,15 +58,13 @@ pub trait ReceiptConverter<N: NodePrimitives>: Debug + 'static {
 
 /// A type that knows how to convert a consensus header into an RPC header.
 pub trait HeaderConverter<Consensus, Rpc>: Send + Sync + Unpin + Clone + 'static {
-    /// An associated RPC conversion error.
-    type Err: error::Error;
-
     /// Converts a consensus header into an RPC header.
     fn convert_header(
         &self,
         header: SealedHeader<Consensus>,
         block_size: usize,
-    ) -> Result<Rpc, Self::Err>;
+        td: Option<U256>,
+    ) -> Rpc;
 }
 
 /// Default implementation of [`HeaderConverter`] that uses [`FromConsensusHeader`] to convert
@@ -75,29 +73,13 @@ impl<Consensus, Rpc> HeaderConverter<Consensus, Rpc> for ()
 where
     Rpc: FromConsensusHeader<Consensus>,
 {
-    type Err = Infallible;
-
     fn convert_header(
         &self,
         header: SealedHeader<Consensus>,
         block_size: usize,
-    ) -> Result<Rpc, Self::Err> {
-        Ok(Rpc::from_consensus_header(header, block_size))
-    }
-}
-
-impl<Consensus, Rpc, F> HeaderConverter<Consensus, Rpc> for F
-where
-    F: Fn(SealedHeader<Consensus>, usize) -> Rpc + Send + Sync + Unpin + Clone + 'static,
-{
-    type Err = Infallible;
-
-    fn convert_header(
-        &self,
-        header: SealedHeader<Consensus>,
-        block_size: usize,
-    ) -> Result<Rpc, Self::Err> {
-        Ok(self(header, block_size))
+        _td: Option<U256>,
+    ) -> Rpc {
+        Rpc::from_consensus_header(header, block_size)
     }
 }
 
@@ -182,6 +164,7 @@ pub trait RpcConvert: Send + Sync + Unpin + Debug + DynClone + 'static {
         &self,
         header: SealedHeaderFor<Self::Primitives>,
         block_size: usize,
+        td: Option<U256>,
     ) -> Result<RpcHeader<Self::Network>, Self::Error>;
 }
 
@@ -682,7 +665,6 @@ where
                        + From<TxEnv::Error>
                        + From<<Map as TxInfoMapper<TxTy<N>>>::Err>
                        + From<RpcTx::Err>
-                       + From<Header::Err>
                        + Error
                        + Unpin
                        + Sync
@@ -753,7 +735,8 @@ where
         &self,
         header: SealedHeaderFor<Self::Primitives>,
         block_size: usize,
+        td: Option<U256>,
     ) -> Result<RpcHeader<Self::Network>, Self::Error> {
-        Ok(self.header_converter.convert_header(header, block_size)?)
+        Ok(self.header_converter.convert_header(header, block_size, td))
     }
 }

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -19,7 +19,7 @@ use alloy_serde::JsonStorageKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth_primitives_traits::TxTy;
 use reth_rpc_convert::RpcTxReq;
-use reth_rpc_eth_types::{EthApiError, FillTransaction};
+use reth_rpc_eth_types::{EthApiError, FillTransaction, TransactionDataAndReceipt};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -136,6 +136,10 @@ pub trait EthApi<
         index: Index,
     ) -> RpcResult<Option<B>>;
 
+    /// Returns pending transactions.
+    #[method(name = "pendingTransactions")]
+    async fn pending_transactions(&self) -> RpcResult<Option<Vec<T>>>;
+
     /// Returns the EIP-2718 encoded transaction if it exists.
     ///
     /// If this is an EIP-4844 transaction that is in the pool, it will include the sidecar.
@@ -179,6 +183,17 @@ pub trait EthApi<
         index: Index,
     ) -> RpcResult<Option<T>>;
 
+    /// Returns information about all transactions by block hash.
+    #[method(name = "getTransactionsByBlockHash")]
+    async fn transactions_by_block_hash(&self, hash: B256) -> RpcResult<Option<Vec<T>>>;
+
+    /// Returns information about all transactions by block number.
+    #[method(name = "getTransactionsByBlockNumber")]
+    async fn transactions_by_block_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<Option<Vec<T>>>;
+
     /// Returns information about a transaction by sender and nonce.
     #[method(name = "getTransactionBySenderAndNonce")]
     async fn transaction_by_sender_and_nonce(
@@ -190,6 +205,13 @@ pub trait EthApi<
     /// Returns the receipt of a transaction by transaction hash.
     #[method(name = "getTransactionReceipt")]
     async fn transaction_receipt(&self, hash: B256) -> RpcResult<Option<R>>;
+
+    /// Returns the transaction data and receipt for a transaction by transaction hash.
+    #[method(name = "getTransactionDataAndReceipt")]
+    async fn transaction_data_and_receipt(
+        &self,
+        hash: B256,
+    ) -> RpcResult<Option<TransactionDataAndReceipt<T, R>>>;
 
     /// Returns the balance of the account of given address.
     #[method(name = "getBalance")]
@@ -562,6 +584,14 @@ where
         Ok(EthBlocks::ommer_by_block_and_index(self, number.into(), index).await?)
     }
 
+    /// Handler for: `eth_pendingTransactions`
+    async fn pending_transactions(
+        &self,
+    ) -> RpcResult<Option<Vec<RpcTransaction<T::NetworkTypes>>>> {
+        trace!(target: "rpc::eth", "Serving eth_pendingTransactions");
+        Ok(EthTransactions::pending_transactions(self).await?)
+    }
+
     /// Handler for: `eth_getRawTransactionByHash`
     async fn raw_transaction_by_hash(&self, hash: B256) -> RpcResult<Option<Bytes>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getRawTransactionByHash");
@@ -629,6 +659,24 @@ where
             .await?)
     }
 
+    /// Handler for: `eth_getTransactionsByBlockHash`
+    async fn transactions_by_block_hash(
+        &self,
+        hash: B256,
+    ) -> RpcResult<Option<Vec<RpcTransaction<T::NetworkTypes>>>> {
+        trace!(target: "rpc::eth", ?hash, "Serving eth_getTransactionsByBlockHash");
+        Ok(EthTransactions::transactions_by_block_id(self, hash.into()).await?)
+    }
+
+    /// Handler for: `eth_getTransactionsByBlockNumber`
+    async fn transactions_by_block_number(
+        &self,
+        number: BlockNumberOrTag,
+    ) -> RpcResult<Option<Vec<RpcTransaction<T::NetworkTypes>>>> {
+        trace!(target: "rpc::eth", ?number, "Serving eth_getTransactionsByBlockNumber");
+        Ok(EthTransactions::transactions_by_block_id(self, number.into()).await?)
+    }
+
     /// Handler for: `eth_getTransactionBySenderAndNonce`
     async fn transaction_by_sender_and_nonce(
         &self,
@@ -647,6 +695,19 @@ where
     ) -> RpcResult<Option<RpcReceipt<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getTransactionReceipt");
         Ok(EthTransactions::transaction_receipt(self, hash).await?)
+    }
+
+    /// Handler for: `eth_getTransactionDataAndReceipt`
+    async fn transaction_data_and_receipt(
+        &self,
+        hash: B256,
+    ) -> RpcResult<
+        Option<
+            TransactionDataAndReceipt<RpcTransaction<T::NetworkTypes>, RpcReceipt<T::NetworkTypes>>,
+        >,
+    > {
+        trace!(target: "rpc::eth", ?hash, "Serving eth_getTransactionDataAndReceipt");
+        Ok(EthTransactions::transaction_data_and_receipt(self, hash).await?)
     }
 
     /// Handler for: `eth_getBalance`

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -41,8 +41,11 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
     {
         async move {
             let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
-            let header =
-                self.converter().convert_header(block.clone_sealed_header(), block.rlp_length())?;
+            let header = self.converter().convert_header(
+                block.clone_sealed_header(),
+                block.rlp_length(),
+                None,
+            )?;
             Ok(Some(header))
         }
     }
@@ -65,7 +68,7 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
             let block = block.clone_into_rpc_block(
                 full.into(),
                 |tx, tx_info| self.converter().fill(tx, tx_info),
-                |header, size| self.converter().convert_header(header, size),
+                |header, size| self.converter().convert_header(header, size, None),
             )?;
             Ok(Some(block))
         }
@@ -232,9 +235,11 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
                     let block =
                         alloy_consensus::Block::<alloy_consensus::TxEnvelope, _>::uncle(header);
                     let size = block.length();
-                    let header = self
-                        .converter()
-                        .convert_header(SealedHeader::new_unhashed(block.header), size)?;
+                    let header = self.converter().convert_header(
+                        SealedHeader::new_unhashed(block.header),
+                        size,
+                        None,
+                    )?;
                     Ok(Block {
                         uncles: vec![],
                         header,

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -26,11 +26,11 @@ use reth_rpc_eth_types::{
     block::convert_transaction_receipt,
     utils::{binary_search, recover_raw_transaction},
     EthApiError::{self, TransactionConfirmationTimeout},
-    FillTransaction, SignError, TransactionSource,
+    FillTransaction, SignError, TransactionDataAndReceipt, TransactionSource,
 };
 use reth_storage_api::{
-    BlockNumReader, BlockReaderIdExt, ProviderBlock, ProviderReceipt, ProviderTx, ReceiptProvider,
-    TransactionsProvider,
+    BlockIdReader, BlockNumReader, BlockReaderIdExt, ProviderBlock, ProviderReceipt, ProviderTx,
+    ReceiptProvider, TransactionsProvider,
 };
 use reth_transaction_pool::{
     AddedTransactionOutcome, PoolPooledTx, PoolTransaction, TransactionOrigin, TransactionPool,
@@ -191,7 +191,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             if let Some(tx) =
                 self.pool().get_pooled_transaction_element(hash).map(|tx| tx.encoded_2718().into())
             {
-                return Ok(Some(tx))
+                return Ok(Some(tx));
             }
 
             self.spawn_blocking_io(move |ref this| {
@@ -347,6 +347,135 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
         }
     }
 
+    /// Get all transactions by [`BlockId`].
+    ///
+    /// Returns `Ok(None)` if the block does not exist.
+    #[expect(clippy::type_complexity)]
+    fn transactions_by_block_id(
+        &self,
+        block_id: BlockId,
+    ) -> impl Future<Output = Result<Option<Vec<RpcTransaction<Self::NetworkTypes>>>, Self::Error>> + Send
+    where
+        Self: LoadBlock,
+        Self::Provider: BlockIdReader,
+    {
+        async move {
+            let block_info = self
+                .recovered_block(block_id)
+                .await?
+                .map(|block| (block.hash(), block.number(), block.base_fee_per_gas()));
+
+            let block_hash = match block_id {
+                BlockId::Hash(hash) => hash.block_hash,
+                BlockId::Number(_) => {
+                    if let Some(hash) = self
+                        .provider()
+                        .block_hash_for_id(block_id)
+                        .map_err(Self::Error::from_eth_err)?
+                    {
+                        hash
+                    } else {
+                        return Ok(None);
+                    }
+                }
+            };
+
+            let transactions = EthTransactions::transactions_by_block(self, block_hash).await?;
+
+            match transactions {
+                Some(txs) => {
+                    let mut rpc_transactions = Vec::with_capacity(txs.len());
+                    for (index, tx) in txs.into_iter().enumerate() {
+                        let recovered = tx
+                            .try_into_recovered_unchecked()
+                            .map_err(|_| EthApiError::InvalidTransactionSignature)?;
+
+                        let source = match block_info {
+                            Some((block_hash, block_number, base_fee)) => {
+                                TransactionSource::Block {
+                                    transaction: recovered,
+                                    index: index as u64,
+                                    block_hash,
+                                    block_number,
+                                    base_fee,
+                                }
+                            }
+                            None => TransactionSource::Pool(recovered),
+                        };
+
+                        let rpc_tx = source.into_transaction(self.converter())?;
+                        rpc_transactions.push(rpc_tx);
+                    }
+                    Ok(Some(rpc_transactions))
+                }
+                None => Ok(None),
+            }
+        }
+    }
+
+    /// Get all pending transactions from the transaction pool.
+    ///
+    /// Returns `Ok(Some(Vec))` with all pending transactions converted to RPC format.
+    /// Returns `Ok(Some(Vec::new()))` if there are no pending transactions.
+    #[expect(clippy::type_complexity)]
+    fn pending_transactions(
+        &self,
+    ) -> impl Future<Output = Result<Option<Vec<RpcTransaction<Self::NetworkTypes>>>, Self::Error>> + Send
+    {
+        async move {
+            let pending_txs = RpcNodeCore::pool(self).pending_transactions();
+            if pending_txs.is_empty() {
+                return Ok(Some(Vec::new()));
+            }
+
+            let mut rpc_transactions = Vec::with_capacity(pending_txs.len());
+            for pool_tx in pending_txs {
+                let recovered = pool_tx.transaction.clone_into_consensus();
+                let source = TransactionSource::Pool(recovered);
+                let rpc_tx = source.into_transaction(self.converter())?;
+                rpc_transactions.push(rpc_tx);
+            }
+
+            Ok(Some(rpc_transactions))
+        }
+    }
+
+    /// Get the transaction data and receipt for the given hash.
+    ///
+    /// Returns a structured response with `txData` and `receipt` fields.
+    /// Returns `Ok(None)` if the transaction does not exist.
+    #[expect(clippy::type_complexity)]
+    fn transaction_data_and_receipt(
+        &self,
+        hash: B256,
+    ) -> impl Future<
+        Output = Result<
+            Option<
+                TransactionDataAndReceipt<
+                    RpcTransaction<Self::NetworkTypes>,
+                    RpcReceipt<Self::NetworkTypes>,
+                >,
+            >,
+            Self::Error,
+        >,
+    > + Send
+    where
+        Self: LoadReceipt,
+    {
+        async move {
+            let receipt = self.transaction_receipt(hash).await?;
+            let data = match LoadTransaction::transaction_by_hash(self, hash).await? {
+                Some(tx) => {
+                    let rpc_tx = tx.into_transaction(self.converter())?;
+                    Some(rpc_tx)
+                }
+                None => None,
+            };
+
+            Ok(Some(TransactionDataAndReceipt { tx_data: data, receipt }))
+        }
+    }
+
     /// Find a transaction by sender's address and nonce.
     fn get_transaction_by_sender_and_nonce(
         &self,
@@ -458,7 +587,7 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
             };
 
             if self.find_signer(&from).is_err() {
-                return Err(SignError::NoAccount.into_eth_err())
+                return Err(SignError::NoAccount.into_eth_err());
             }
 
             // set nonce if not already set before

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -40,5 +40,5 @@ pub use gas_oracle::{
 };
 pub use id_provider::EthSubscriptionIdProvider;
 pub use pending_block::{PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
-pub use transaction::TransactionSource;
+pub use transaction::{FillTransactionResult, TransactionDataAndReceipt, TransactionSource};
 pub use tx_forward::ForwardConfig;

--- a/crates/rpc/rpc-eth-types/src/simulate.rs
+++ b/crates/rpc/rpc-eth-types/src/simulate.rs
@@ -371,7 +371,7 @@ where
     let block = block.into_rpc_block(
         txs_kind,
         |tx, tx_info| converter.fill(tx, tx_info),
-        |header, size| converter.convert_header(header, size),
+        |header, size| converter.convert_header(header, size, None),
     )?;
     Ok(SimulatedBlock { inner: block, calls })
 }

--- a/crates/rpc/rpc-eth-types/src/transaction.rs
+++ b/crates/rpc/rpc-eth-types/src/transaction.rs
@@ -2,11 +2,21 @@
 //!
 //! Transaction wrapper that labels transaction with its origin.
 
-use alloy_primitives::B256;
+use alloy_primitives::{Bytes, B256};
 use alloy_rpc_types_eth::TransactionInfo;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_primitives_traits::{NodePrimitives, Recovered, SignedTransaction};
 use reth_rpc_convert::{RpcConvert, RpcTransaction};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Response type for `eth_fillTransaction` RPC method.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FillTransactionResult<T> {
+    /// RLP-encoded transaction bytes
+    pub raw: Bytes,
+    /// Filled transaction object
+    pub tx: T,
+}
 
 /// Represents from where a transaction was fetched.
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -96,5 +106,99 @@ impl<T> From<TransactionSource<T>> for Recovered<T> {
             TransactionSource::Pool(tx) => tx,
             TransactionSource::Block { transaction, .. } => transaction,
         }
+    }
+}
+
+/// Response structure for transaction data and receipt with custom field names
+#[derive(Debug, Clone)]
+pub struct TransactionDataAndReceipt<TX, RX> {
+    /// Transaction data (corresponds to "txData" in JSON)
+    pub tx_data: Option<TX>,
+    /// Transaction receipt
+    pub receipt: Option<RX>,
+}
+
+impl<TX, RX> Serialize for TransactionDataAndReceipt<TX, RX>
+where
+    TX: Serialize,
+    RX: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("TransactionDataAndReceipt", 2)?;
+        state.serialize_field("txData", &self.tx_data)?;
+        state.serialize_field("receipt", &self.receipt)?;
+        state.end()
+    }
+}
+
+impl<'de, TX, RX> Deserialize<'de> for TransactionDataAndReceipt<TX, RX>
+where
+    TX: Deserialize<'de>,
+    RX: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{MapAccess, Visitor};
+        use std::fmt;
+
+        struct TransactionDataAndReceiptVisitor<TX, RX>(std::marker::PhantomData<(TX, RX)>);
+
+        impl<'de, TX, RX> Visitor<'de> for TransactionDataAndReceiptVisitor<TX, RX>
+        where
+            TX: Deserialize<'de>,
+            RX: Deserialize<'de>,
+        {
+            type Value = TransactionDataAndReceipt<TX, RX>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("struct TransactionDataAndReceipt")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut tx_data = None;
+                let mut receipt = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "txData" => {
+                            if tx_data.is_some() {
+                                return Err(serde::de::Error::duplicate_field("txData"));
+                            }
+                            tx_data = Some(map.next_value()?);
+                        }
+                        "receipt" => {
+                            if receipt.is_some() {
+                                return Err(serde::de::Error::duplicate_field("receipt"));
+                            }
+                            receipt = Some(map.next_value()?);
+                        }
+                        _ => {
+                            // Ignore unknown fields
+                            let _ = map.next_value::<serde::de::IgnoredAny>()?;
+                        }
+                    }
+                }
+
+                Ok(TransactionDataAndReceipt {
+                    tx_data: tx_data.unwrap_or(None),
+                    receipt: receipt.unwrap_or(None),
+                })
+            }
+        }
+
+        deserializer.deserialize_struct(
+            "TransactionDataAndReceipt",
+            &["txData", "receipt"],
+            TransactionDataAndReceiptVisitor(std::marker::PhantomData),
+        )
     }
 }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -749,7 +749,7 @@ where
                 .clone_into_rpc_block(
                     BlockTransactionsKind::Full,
                     |tx, tx_info| self.eth_api().converter().fill(tx, tx_info),
-                    |header, size| self.eth_api().converter().convert_header(header, size),
+                    |header, size| self.eth_api().converter().convert_header(header, size, None),
                 )
                 .map_err(|err| Eth::Error::from(err).into())?;
 

--- a/crates/rpc/rpc/src/eth/pubsub.rs
+++ b/crates/rpc/rpc/src/eth/pubsub.rs
@@ -340,8 +340,11 @@ where
                 .committed()
                 .blocks_iter()
                 .filter_map(|block| {
-                    match converter.convert_header(block.clone_sealed_header(), block.rlp_length())
-                    {
+                    match converter.convert_header(
+                        block.clone_sealed_header(),
+                        block.rlp_length(),
+                        None,
+                    ) {
                         Ok(header) => Some(header),
                         Err(err) => {
                             error!(target = "rpc", %err, "Failed to convert header");


### PR DESCRIPTION
Cherry-picks from `develop` onto `develop-v2-port`.

## Commits included

- `9ceb03c0d` feat: add missing RPC methods (#15)
- `026b85924` chore: modify code owners

## Conflict resolutions

- `rpc-convert/Cargo.toml` — kept `default = []`, made `serde` a required dep (needed by `CustomRpcHeader` which is always used as an `RpcObject`)
- `rpc-convert/src/lib.rs` — added `custom_header` module, skipped `block`/`receipt` (don't exist in develop-v2)
- `rpc-convert/src/transaction.rs` — removed `type Err` from `HeaderConverter` trait (unused), kept `td: Option<U256>` param, fixed `impl for ()` to use 2-param `FromConsensusHeader` from published crate
- `rpc-convert/src/custom_header.rs` — removed `cfg_attr(feature = "serde", ...)` gates, serde is now always available; added `FromConsensusHeader` impl (2-param, `td = None`)
- `rpc-eth-api/src/core.rs` — merged both `EthApiError` and `TransactionDataAndReceipt` imports (both used)
- `rpc-eth-api/src/helpers/block.rs` — added missing `td: None` argument to `convert_header` calls
- `rpc/src/eth/pubsub.rs` — added missing `td: None` argument to `convert_header` call
- `rpc/src/debug.rs` — added missing `td: None` argument to `convert_header` call
- `ethereum/node/tests/e2e/dev.rs` — `CustomRpcHeader` wraps consensus header in `.inner`; changed `.header.beneficiary` → `.header.inner.beneficiary`

## Next commit to cherry-pick

`c28a1cdd8 fix: forbid to use pending tag`