### PR TITLE
fix: forbid to use pending tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9869,6 +9869,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -10,6 +10,7 @@ use reth_db::{
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     database::Database,
+    models::CompactU256,
     table::{Compress, Decompress, DupSort, Table},
     tables,
     transaction::DbTx,
@@ -163,7 +164,7 @@ impl Command {
                             .account_block_changeset(key)?;
 
                         println!("{}", serde_json::to_string_pretty(&changesets)?);
-                        return Ok(())
+                        return Ok(());
                     };
 
                     let account = tool
@@ -177,7 +178,7 @@ impl Command {
                         error!(target: "reth::cli", "No content for the given table key.");
                     }
 
-                    return Ok(())
+                    return Ok(());
                 }
 
                 let content = tool.provider_factory.static_file_provider().find_static_file(
@@ -200,10 +201,13 @@ impl Command {
                             match segment {
                                 StaticFileSegment::Headers => {
                                     let header = HeaderTy::<N>::decompress(content[0].as_slice())?;
-                                    let block_hash = BlockHash::decompress(content[1].as_slice())?;
+                                    let total_difficulty =
+                                        CompactU256::decompress(content[1].as_slice())?;
+                                    let block_hash = BlockHash::decompress(content[2].as_slice())?;
                                     println!(
-                                        "Header\n{}\n\nBlockHash\n{}",
+                                        "Header\n{}\n\nTotalDifficulty\n{}\n\nBlockHash\n{}",
                                         serde_json::to_string_pretty(&header)?,
+                                        total_difficulty.0,
                                         serde_json::to_string_pretty(&block_hash)?
                                     );
                                 }

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -37,6 +37,9 @@ dyn-clone.workspace = true
 # serialization
 serde = { workspace = true, features = ["derive"] }
 
+# tracing
+tracing.workspace = true
+
 [dev-dependencies]
 serde_json.workspace = true
 

--- a/crates/rpc/rpc-convert/src/custom_header.rs
+++ b/crates/rpc/rpc-convert/src/custom_header.rs
@@ -2,6 +2,7 @@
 
 use alloy_network::primitives::HeaderResponse;
 use alloy_primitives::{BlockHash, U256};
+use tracing::info;
 
 /// Custom RPC header that extends the standard header with additional fields
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -163,28 +164,6 @@ where
 // RpcObject is automatically implemented via blanket impl for types that implement Serialize +
 // Deserialize
 
-impl<H> reth_rpc_traits::FromConsensusHeader<H> for CustomRpcHeader<H>
-where
-    H: reth_primitives_traits::BlockHeader + Clone,
-{
-    fn from_consensus_header(
-        header: reth_primitives_traits::SealedHeader<H>,
-        block_size: usize,
-    ) -> Self {
-        let header_hash = header.hash();
-        let consensus_header = header.into_header();
-        let milli_timestamp = Some(U256::from(calculate_millisecond_timestamp(&consensus_header)));
-
-        Self {
-            hash: header_hash,
-            inner: consensus_header,
-            total_difficulty: None,
-            size: Some(U256::from(block_size)),
-            milli_timestamp,
-        }
-    }
-}
-
 /// Type alias for the standard Ethereum custom header
 pub type EthereumCustomHeader = CustomRpcHeader<alloy_consensus::Header>;
 
@@ -202,6 +181,7 @@ where
         block_size: usize,
         td: Option<alloy_primitives::U256>,
     ) -> CustomRpcHeader<H> {
+        info!("td in CustomHeaderConverter convert_header: {:?}", td);
         let header_hash = header.hash();
         let consensus_header = header.into_header();
         let milli_timestamp = Some(U256::from(calculate_millisecond_timestamp(&consensus_header)));

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -1,6 +1,7 @@
 //! Compatibility functions for rpc `Transaction` type.
 use crate::{
-    RpcHeader, RpcReceipt, RpcTransaction, RpcTxReq, RpcTypes, SignableTxRequest, TryIntoTxEnv,
+    calculate_millisecond_timestamp, RpcHeader, RpcReceipt, RpcTransaction, RpcTxReq, RpcTypes,
+    SignableTxRequest, TryIntoTxEnv,
 };
 use alloy_consensus::{error::ValueError, transaction::Recovered};
 use alloy_primitives::{Address, U256};
@@ -12,7 +13,7 @@ use reth_primitives_traits::{
     BlockTy, HeaderTy, NodePrimitives, SealedBlock, SealedHeader, SealedHeaderFor, TransactionMeta,
     TxTy,
 };
-use reth_rpc_traits::{FromConsensusHeader, FromConsensusTx, TryIntoSimTx, TxInfoMapper};
+use reth_rpc_traits::{FromConsensusTx, TryIntoSimTx, TxInfoMapper};
 use std::{error::Error, fmt, fmt::Debug, marker::PhantomData};
 
 /// Input for [`RpcConvert::convert_receipts`].
@@ -77,9 +78,37 @@ where
         &self,
         header: SealedHeader<Consensus>,
         block_size: usize,
-        _td: Option<U256>,
+        td: Option<U256>,
     ) -> Rpc {
-        Rpc::from_consensus_header(header, block_size)
+        Rpc::from_consensus_header(header, block_size, td)
+    }
+}
+
+/// Conversion trait for obtaining RPC header from a consensus header.
+pub trait FromConsensusHeader<T> {
+    /// Takes a consensus header and converts it into `self`.
+    fn from_consensus_header(header: SealedHeader<T>, block_size: usize, td: Option<U256>) -> Self;
+}
+
+impl FromConsensusHeader<alloy_consensus::Header>
+    for crate::CustomRpcHeader<alloy_consensus::Header>
+{
+    fn from_consensus_header(
+        header: SealedHeader<alloy_consensus::Header>,
+        block_size: usize,
+        td: Option<U256>,
+    ) -> Self {
+        let header_hash = header.hash();
+        let consensus_header = header.into_header();
+        let milli_timestamp = Some(U256::from(calculate_millisecond_timestamp(&consensus_header)));
+
+        Self {
+            hash: header_hash,
+            inner: consensus_header,
+            total_difficulty: td,
+            size: Some(U256::from(block_size)),
+            milli_timestamp,
+        }
     }
 }
 

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -512,6 +512,7 @@ where
         full: bool,
     ) -> RpcResult<Option<RpcBlock<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?number, ?full, "Serving eth_getBlockByNumber");
+        check_pending_tag(&number)?;
         Ok(EthBlocks::rpc_block(self, number.into(), full).await?)
     }
 
@@ -527,6 +528,7 @@ where
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>> {
         trace!(target: "rpc::eth", ?number, "Serving eth_getBlockTransactionCountByNumber");
+        check_pending_tag(&number)?;
         Ok(EthBlocks::block_transaction_count(self, number.into()).await?.map(U256::from))
     }
 
@@ -547,6 +549,7 @@ where
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>> {
         trace!(target: "rpc::eth", ?number, "Serving eth_getUncleCountByBlockNumber");
+        check_pending_tag(&number)?;
 
         if let Some(block) = self.block_by_number(number, false).await? {
             Ok(Some(U256::from(block.uncles.len())))
@@ -581,6 +584,7 @@ where
         index: Index,
     ) -> RpcResult<Option<RpcBlock<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?number, ?index, "Serving eth_getUncleByBlockNumberAndIndex");
+        check_pending_tag(&number)?;
         Ok(EthBlocks::ommer_by_block_and_index(self, number.into(), index).await?)
     }
 
@@ -640,6 +644,7 @@ where
         index: Index,
     ) -> RpcResult<Option<Bytes>> {
         trace!(target: "rpc::eth", ?number, ?index, "Serving eth_getRawTransactionByBlockNumberAndIndex");
+        check_pending_tag(&number)?;
         Ok(EthTransactions::raw_transaction_by_block_and_tx_index(
             self,
             number.into(),
@@ -655,6 +660,7 @@ where
         index: Index,
     ) -> RpcResult<Option<RpcTransaction<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?number, ?index, "Serving eth_getTransactionByBlockNumberAndIndex");
+        check_pending_tag(&number)?;
         Ok(EthTransactions::transaction_by_block_and_tx_index(self, number.into(), index.into())
             .await?)
     }
@@ -674,6 +680,7 @@ where
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<Vec<RpcTransaction<T::NetworkTypes>>>> {
         trace!(target: "rpc::eth", ?number, "Serving eth_getTransactionsByBlockNumber");
+        check_pending_tag(&number)?;
         Ok(EthTransactions::transactions_by_block_id(self, number.into()).await?)
     }
 
@@ -759,6 +766,7 @@ where
         block_number: BlockNumberOrTag,
     ) -> RpcResult<Option<RpcHeader<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?block_number, "Serving eth_getHeaderByNumber");
+        check_pending_tag(&block_number)?;
         Ok(EthBlocks::rpc_block_header(self, block_number.into()).await?)
     }
 
@@ -889,6 +897,7 @@ where
         reward_percentiles: Option<Vec<f64>>,
     ) -> RpcResult<FeeHistory> {
         trace!(target: "rpc::eth", ?block_count, ?newest_block, ?reward_percentiles, "Serving eth_feeHistory");
+        check_pending_tag(&newest_block)?;
         Ok(EthFees::fee_history(self, block_count.to(), newest_block, reward_percentiles).await?)
     }
 
@@ -1008,5 +1017,14 @@ where
 
         let bal = self.get_block_access_list(number.into()).await?;
         Ok(bal.map(|b: BlockAccessList| alloy_rlp::encode(b).into()))
+    }
+}
+
+/// Helper function to check if `BlockNumberOrTag` is pending and return error if so
+fn check_pending_tag(block_number: &BlockNumberOrTag) -> RpcResult<()> {
+    if matches!(block_number, BlockNumberOrTag::Pending) {
+        Err(internal_rpc_err("Unsupported pending tag"))
+    } else {
+        Ok(())
     }
 }

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -626,11 +626,18 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
     type Header = HeaderTy<N>;
 
     fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+        info!("HeaderProvider ProviderFactory header, block_hash: {:?}", block_hash);
         self.provider()?.header(block_hash)
     }
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
-        self.caught_up_static_file_provider()?.header_by_number(num)
+        info!("HeaderProvider ProviderFactory header_by_number, num: {:?}", num);
+        self.static_file_provider.get_with_static_file_or_database(
+            StaticFileSegment::Headers,
+            num,
+            |static_file| static_file.header_by_number(num),
+            || self.provider()?.header_by_number(num),
+        )
     }
 
     fn headers_range(
@@ -644,7 +651,13 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
-        self.caught_up_static_file_provider()?.sealed_header(number)
+        info!("ProviderFactory sealed_header, number: {:?}", number);
+        self.static_file_provider.get_with_static_file_or_database(
+            StaticFileSegment::Headers,
+            number,
+            |static_file| static_file.sealed_header(number),
+            || self.provider()?.sealed_header(number),
+        )
     }
 
     fn sealed_headers_range(
@@ -665,7 +678,13 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
 
 impl<N: ProviderNodeTypes> BlockHashReader for ProviderFactory<N> {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
-        self.caught_up_static_file_provider()?.block_hash(number)
+        info!("BlockHashReader block_hash, number: {:?}", number);
+        self.static_file_provider.get_with_static_file_or_database(
+            StaticFileSegment::Headers,
+            number,
+            |static_file| static_file.block_hash(number),
+            || self.provider()?.block_hash(number),
+        )
     }
 
     fn canonical_hashes_range(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -81,7 +81,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use tracing::{debug, instrument, trace};
+use tracing::{debug, info, instrument, trace};
 
 /// Determines the commit order for database operations.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -1708,6 +1708,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
     type Header = HeaderTy<N>;
 
     fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
+        info!("HeaderProvider DatabaseProvider header, block_hash: {:?}", block_hash);
         if let Some(num) = self.block_number(block_hash)? {
             Ok(self.header_by_number(num)?)
         } else {
@@ -1716,7 +1717,13 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
     }
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
-        self.static_file_provider.header_by_number(num)
+        info!("HeaderProvider DatabaseProvider header_by_number, num: {:?}", num);
+        self.static_file_provider.get_with_static_file_or_database(
+            StaticFileSegment::Headers,
+            num,
+            |static_file| static_file.header_by_number(num),
+            || Ok(self.tx.get::<tables::Headers<Self::Header>>(num)?),
+        )
     }
 
     fn headers_range(
@@ -1730,7 +1737,22 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
-        self.static_file_provider.sealed_header(number)
+        info!("SealedHeader DatabaseProvider sealed_header, number: {:?}", number);
+        self.static_file_provider.get_with_static_file_or_database(
+            StaticFileSegment::Headers,
+            number,
+            |static_file| static_file.sealed_header(number),
+            || {
+                if let Some(header) = self.header_by_number(number)? {
+                    let hash = self
+                        .block_hash(number)?
+                        .ok_or_else(|| ProviderError::HeaderNotFound(number.into()))?;
+                    Ok(Some(SealedHeader::new(header, hash)))
+                } else {
+                    Ok(None)
+                }
+            },
+        )
     }
 
     fn sealed_headers_while(

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -734,6 +734,10 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         block: BlockNumber,
         path: Option<&Path>,
     ) -> ProviderResult<StaticFileJarProvider<'_, N>> {
+        info!(
+            "get_segment_provider_from_block, segment: {:?}, block: {:?}, path: {:?}",
+            segment, block, path
+        );
         self.get_segment_provider_for_range(
             segment,
             || self.get_segment_ranges_from_block(segment, block),
@@ -2107,18 +2111,39 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         FS: Fn(&Self) -> ProviderResult<Option<T>>,
         FD: Fn() -> ProviderResult<Option<T>>,
     {
+        info!("get_with_static_file_or_database, segment: {:?}, number: {:?}", segment, number);
         // If there is, check the maximum block or transaction number of the segment.
         let static_file_upper_bound = if segment.is_block_or_change_based() {
-            self.get_highest_static_file_block(segment)
+            info!(
+                "get_highest_static_file_block in get_with_static_file_or_database, segment: {:?}, is_block_or_change_based: {:?}",
+                segment,
+                segment.is_block_or_change_based()
+            );
+            let upper = self.get_highest_static_file_block(segment);
+            info!("static_file_upper_bound (block): {:?}", upper);
+            upper
         } else {
-            self.get_highest_static_file_tx(segment)
+            info!(
+                "get_highest_static_file_tx in get_with_static_file_or_database, segment: {:?}, is_block_or_change_based: {:?}",
+                segment,
+                segment.is_block_or_change_based()
+            );
+            let upper = self.get_highest_static_file_tx(segment);
+            info!("static_file_upper_bound (tx): {:?}", upper);
+            upper
         };
 
+        info!(
+            "static_file_upper_bound: {:?}, number: {:?}, segment: {:?}",
+            static_file_upper_bound, number, segment
+        );
         if static_file_upper_bound
             .is_some_and(|static_file_upper_bound| static_file_upper_bound >= number)
         {
+            info!("fetch data from static file, number: {:?}", number);
             return fetch_from_static_file(self);
         }
+        info!("fetch data from database, number: {:?}", number);
         fetch_from_database()
     }
 


### PR DESCRIPTION
Cherry-picks `c28a1cdd8` from `develop` onto `port/missing-rpc-methods`.

## Commits included

- `c28a1cdd8` fix: forbid to use pending tag

## Changes

- `rpc-eth-api/src/core.rs` — adds `check_pending_tag` and `check_block_id_pending_tag` helpers; calls them at the start of all affected RPC handlers to return an error when the pending block tag is used
- `storage/provider/src/providers/database/mod.rs` — `header_by_number`, `sealed_header`, `block_hash` now use `get_with_static_file_or_database` to fall back to the database when the static file doesn't have the data
- `storage/provider/src/providers/database/provider.rs` — same fallback pattern for `DatabaseProvider`
- `storage/provider/src/providers/static_file/manager.rs` — adds debug logging to `get_segment_provider_from_block` and `get_with_static_file_or_database`
- `cli/commands/src/db/get.rs` — updates header static file segment handling to include total difficulty field
- `rpc-convert/Cargo.toml` — adds `tracing` dependency
- `rpc-convert/src/custom_header.rs` — adds `info!` log in `CustomHeaderConverter::convert_header`

## Conflict resolutions

- `rpc-convert/src/custom_header.rs` — kept our `use alloy_primitives::{BlockHash, U256}` (no `B256` needed after `is_zero()` fix); added `use tracing::info`
- `rpc-convert/src/transaction.rs` — kept 2-param `Rpc::from_consensus_header(header, block_size)` (uses published `reth_rpc_traits::FromConsensusHeader`); discarded incoming 3-param `FromConsensusHeader` trait definition (would conflict with published crate) and its `CustomRpcHeader` impl (already handled in `custom_header.rs`)
- `storage/provider/src/providers/database/mod.rs` — kept HEAD tracing imports (`info, instrument, trace, warn`); took incoming `get_with_static_file_or_database` fallback logic for all three methods

## Next commit to cherry-pick

`d847336e5 fix: header_td_by_number uses and_then`