### PR TITLE
fix: header_td_by_number uses and_then

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9869,7 +9869,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]

--- a/crates/cli/commands/src/db/get.rs
+++ b/crates/cli/commands/src/db/get.rs
@@ -10,7 +10,6 @@ use reth_db::{
 use reth_db_api::{
     cursor::{DbCursorRO, DbDupCursorRO},
     database::Database,
-    models::CompactU256,
     table::{Compress, Decompress, DupSort, Table},
     tables,
     transaction::DbTx,
@@ -123,22 +122,22 @@ impl Command {
                     StaticFileSegment::Headers => (
                         table_key::<tables::Headers>(&key)?,
                         None,
-                        <HeaderWithHashMask<HeaderTy<N>>>::MASK,
+                        <HeaderWithHashMask<HeaderTy<N>> as ColumnSelectorTwo>::MASK,
                     ),
                     StaticFileSegment::Transactions => (
                         table_key::<tables::Transactions>(&key)?,
                         None,
-                        <TransactionMask<TxTy<N>>>::MASK,
+                        <TransactionMask<TxTy<N>> as ColumnSelectorOne>::MASK,
                     ),
                     StaticFileSegment::Receipts => (
                         table_key::<tables::Receipts>(&key)?,
                         None,
-                        <ReceiptMask<ReceiptTy<N>>>::MASK,
+                        <ReceiptMask<ReceiptTy<N>> as ColumnSelectorOne>::MASK,
                     ),
                     StaticFileSegment::TransactionSenders => (
                         table_key::<tables::TransactionSenders>(&key)?,
                         None,
-                        TransactionSenderMask::MASK,
+                        <TransactionSenderMask as ColumnSelectorOne>::MASK,
                     ),
                     StaticFileSegment::AccountChangeSets => {
                         let subkey =
@@ -146,7 +145,7 @@ impl Command {
                         (
                             table_key::<tables::AccountChangeSets>(&key)?,
                             subkey,
-                            AccountChangesetMask::MASK,
+                            <AccountChangesetMask as ColumnSelectorOne>::MASK,
                         )
                     }
                     StaticFileSegment::StorageChangeSets => {
@@ -201,13 +200,10 @@ impl Command {
                             match segment {
                                 StaticFileSegment::Headers => {
                                     let header = HeaderTy::<N>::decompress(content[0].as_slice())?;
-                                    let total_difficulty =
-                                        CompactU256::decompress(content[1].as_slice())?;
-                                    let block_hash = BlockHash::decompress(content[2].as_slice())?;
+                                    let block_hash = BlockHash::decompress(content[1].as_slice())?;
                                     println!(
-                                        "Header\n{}\n\nTotalDifficulty\n{}\n\nBlockHash\n{}",
+                                        "Header\n{}\n\nBlockHash\n{}",
                                         serde_json::to_string_pretty(&header)?,
-                                        total_difficulty.0,
                                         serde_json::to_string_pretty(&block_hash)?
                                     );
                                 }

--- a/crates/rpc/rpc-convert/Cargo.toml
+++ b/crates/rpc/rpc-convert/Cargo.toml
@@ -37,11 +37,7 @@ dyn-clone.workspace = true
 # serialization
 serde = { workspace = true, features = ["derive"] }
 
-# tracing
-tracing.workspace = true
-
 [dev-dependencies]
 serde_json.workspace = true
-
 [features]
 default = []

--- a/crates/rpc/rpc-convert/src/custom_header.rs
+++ b/crates/rpc/rpc-convert/src/custom_header.rs
@@ -2,7 +2,6 @@
 
 use alloy_network::primitives::HeaderResponse;
 use alloy_primitives::{BlockHash, U256};
-use tracing::info;
 
 /// Custom RPC header that extends the standard header with additional fields
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -181,7 +180,6 @@ where
         block_size: usize,
         td: Option<alloy_primitives::U256>,
     ) -> CustomRpcHeader<H> {
-        info!("td in CustomHeaderConverter convert_header: {:?}", td);
         let header_hash = header.hash();
         let consensus_header = header.into_header();
         let milli_timestamp = Some(U256::from(calculate_millisecond_timestamp(&consensus_header)));

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -626,12 +626,10 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
     type Header = HeaderTy<N>;
 
     fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
-        info!("HeaderProvider ProviderFactory header, block_hash: {:?}", block_hash);
         self.provider()?.header(block_hash)
     }
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
-        info!("HeaderProvider ProviderFactory header_by_number, num: {:?}", num);
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             num,
@@ -651,7 +649,6 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
-        info!("ProviderFactory sealed_header, number: {:?}", number);
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             number,
@@ -678,7 +675,6 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
 
 impl<N: ProviderNodeTypes> BlockHashReader for ProviderFactory<N> {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
-        info!("BlockHashReader block_hash, number: {:?}", number);
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             number,

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -81,7 +81,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use tracing::{debug, info, instrument, trace};
+use tracing::{debug, instrument, trace};
 
 /// Determines the commit order for database operations.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -1708,7 +1708,6 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
     type Header = HeaderTy<N>;
 
     fn header(&self, block_hash: BlockHash) -> ProviderResult<Option<Self::Header>> {
-        info!("HeaderProvider DatabaseProvider header, block_hash: {:?}", block_hash);
         if let Some(num) = self.block_number(block_hash)? {
             Ok(self.header_by_number(num)?)
         } else {
@@ -1717,7 +1716,6 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
     }
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
-        info!("HeaderProvider DatabaseProvider header_by_number, num: {:?}", num);
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             num,
@@ -1737,7 +1735,6 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
-        info!("SealedHeader DatabaseProvider sealed_header, number: {:?}", number);
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             number,

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -734,10 +734,6 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         block: BlockNumber,
         path: Option<&Path>,
     ) -> ProviderResult<StaticFileJarProvider<'_, N>> {
-        info!(
-            "get_segment_provider_from_block, segment: {:?}, block: {:?}, path: {:?}",
-            segment, block, path
-        );
         self.get_segment_provider_for_range(
             segment,
             || self.get_segment_ranges_from_block(segment, block),
@@ -2111,39 +2107,18 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         FS: Fn(&Self) -> ProviderResult<Option<T>>,
         FD: Fn() -> ProviderResult<Option<T>>,
     {
-        info!("get_with_static_file_or_database, segment: {:?}, number: {:?}", segment, number);
         // If there is, check the maximum block or transaction number of the segment.
-        let static_file_upper_bound = if segment.is_block_or_change_based() {
-            info!(
-                "get_highest_static_file_block in get_with_static_file_or_database, segment: {:?}, is_block_or_change_based: {:?}",
-                segment,
-                segment.is_block_or_change_based()
-            );
-            let upper = self.get_highest_static_file_block(segment);
-            info!("static_file_upper_bound (block): {:?}", upper);
-            upper
+        let static_file_upper_bound = if segment.is_block_based() {
+            self.get_highest_static_file_block(segment)
         } else {
-            info!(
-                "get_highest_static_file_tx in get_with_static_file_or_database, segment: {:?}, is_block_or_change_based: {:?}",
-                segment,
-                segment.is_block_or_change_based()
-            );
-            let upper = self.get_highest_static_file_tx(segment);
-            info!("static_file_upper_bound (tx): {:?}", upper);
-            upper
+            self.get_highest_static_file_tx(segment)
         };
 
-        info!(
-            "static_file_upper_bound: {:?}, number: {:?}, segment: {:?}",
-            static_file_upper_bound, number, segment
-        );
         if static_file_upper_bound
             .is_some_and(|static_file_upper_bound| static_file_upper_bound >= number)
         {
-            info!("fetch data from static file, number: {:?}", number);
             return fetch_from_static_file(self);
         }
-        info!("fetch data from database, number: {:?}", number);
         fetch_from_database()
     }
 


### PR DESCRIPTION
Ports `d847336e5` from `develop`.

Removes debug `info!` logging added during porting, drops the unused `tracing` dependency from `reth-rpc-convert`, and cleans up the `HeaderWithHashMask` usage in `db get` (removing `CompactU256` / total difficulty from the static file header output).

Next: `5883af336 feat: add eth_getFinalizeBlock/Header api (#24)`