### PR TITLE
feat: add eth_getFinalizeBlock/Header api

### DIFF
--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -254,6 +254,29 @@ pub trait EthApi<
     #[method(name = "getHeaderByHash")]
     async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<H>>;
 
+    /// Returns the finalized block header.
+    ///
+    /// The `verified_validator_num` parameter is provided for BSC compatibility but is not used
+    /// in standard Ethereum. The finalized block is determined by the Beacon Chain consensus
+    /// (Casper FFG) and requires 2/3+ validator attestations.
+    #[method(name = "getFinalizedHeader")]
+    async fn finalized_header(&self, verified_validator_num: u64) -> RpcResult<Option<H>>;
+
+    /// Returns the finalized block.
+    ///
+    /// The `verified_validator_num` parameter is provided for BSC compatibility but is not used
+    /// in standard Ethereum. The finalized block is determined by the Beacon Chain consensus
+    /// (Casper FFG) and requires 2/3+ validator attestations.
+    ///
+    /// If `full` is true, the block object will contain all transaction objects,
+    /// otherwise it will only contain the transaction hashes.
+    #[method(name = "getFinalizedBlock")]
+    async fn finalized_block(
+        &self,
+        verified_validator_num: u64,
+        full: bool,
+    ) -> RpcResult<Option<B>>;
+
     /// `eth_simulateV1` executes an arbitrary number of transactions on top of the requested state.
     /// The transactions are packed into individual blocks. Overrides can be provided.
     #[method(name = "simulateV1")]
@@ -774,6 +797,25 @@ where
     async fn header_by_hash(&self, hash: B256) -> RpcResult<Option<RpcHeader<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?hash, "Serving eth_getHeaderByHash");
         Ok(EthBlocks::rpc_block_header(self, hash.into()).await?)
+    }
+
+    /// Handler for: `eth_getFinalizedHeader`
+    async fn finalized_header(
+        &self,
+        verified_validator_num: u64,
+    ) -> RpcResult<Option<RpcHeader<T::NetworkTypes>>> {
+        trace!(target: "rpc::eth", verified_validator_num, "Serving eth_getFinalizedHeader");
+        Ok(EthBlocks::rpc_finalized_header(self, verified_validator_num).await?)
+    }
+
+    /// Handler for: `eth_getFinalizedBlock`
+    async fn finalized_block(
+        &self,
+        verified_validator_num: u64,
+        full: bool,
+    ) -> RpcResult<Option<RpcBlock<T::NetworkTypes>>> {
+        trace!(target: "rpc::eth", verified_validator_num, ?full, "Serving eth_getFinalizedBlock");
+        Ok(EthBlocks::rpc_finalized_block(self, verified_validator_num, full).await?)
     }
 
     /// Handler for: `eth_simulateV1`

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -6,7 +6,7 @@ use crate::{
     RpcReceipt,
 };
 use alloy_consensus::{transaction::TxHashRef, TxReceipt};
-use alloy_eips::BlockId;
+use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::{Block, BlockTransactions, Index};
 use futures::Future;
@@ -71,6 +71,46 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
                 |header, size| self.converter().convert_header(header, size, None),
             )?;
             Ok(Some(block))
+        }
+    }
+
+    /// Returns the finalized block header.
+    ///
+    /// The `verified_validator_num` parameter is provided for BSC compatibility but is ignored
+    /// in the implementation. In standard Ethereum, the finalized block is determined by the
+    /// Beacon Chain consensus (Casper FFG).
+    fn rpc_finalized_header(
+        &self,
+        _verified_validator_num: u64,
+    ) -> impl Future<Output = Result<Option<RpcHeader<Self::NetworkTypes>>, Self::Error>> + Send
+    where
+        Self: FullEthApiTypes,
+    {
+        async move {
+            // Simply delegate to rpc_block_header with Finalized tag
+            self.rpc_block_header(BlockNumberOrTag::Finalized.into()).await
+        }
+    }
+
+    /// Returns the finalized block.
+    ///
+    /// The `verified_validator_num` parameter is provided for BSC compatibility but is ignored
+    /// in the implementation. In standard Ethereum, the finalized block is determined by the
+    /// Beacon Chain consensus (Casper FFG).
+    ///
+    /// If `full` is true, the block object will contain all transaction objects, otherwise it will
+    /// only contain the transaction hashes.
+    fn rpc_finalized_block(
+        &self,
+        _verified_validator_num: u64,
+        full: bool,
+    ) -> impl Future<Output = Result<Option<RpcBlock<Self::NetworkTypes>>, Self::Error>> + Send
+    where
+        Self: FullEthApiTypes,
+    {
+        async move {
+            // Simply delegate to rpc_block with Finalized tag
+            self.rpc_block(BlockNumberOrTag::Finalized.into(), full).await
         }
     }
 


### PR DESCRIPTION
Ports `5883af336` from `develop`.

Adds `eth_getFinalizeBlock` and `eth_getFinalizeHeader` RPC methods to the eth API.

Next: `64ef709a2 feat: support BSC system transactions and refactor tracer code`