### PR TITLE
feat: support BSC system transactions and refactor tracer code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2945,7 +2945,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -11097,9 +11097,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -1,15 +1,17 @@
 use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_eip7928::BlockAccessList;
 use alloy_eips::{eip2718::Encodable2718, BlockId, BlockNumberOrTag};
-use alloy_evm::{env::BlockEnvironment, Evm};
+use alloy_evm::{env::BlockEnvironment, Evm, TransactionTr};
 use alloy_genesis::ChainConfig;
 use alloy_primitives::{hex::decode, uint, Address, Bytes, B256, U64};
 use alloy_rlp::{Decodable, Encodable};
 use alloy_rpc_types::BlockTransactionsKind;
 use alloy_rpc_types_debug::ExecutionWitness;
-use alloy_rpc_types_eth::{state::EvmOverrides, BlockError, Bundle, StateContext};
+use alloy_rpc_types_eth::{state::EvmOverrides, BlockError, Bundle, StateContext, TransactionInfo};
 use alloy_rpc_types_trace::geth::{
-    BlockTraceResult, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, TraceResult,
+    call::FlatCallFrame, BlockTraceResult, FourByteFrame, GethDebugBuiltInTracerType,
+    GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
+    NoopFrame, TraceResult,
 };
 use async_trait::async_trait;
 use futures::Stream;
@@ -18,7 +20,7 @@ use parking_lot::RwLock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_engine_primitives::ConsensusEngineEvent;
 use reth_errors::RethError;
-use reth_evm::{execute::Executor, ConfigureEvm, EvmEnvFor};
+use reth_evm::{execute::Executor, ConfigureEvm, EvmEnvFor, TxEnvFor};
 use reth_primitives_traits::{
     Block as BlockTrait, BlockBody, BlockTy, ReceiptWithBloom, RecoveredBlock,
 };
@@ -29,7 +31,7 @@ use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
     FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
-use reth_rpc_eth_types::EthApiError;
+use reth_rpc_eth_types::{EthApiError, StateCacheDb};
 use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
 use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
@@ -38,8 +40,14 @@ use reth_storage_api::{
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
-use revm::{database::states::bundle_state::BundleRetention, DatabaseCommit};
-use revm_inspectors::tracing::{DebugInspector, TransactionContext};
+use revm::{
+    context_interface::Block as BlockEnvTrait, database::states::bundle_state::BundleRetention,
+    state::EvmState, DatabaseCommit,
+};
+use revm_inspectors::tracing::{
+    DebugInspector, FourByteInspector, MuxInspector, TracingInspector, TracingInspectorConfig,
+    TransactionContext,
+};
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
@@ -101,6 +109,21 @@ impl<Eth> DebugApi<Eth>
 where
     Eth: TraceExt,
 {
+    /// Handles BSC system transactions by disabling block gas limit validation.
+    ///
+    /// BSC system transactions are identified by:
+    /// 1. `gas_limit` == `u64::MAX / 2`
+    /// 2. caller == block beneficiary (coinbase)
+    fn handle_bsc_system_transaction(
+        evm_env: &mut EvmEnvFor<Eth::Evm>,
+        tx_env: &TxEnvFor<Eth::Evm>,
+    ) {
+        if tx_env.gas_limit() == u64::MAX / 2 && tx_env.caller() == evm_env.block_env.beneficiary()
+        {
+            evm_env.cfg_env.disable_block_gas_limit = true;
+        }
+    }
+
     /// Acquires a permit to execute a tracing call.
     async fn acquire_trace_permit(&self) -> Result<OwnedSemaphorePermit, AcquireError> {
         self.inner.blocking_task_guard.clone().acquire_owned().await
@@ -113,6 +136,7 @@ where
         evm_env: EvmEnvFor<Eth::Evm>,
         opts: GethDebugTracingOptions,
     ) -> Result<Vec<TraceResult>, Eth::Error> {
+        let this = self.clone();
         self.eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 let mut results = Vec::with_capacity(block.body().transactions().len());
@@ -120,37 +144,31 @@ where
                 eth_api.apply_pre_execution_changes(&block, &mut db)?;
 
                 let mut transactions = block.transactions_recovered().enumerate().peekable();
-                let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
+                let mut inspector = None;
                 while let Some((index, tx)) = transactions.next() {
                     let tx_hash = *tx.tx_hash();
                     let tx_env = eth_api.evm_config().tx_env(tx);
 
-                    let res = eth_api.inspect(
-                        &mut db,
+                    let (result, state_changes) = this.trace_transaction(
+                        &opts,
                         evm_env.clone(),
-                        tx_env.clone(),
+                        tx_env,
+                        &mut db,
+                        Some(TransactionContext {
+                            block_hash: Some(block.hash()),
+                            tx_hash: Some(tx_hash),
+                            tx_index: Some(index),
+                        }),
                         &mut inspector,
                     )?;
-                    let result = inspector
-                        .get_result(
-                            Some(TransactionContext {
-                                block_hash: Some(block.hash()),
-                                tx_hash: Some(tx_hash),
-                                tx_index: Some(index),
-                            }),
-                            &tx_env,
-                            &evm_env.block_env,
-                            &res,
-                            &mut db,
-                        )
-                        .map_err(Eth::Error::from_eth_err)?;
+
+                    inspector = inspector.map(|insp| insp.fused());
 
                     results.push(TraceResult::Success { result, tx_hash: Some(tx_hash) });
                     if transactions.peek().is_some() {
-                        inspector.fuse().map_err(Eth::Error::from_eth_err)?;
                         // need to apply the state changes of this transaction before executing the
                         // next transaction
-                        db.commit(res.state)
+                        db.commit(state_changes)
                     }
                 }
 
@@ -227,6 +245,7 @@ where
         let state_at: BlockId = block.parent_hash().into();
         let block_hash = block.hash();
 
+        let this = self.clone();
         self.eth_api()
             .spawn_with_state_at_block(state_at, move |eth_api, mut db| {
                 let block_txs = block.transactions_recovered();
@@ -246,24 +265,19 @@ where
 
                 let tx_env = eth_api.evm_config().tx_env(&tx);
 
-                let mut inspector = DebugInspector::new(opts).map_err(Eth::Error::from_eth_err)?;
-                let res =
-                    eth_api.inspect(&mut db, evm_env.clone(), tx_env.clone(), &mut inspector)?;
-                let trace = inspector
-                    .get_result(
-                        Some(TransactionContext {
-                            block_hash: Some(block_hash),
-                            tx_index: Some(index),
-                            tx_hash: Some(*tx.tx_hash()),
-                        }),
-                        &tx_env,
-                        &evm_env.block_env,
-                        &res,
-                        &mut db,
-                    )
-                    .map_err(Eth::Error::from_eth_err)?;
-
-                Ok(trace)
+                this.trace_transaction(
+                    &opts,
+                    evm_env,
+                    tx_env,
+                    &mut db,
+                    Some(TransactionContext {
+                        block_hash: Some(block_hash),
+                        tx_index: Some(index),
+                        tx_hash: Some(*tx.tx_hash()),
+                    }),
+                    &mut None,
+                )
+                .map(|(trace, _)| trace)
             })
             .await
     }
@@ -299,23 +313,243 @@ where
                 .await;
         }
 
+        let GethDebugTracingOptions { config, tracer, tracer_config, .. } = tracing_options;
+
         let this = self.clone();
-        self.eth_api()
-            .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
-                let mut inspector =
-                    DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
-                let res = this.eth_api().inspect(
-                    &mut *db,
-                    evm_env.clone(),
-                    tx_env.clone(),
-                    &mut inspector,
-                )?;
-                let trace = inspector
-                    .get_result(None, &tx_env, &evm_env.block_env, &res, db)
-                    .map_err(Eth::Error::from_eth_err)?;
-                Ok(trace)
+        if let Some(tracer) = tracer {
+            #[allow(unreachable_patterns)]
+            return match tracer {
+                GethDebugTracerType::BuiltInTracer(tracer) => match tracer {
+                    GethDebugBuiltInTracerType::FourByteTracer => {
+                        let mut inspector = FourByteInspector::default();
+                        let inspector = self
+                            .eth_api()
+                            .spawn_with_call_at(
+                                call,
+                                at,
+                                overrides,
+                                move |db, mut evm_env, tx_env| {
+                                    Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+                                    this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                                    Ok(inspector)
+                                },
+                            )
+                            .await?;
+                        Ok(FourByteFrame::from(&inspector).into())
+                    }
+                    GethDebugBuiltInTracerType::CallTracer => {
+                        let call_config = tracer_config
+                            .into_call_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        let mut inspector = TracingInspector::new(
+                            TracingInspectorConfig::from_geth_call_config(&call_config),
+                        );
+
+                        let frame = self
+                            .eth_api()
+                            .spawn_with_call_at(
+                                call,
+                                at,
+                                overrides,
+                                move |db, mut evm_env, tx_env| {
+                                    Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+
+                                    let gas_limit = tx_env.gas_limit();
+                                    let res = this.eth_api().inspect(
+                                        db,
+                                        evm_env,
+                                        tx_env,
+                                        &mut inspector,
+                                    )?;
+                                    let frame = inspector
+                                        .with_transaction_gas_limit(gas_limit)
+                                        .into_geth_builder()
+                                        .geth_call_traces(call_config, res.result.gas_used());
+                                    Ok(frame.into())
+                                },
+                            )
+                            .await?;
+                        Ok(frame)
+                    }
+                    GethDebugBuiltInTracerType::PreStateTracer => {
+                        let prestate_config = tracer_config
+                            .into_pre_state_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+                        let mut inspector = TracingInspector::new(
+                            TracingInspectorConfig::from_geth_prestate_config(&prestate_config),
+                        );
+
+                        let frame = self
+                            .eth_api()
+                            .spawn_with_call_at(
+                                call,
+                                at,
+                                overrides,
+                                move |db, mut evm_env, tx_env| {
+                                    Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+
+                                    let gas_limit = tx_env.gas_limit();
+                                    let res = this.eth_api().inspect(
+                                        &mut *db,
+                                        evm_env,
+                                        tx_env,
+                                        &mut inspector,
+                                    )?;
+                                    let frame = inspector
+                                        .with_transaction_gas_limit(gas_limit)
+                                        .into_geth_builder()
+                                        .geth_prestate_traces(&res, &prestate_config, db)
+                                        .map_err(Eth::Error::from_eth_err)?;
+                                    Ok(frame)
+                                },
+                            )
+                            .await?;
+                        Ok(frame.into())
+                    }
+                    GethDebugBuiltInTracerType::NoopTracer => Ok(NoopFrame::default().into()),
+                    GethDebugBuiltInTracerType::MuxTracer => {
+                        let mux_config = tracer_config
+                            .into_mux_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        let mut inspector = MuxInspector::try_from_config(mux_config)
+                            .map_err(Eth::Error::from_eth_err)?;
+
+                        let frame = self
+                            .inner
+                            .eth_api
+                            .spawn_with_call_at(
+                                call,
+                                at,
+                                overrides,
+                                move |db, mut evm_env, tx_env| {
+                                    let tx_info = TransactionInfo {
+                                        block_number: Some(
+                                            evm_env.block_env.number().saturating_to(),
+                                        ),
+                                        base_fee: Some(evm_env.block_env.basefee()),
+                                        hash: None,
+                                        block_hash: None,
+                                        index: None,
+                                    };
+
+                                    Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+
+                                    let res = this.eth_api().inspect(
+                                        &mut *db,
+                                        evm_env,
+                                        tx_env,
+                                        &mut inspector,
+                                    )?;
+                                    let frame = inspector
+                                        .try_into_mux_frame(&res, db, tx_info)
+                                        .map_err(Eth::Error::from_eth_err)?;
+                                    Ok(frame.into())
+                                },
+                            )
+                            .await?;
+                        Ok(frame)
+                    }
+                    GethDebugBuiltInTracerType::FlatCallTracer => {
+                        let flat_call_config = tracer_config
+                            .into_flat_call_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        let mut inspector = TracingInspector::new(
+                            TracingInspectorConfig::from_flat_call_config(&flat_call_config),
+                        );
+
+                        let frame: FlatCallFrame = self
+                            .inner
+                            .eth_api
+                            .spawn_with_call_at(
+                                call,
+                                at,
+                                overrides,
+                                move |db, mut evm_env, tx_env| {
+                                    Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+
+                                    let gas_limit = tx_env.gas_limit();
+                                    this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                                    let tx_info = TransactionInfo::default();
+                                    let frame: FlatCallFrame = inspector
+                                        .with_transaction_gas_limit(gas_limit)
+                                        .into_parity_builder()
+                                        .into_localized_transaction_traces(tx_info);
+                                    Ok(frame)
+                                },
+                            )
+                            .await?;
+
+                        Ok(frame.into())
+                    }
+                    _ => {
+                        // Note: this match is non-exhaustive in case we need to add support for
+                        // additional tracers
+                        Err(EthApiError::Unsupported("unsupported tracer").into())
+                    }
+                },
+                #[cfg(not(feature = "js-tracer"))]
+                GethDebugTracerType::JsTracer(_) => {
+                    Err(EthApiError::Unsupported("JS Tracer is not enabled").into())
+                }
+                #[cfg(feature = "js-tracer")]
+                GethDebugTracerType::JsTracer(code) => {
+                    let config = tracer_config.into_json();
+
+                    let (_, at) = self.eth_api().evm_env_at(at).await?;
+
+                    let res = self
+                        .eth_api()
+                        .spawn_with_call_at(call, at, overrides, move |db, evm_env, tx_env| {
+                            let mut inspector =
+                                revm_inspectors::tracing::js::JsInspector::new(code, config)
+                                    .map_err(Eth::Error::from_eth_err)?;
+                            let res = this.eth_api().inspect(
+                                &mut *db,
+                                evm_env.clone(),
+                                tx_env.clone(),
+                                &mut inspector,
+                            )?;
+                            inspector
+                                .json_result(res, &tx_env, &evm_env.block_env, &*db)
+                                .map_err(Eth::Error::from_eth_err)
+                        })
+                        .await?;
+
+                    Ok(GethTrace::JS(res))
+                }
+                _ => {
+                    // Note: this match is non-exhaustive in case we need to add support for
+                    // additional tracers
+                    Err(EthApiError::Unsupported("unsupported tracer").into())
+                }
+            }
+        }
+
+        // default structlog tracer
+        let inspector_config = TracingInspectorConfig::from_geth_config(&config);
+
+        let mut inspector = TracingInspector::new(inspector_config);
+
+        let (res, tx_gas_limit, inspector) = self
+            .eth_api()
+            .spawn_with_call_at(call, at, overrides, move |db, mut evm_env, tx_env| {
+                Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+                let gas_limit = tx_env.gas_limit();
+                let res = this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                Ok((res, gas_limit, inspector))
             })
-            .await
+            .await?;
+        let gas_used = res.result.gas_used();
+        let return_value = res.result.into_output().unwrap_or_default();
+        let frame = inspector
+            .with_transaction_gas_limit(tx_gas_limit)
+            .into_geth_builder()
+            .geth_traces(gas_used, return_value, config);
+
+        Ok(frame.into())
     }
 
     /// Helper method to execute `debug_trace_call` at a specific transaction index within a block.
@@ -365,8 +599,10 @@ where
                 )?;
 
                 // 3. now execute the trace call on this state
-                let (evm_env, tx_env) =
+                let (mut evm_env, tx_env) =
                     eth_api.prepare_call_env(evm_env, call, &mut db, overrides)?;
+
+                Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
 
                 let mut inspector =
                     DebugInspector::new(tracing_options).map_err(Eth::Error::from_eth_err)?;
@@ -601,6 +837,201 @@ where
             .bytecode_by_hash(&hash)
             .map_err(Eth::Error::from_eth_err)?
             .map(|b| b.original_bytes()))
+    }
+
+    /// Executes the configured transaction with the environment on the given database.
+    ///
+    /// It optionally takes fused inspector ([`TracingInspector::fused`]) to avoid re-creating the
+    /// inspector for each transaction. This is useful when tracing multiple transactions in a
+    /// block. This is only useful for block tracing which uses the same tracer for all transactions
+    /// in the block.
+    ///
+    /// Caution: If the inspector is provided then `opts.tracer_config` is ignored.
+    ///
+    /// Returns the trace frame and the state that got updated after executing the transaction.
+    ///
+    /// Note: this does not apply any state overrides if they're configured in the `opts`.
+    ///
+    /// Caution: this is blocking and should be performed on a blocking task.
+    fn trace_transaction(
+        &self,
+        opts: &GethDebugTracingOptions,
+        mut evm_env: EvmEnvFor<Eth::Evm>,
+        tx_env: TxEnvFor<Eth::Evm>,
+        db: &mut StateCacheDb,
+        transaction_context: Option<TransactionContext>,
+        fused_inspector: &mut Option<TracingInspector>,
+    ) -> Result<(GethTrace, EvmState), Eth::Error> {
+        let GethDebugTracingOptions { config, tracer, tracer_config, .. } = opts;
+
+        let tx_info = TransactionInfo {
+            hash: transaction_context.as_ref().map(|c| c.tx_hash).unwrap_or_default(),
+            index: transaction_context
+                .as_ref()
+                .map(|c| c.tx_index.map(|i| i as u64))
+                .unwrap_or_default(),
+            block_hash: transaction_context.as_ref().map(|c| c.block_hash).unwrap_or_default(),
+            block_number: Some(evm_env.block_env.number().saturating_to()),
+            base_fee: Some(evm_env.block_env.basefee()),
+        };
+
+        if let Some(tracer) = tracer {
+            #[allow(unreachable_patterns)]
+            return match tracer {
+                GethDebugTracerType::BuiltInTracer(tracer) => match tracer {
+                    GethDebugBuiltInTracerType::FourByteTracer => {
+                        let mut inspector = FourByteInspector::default();
+                        Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+                        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                        return Ok((FourByteFrame::from(&inspector).into(), res.state))
+                    }
+                    GethDebugBuiltInTracerType::CallTracer => {
+                        let call_config = tracer_config
+                            .clone()
+                            .into_call_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        let mut inspector = fused_inspector.get_or_insert_with(|| {
+                            TracingInspector::new(TracingInspectorConfig::from_geth_call_config(
+                                &call_config,
+                            ))
+                        });
+
+                        Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+
+                        let gas_limit = tx_env.gas_limit();
+                        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+
+                        inspector.set_transaction_gas_limit(gas_limit);
+
+                        let frame = inspector
+                            .geth_builder()
+                            .geth_call_traces(call_config, res.result.gas_used());
+
+                        return Ok((frame.into(), res.state))
+                    }
+                    GethDebugBuiltInTracerType::PreStateTracer => {
+                        let prestate_config = tracer_config
+                            .clone()
+                            .into_pre_state_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        let mut inspector = fused_inspector.get_or_insert_with(|| {
+                            TracingInspector::new(
+                                TracingInspectorConfig::from_geth_prestate_config(&prestate_config),
+                            )
+                        });
+
+                        Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+
+                        let gas_limit = tx_env.gas_limit();
+                        let res =
+                            self.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
+
+                        inspector.set_transaction_gas_limit(gas_limit);
+                        let frame = inspector
+                            .geth_builder()
+                            .geth_prestate_traces(&res, &prestate_config, db)
+                            .map_err(Eth::Error::from_eth_err)?;
+
+                        return Ok((frame.into(), res.state))
+                    }
+                    GethDebugBuiltInTracerType::NoopTracer => {
+                        Ok((NoopFrame::default().into(), Default::default()))
+                    }
+                    GethDebugBuiltInTracerType::MuxTracer => {
+                        let mux_config = tracer_config
+                            .clone()
+                            .into_mux_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        let mut inspector = MuxInspector::try_from_config(mux_config)
+                            .map_err(Eth::Error::from_eth_err)?;
+
+                        Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+
+                        let res =
+                            self.eth_api().inspect(&mut *db, evm_env, tx_env, &mut inspector)?;
+                        let frame = inspector
+                            .try_into_mux_frame(&res, db, tx_info)
+                            .map_err(Eth::Error::from_eth_err)?;
+                        return Ok((frame.into(), res.state))
+                    }
+                    GethDebugBuiltInTracerType::FlatCallTracer => {
+                        let flat_call_config = tracer_config
+                            .clone()
+                            .into_flat_call_config()
+                            .map_err(|_| EthApiError::InvalidTracerConfig)?;
+
+                        let mut inspector = TracingInspector::new(
+                            TracingInspectorConfig::from_flat_call_config(&flat_call_config),
+                        );
+
+                        Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+
+                        let gas_limit = tx_env.gas_limit();
+                        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                        let frame: FlatCallFrame = inspector
+                            .with_transaction_gas_limit(gas_limit)
+                            .into_parity_builder()
+                            .into_localized_transaction_traces(tx_info);
+
+                        return Ok((frame.into(), res.state));
+                    }
+                    _ => {
+                        // Note: this match is non-exhaustive in case we need to add support for
+                        // additional tracers
+                        Err(EthApiError::Unsupported("unsupported tracer").into())
+                    }
+                },
+                #[cfg(not(feature = "js-tracer"))]
+                GethDebugTracerType::JsTracer(_) => {
+                    Err(EthApiError::Unsupported("JS Tracer is not enabled").into())
+                }
+                #[cfg(feature = "js-tracer")]
+                GethDebugTracerType::JsTracer(code) => {
+                    let config = tracer_config.clone().into_json();
+                    let mut inspector =
+                        revm_inspectors::tracing::js::JsInspector::with_transaction_context(
+                            code.clone(),
+                            config,
+                            transaction_context.unwrap_or_default(),
+                        )
+                        .map_err(Eth::Error::from_eth_err)?;
+                    let res = self.eth_api().inspect(
+                        &mut *db,
+                        evm_env.clone(),
+                        tx_env.clone(),
+                        &mut inspector,
+                    )?;
+
+                    let state = res.state.clone();
+                    let result = inspector
+                        .json_result(res, &tx_env, &evm_env.block_env, db)
+                        .map_err(Eth::Error::from_eth_err)?;
+                    Ok((GethTrace::JS(result), state))
+                }
+                _ => {
+                    // Note: this match is non-exhaustive in case we need to add support for
+                    // additional tracers
+                    Err(EthApiError::Unsupported("unsupported tracer").into())
+                }
+            }
+        }
+
+        // default structlog tracer
+        let mut inspector = fused_inspector.get_or_insert_with(|| {
+            let inspector_config = TracingInspectorConfig::from_geth_config(config);
+            TracingInspector::new(inspector_config)
+        });
+        let gas_limit = tx_env.gas_limit();
+        let res = self.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+        let gas_used = res.result.gas_used();
+        let return_value = res.result.into_output().unwrap_or_default();
+        inspector.set_transaction_gas_limit(gas_limit);
+        let frame = inspector.geth_builder().geth_traces(gas_used, return_value, *config);
+
+        Ok((frame.into(), res.state))
     }
 
     /// Returns the state root of the `HashedPostState` on top of the state for the given block with


### PR DESCRIPTION
Ports `64ef709a2` from `develop`.

Adds BSC system transaction support across all debug tracers (`4byteTracer`, `callTracer`, `preStateTracer`, `muxTracer`, `flatCallTracer`). BSC system txs are detected by `gas_limit == u64::MAX/2 && caller == beneficiary`, which disables block gas limit validation. Extracts a shared `handle_bsc_system_transaction()` helper to avoid duplication across `debug_traceCall` and `debug_traceTransaction`.

Next: `d7582075d feat: support bsc validator (#18)`