### PR TITLE
feat: support bsc validator

### DIFF
--- a/crates/engine/primitives/src/error.rs
+++ b/crates/engine/primitives/src/error.rs
@@ -45,3 +45,18 @@ impl BeaconForkChoiceUpdateError {
         Self::Internal(Box::new(e))
     }
 }
+
+/// Represents error cases for a BSC message.
+#[derive(Debug, thiserror::Error)]
+pub enum BSCEngineMessageError {
+    /// An internal error occurred, not necessarily related to the message.
+    #[error(transparent)]
+    Internal(Box<dyn core::error::Error + Send + Sync>),
+}
+
+impl BSCEngineMessageError {
+    /// Create a new internal error.
+    pub fn internal<E: core::error::Error + Send + Sync + 'static>(e: E) -> Self {
+        Self::Internal(Box::new(e))
+    }
+}

--- a/crates/engine/primitives/src/message.rs
+++ b/crates/engine/primitives/src/message.rs
@@ -1,6 +1,8 @@
 use crate::{
-    error::BeaconForkChoiceUpdateError, BeaconOnNewPayloadError, ExecutionPayload, ForkchoiceStatus,
+    error::BeaconForkChoiceUpdateError, BSCEngineMessageError, BeaconOnNewPayloadError,
+    ExecutionPayload, ForkchoiceStatus,
 };
+use alloy_primitives::{BlockHash, BlockNumber, U256};
 use alloy_rpc_types_engine::{
     ForkChoiceUpdateResult, ForkchoiceState, ForkchoiceUpdateError, ForkchoiceUpdated, PayloadId,
     PayloadStatus, PayloadStatusEnum,
@@ -224,6 +226,16 @@ pub enum BeaconEngineMessage<Payload: PayloadTypes> {
         /// The sender for returning forkchoice updated result.
         tx: oneshot::Sender<RethResult<OnForkChoiceUpdated>>,
     },
+
+    /// BSC specific engine message
+    QueryTd {
+        /// The block number to query the TD of.
+        number: BlockNumber,
+        /// The block hash to query the TD of.
+        hash: BlockHash,
+        /// The sender for returning the TD.
+        tx: oneshot::Sender<RethResult<Option<U256>>>,
+    },
 }
 
 impl<Payload: PayloadTypes> Display for BeaconEngineMessage<Payload> {
@@ -255,6 +267,9 @@ impl<Payload: PayloadTypes> Display for BeaconEngineMessage<Payload> {
                     "ForkchoiceUpdated {{ state: {state:?}, has_payload_attributes: {} }}",
                     payload_attrs.is_some()
                 )
+            }
+            Self::QueryTd { number, hash, .. } => {
+                write!(f, "QueryHeaderWithTd {{ number: {}, hash: {} }}", number, hash)
             }
         }
     }
@@ -345,5 +360,16 @@ where
             tx,
         });
         rx
+    }
+
+    /// Sends a query TD message to the beacon consensus engine and waits for a response.
+    pub async fn query_td(
+        &self,
+        number: BlockNumber,
+        hash: BlockHash,
+    ) -> Result<Option<U256>, BSCEngineMessageError> {
+        let (tx, rx) = oneshot::channel();
+        let _ = self.to_engine.send(BeaconEngineMessage::QueryTd { number, hash, tx });
+        rx.await.map_err(BSCEngineMessageError::internal)?.map_err(BSCEngineMessageError::internal)
     }
 }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1898::BlockWithParent, merge::EPOCH_SLOTS, BlockNumHash, NumHash};
-use alloy_primitives::B256;
+use alloy_primitives::{BlockHash, BlockNumber, B256};
 use alloy_rpc_types_engine::{
     ForkchoiceState, PayloadStatus, PayloadStatusEnum, PayloadValidationError,
 };
@@ -39,6 +39,7 @@ use reth_stages_api::ControlFlow;
 use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
 use reth_trie_db::ChangesetCache;
 use revm::interpreter::debug_unreachable;
+use revm_primitives::U256;
 use state::TreeState;
 use std::{collections::HashMap, fmt::Debug, ops, sync::Arc, time::Duration};
 
@@ -1724,6 +1725,14 @@ where
 
                                 self.on_maybe_tree_event(maybe_event)?;
                             }
+                            BeaconEngineMessage::QueryTd { number, hash, tx } => {
+                                debug!(target: "engine::tree", number=?number, hash=?hash, "querying header and TD by engine message");
+                                let output = self.query_header_with_td(number, hash);
+
+                                if let Err(err) = tx.send(output.map(|o| o.1).map_err(Into::into)) {
+                                    error!(target: "engine::tree", "Failed to send event: {err:?}");
+                                }
+                            }
                         }
                     }
                 }
@@ -3282,6 +3291,78 @@ where
 
         debug!(target: "engine::tree", %hash, "no canonical state found for block");
         Ok(None)
+    }
+
+    /// Query the header and TD of the given block number and hash.
+    /// If the block is not found, the header and TD of the last block will be returned.
+    pub fn query_header_with_td(
+        &self,
+        number: BlockNumber,
+        hash: BlockHash,
+    ) -> ProviderResult<(N::BlockHeader, Option<U256>)> {
+        // query header td from canonical chain
+        if let Some(block_number) = self.provider.block_number(hash)? {
+            tracing::debug!(target: "engine::tree", number=?number, hash=?hash, "querying TD from canonical chain");
+            let header = self
+                .provider
+                .header_by_number(block_number)?
+                .ok_or(ProviderError::HeaderNotFound(block_number.into()))?;
+            let td = self.provider.header_td_by_number(block_number)?;
+            return Ok((header, td))
+        }
+
+        // query header td from last block number
+        tracing::debug!(target: "engine::tree", number=?number, hash=?hash, "querying TD from fork headers");
+        let mut ret_td = U256::ZERO;
+        let ret_header = self
+            .state
+            .tree_state
+            .blocks_by_hash
+            .get(&hash)
+            .map(|b| b.recovered_block.clone_header())
+            .ok_or(ProviderError::HeaderNotFound(hash.into()))?;
+        ret_td = ret_td.wrapping_add(ret_header.difficulty());
+
+        let last_block_number = self.provider.last_block_number()?;
+        let (mut current_number, mut current_hash) = (number - 1, ret_header.parent_hash());
+        while current_number >= last_block_number {
+            match self.provider.block_number(current_hash)? {
+                Some(block_number) => {
+                    // add canonical chain td
+                    match self.provider.header_td_by_number(block_number)? {
+                        Some(td) => {
+                            ret_td = ret_td.wrapping_add(td);
+                            return Ok((ret_header, Some(ret_td)))
+                        }
+                        None => {
+                            tracing::warn!(target: "engine::tree", current_number=?current_number, current_hash=?current_hash, 
+                                "header td not found for block number, just return none");
+                            return Ok((ret_header, None))
+                        }
+                    }
+                }
+                None => {
+                    // continue to query forks
+                    let header = self
+                        .state
+                        .tree_state
+                        .blocks_by_hash
+                        .get(&current_hash)
+                        .map(|b| b.recovered_block.header())
+                        .ok_or(ProviderError::HeaderNotFound(current_hash.into()))?;
+                    current_hash = header.parent_hash();
+                    ret_td = ret_td.wrapping_add(header.difficulty());
+                }
+            }
+            current_number -= 1;
+        }
+
+        if current_number < last_block_number {
+            tracing::warn!(target: "engine::tree", current_number=?current_number, current_hash=?current_hash, last_block_number=?last_block_number,
+                 "cannot find header td for block number, query beyond last block number, just return none");
+            return Ok((ret_header, None))
+        }
+        Ok((ret_header, Some(ret_td)))
     }
 }
 

--- a/crates/engine/util/src/engine_store.rs
+++ b/crates/engine/util/src/engine_store.rs
@@ -82,6 +82,7 @@ impl EngineMessageStore {
                     })?,
                 )?;
             }
+            _ => {}
         };
         Ok(())
     }

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -535,7 +535,6 @@ where
         full: bool,
     ) -> RpcResult<Option<RpcBlock<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?number, ?full, "Serving eth_getBlockByNumber");
-        check_pending_tag(&number)?;
         Ok(EthBlocks::rpc_block(self, number.into(), full).await?)
     }
 
@@ -551,7 +550,6 @@ where
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>> {
         trace!(target: "rpc::eth", ?number, "Serving eth_getBlockTransactionCountByNumber");
-        check_pending_tag(&number)?;
         Ok(EthBlocks::block_transaction_count(self, number.into()).await?.map(U256::from))
     }
 
@@ -572,7 +570,6 @@ where
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<U256>> {
         trace!(target: "rpc::eth", ?number, "Serving eth_getUncleCountByBlockNumber");
-        check_pending_tag(&number)?;
 
         if let Some(block) = self.block_by_number(number, false).await? {
             Ok(Some(U256::from(block.uncles.len())))
@@ -607,7 +604,6 @@ where
         index: Index,
     ) -> RpcResult<Option<RpcBlock<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?number, ?index, "Serving eth_getUncleByBlockNumberAndIndex");
-        check_pending_tag(&number)?;
         Ok(EthBlocks::ommer_by_block_and_index(self, number.into(), index).await?)
     }
 
@@ -667,7 +663,6 @@ where
         index: Index,
     ) -> RpcResult<Option<Bytes>> {
         trace!(target: "rpc::eth", ?number, ?index, "Serving eth_getRawTransactionByBlockNumberAndIndex");
-        check_pending_tag(&number)?;
         Ok(EthTransactions::raw_transaction_by_block_and_tx_index(
             self,
             number.into(),
@@ -683,7 +678,6 @@ where
         index: Index,
     ) -> RpcResult<Option<RpcTransaction<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?number, ?index, "Serving eth_getTransactionByBlockNumberAndIndex");
-        check_pending_tag(&number)?;
         Ok(EthTransactions::transaction_by_block_and_tx_index(self, number.into(), index.into())
             .await?)
     }
@@ -703,7 +697,6 @@ where
         number: BlockNumberOrTag,
     ) -> RpcResult<Option<Vec<RpcTransaction<T::NetworkTypes>>>> {
         trace!(target: "rpc::eth", ?number, "Serving eth_getTransactionsByBlockNumber");
-        check_pending_tag(&number)?;
         Ok(EthTransactions::transactions_by_block_id(self, number.into()).await?)
     }
 
@@ -789,7 +782,6 @@ where
         block_number: BlockNumberOrTag,
     ) -> RpcResult<Option<RpcHeader<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", ?block_number, "Serving eth_getHeaderByNumber");
-        check_pending_tag(&block_number)?;
         Ok(EthBlocks::rpc_block_header(self, block_number.into()).await?)
     }
 
@@ -939,7 +931,6 @@ where
         reward_percentiles: Option<Vec<f64>>,
     ) -> RpcResult<FeeHistory> {
         trace!(target: "rpc::eth", ?block_count, ?newest_block, ?reward_percentiles, "Serving eth_feeHistory");
-        check_pending_tag(&newest_block)?;
         Ok(EthFees::fee_history(self, block_count.to(), newest_block, reward_percentiles).await?)
     }
 
@@ -1059,14 +1050,5 @@ where
 
         let bal = self.get_block_access_list(number.into()).await?;
         Ok(bal.map(|b: BlockAccessList| alloy_rlp::encode(b).into()))
-    }
-}
-
-/// Helper function to check if `BlockNumberOrTag` is pending and return error if so
-fn check_pending_tag(block_number: &BlockNumberOrTag) -> RpcResult<()> {
-    if matches!(block_number, BlockNumberOrTag::Pending) {
-        Err(internal_rpc_err("Unsupported pending tag"))
-    } else {
-        Ok(())
     }
 }

--- a/crates/storage/db-api/src/tables/mod.rs
+++ b/crates/storage/db-api/src/tables/mod.rs
@@ -544,6 +544,13 @@ tables! {
         type Key = BlockNumber;
         type Value = crate::models::ParliaSnapshotBlob;
     }
+
+    /// Stores BSC Parlia checkpoint snapshots (compressed CBOR bytes).
+    /// defined it here is for schema registration and database initialization.
+    table ParliaSnapshotsByHash {
+        type Key = BlockHash;
+        type Value = crate::models::ParliaSnapshotBlob;
+    }
 }
 
 /// Packed-encoding view of the [`AccountsTrie`] table.

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::{BlockHashOrNumber, BlockId, BlockNumHash, BlockNumberOrTag};
-use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
 use alloy_rpc_types_engine::ForkchoiceState;
 use reth_chain_state::{
     BlockState, CanonicalInMemoryState, ForkChoiceNotifications, ForkChoiceSubscriptions,
@@ -121,7 +121,11 @@ impl<N: ProviderNodeTypes> BlockchainProvider<N> {
     /// [`BlockHashReader`]. This may fail if the inner read database transaction fails to open.
     #[track_caller]
     pub fn consistent_provider(&self) -> ProviderResult<ConsistentProvider<N>> {
-        ConsistentProvider::new(self.database.clone(), self.canonical_in_memory_state())
+        ConsistentProvider::new(
+            self.chain_spec(),
+            self.database.clone(),
+            self.canonical_in_memory_state(),
+        )
     }
 
     /// This uses a given [`BlockState`] to initialize a state provider for that block.
@@ -200,6 +204,14 @@ impl<N: ProviderNodeTypes> HeaderProvider for BlockchainProvider<N> {
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
         self.consistent_provider()?.header_by_number(num)
+    }
+
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        self.consistent_provider()?.header_td(hash)
+    }
+
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
+        self.consistent_provider()?.header_td_by_number(number)
     }
 
     fn headers_range(

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -14,10 +14,10 @@ use alloy_eips::{
 };
 use alloy_primitives::{
     map::{hash_map, HashMap},
-    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256,
+    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
 };
 use reth_chain_state::{BlockState, CanonicalInMemoryState, MemoryOverlayStateProviderRef};
-use reth_chainspec::ChainInfo;
+use reth_chainspec::{ChainInfo, EthChainSpec};
 use reth_db_api::models::{AccountBeforeTx, BlockNumberAddress, StoredBlockBodyIndices};
 use reth_execution_types::{BundleStateInit, ExecutionOutcome, RevertsInit};
 use reth_node_types::{BlockTy, HeaderTy, ReceiptTy, TxTy};
@@ -46,6 +46,8 @@ use tracing::trace;
 #[derive(Debug)]
 #[doc(hidden)] // triggers ICE for `cargo docs`
 pub struct ConsistentProvider<N: ProviderNodeTypes> {
+    /// Chain spec.
+    chain_spec: Arc<N::ChainSpec>,
     /// Storage provider.
     storage_provider: <ProviderFactory<N> as DatabaseProviderFactory>::Provider,
     /// Head block at time of [`Self`] creation
@@ -61,6 +63,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
     /// [`ProviderFactory::database_provider_ro`] effectively maintaining one single snapshotted
     /// view of memory and database.
     pub fn new(
+        chain_spec: Arc<N::ChainSpec>,
         storage_provider_factory: ProviderFactory<N>,
         state: CanonicalInMemoryState<N::Primitives>,
     ) -> ProviderResult<Self> {
@@ -73,7 +76,7 @@ impl<N: ProviderNodeTypes> ConsistentProvider<N> {
         // entirely. Resulting in gaps on the range.
         let head_block = state.head_state();
         let storage_provider = storage_provider_factory.database_provider_ro()?;
-        Ok(Self { storage_provider, head_block, canonical_in_memory_state: state })
+        Ok(Self { chain_spec, storage_provider, head_block, canonical_in_memory_state: state })
     }
 
     // Helper function to convert range bounds
@@ -675,6 +678,58 @@ impl<N: ProviderNodeTypes> HeaderProvider for ConsistentProvider<N> {
             |db_provider| db_provider.header_by_number(num),
             |block_state| Ok(Some(block_state.block_ref().recovered_block().clone_header())),
         )
+    }
+
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        if let Some(num) = self.block_number(*hash)? {
+            self.header_td_by_number(num)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
+        // BSC TD calculation logic
+        if self.chain_spec.final_paris_total_difficulty().is_none() {
+            let latest_block_number = self.last_block_number()?;
+            if number <= latest_block_number {
+                return self.storage_provider.header_td_by_number(number);
+            }
+            // found head in memory, calculate td by adding in-memory canonical tds
+            let mut td = self
+                .storage_provider
+                .header_td_by_number(latest_block_number)?
+                .ok_or(ProviderError::HeaderNotFound(latest_block_number.into()))?;
+            for num in latest_block_number + 1..=number {
+                let header =
+                    self.header_by_number(num)?.ok_or(ProviderError::HeaderNotFound(num.into()))?;
+                td = td.wrapping_add(header.difficulty());
+            }
+            return Ok(Some(td));
+        }
+
+        // ETH TD calculation logic
+        let number =
+            if self.head_block.as_ref().and_then(|b| b.block_on_chain(number.into())).is_some() {
+                // If the block exists in memory, we should return a TD for it.
+                //
+                // The canonical in memory state should only store post-merge blocks. Post-merge
+                // blocks have zero difficulty. This means we can use the total
+                // difficulty for the last finalized block number if present (so
+                // that we are not affected by reorgs), if not the last number in
+                // the database will be used.
+                if let Some(last_finalized_num_hash) =
+                    self.canonical_in_memory_state.get_finalized_num_hash()
+                {
+                    last_finalized_num_hash.number
+                } else {
+                    self.last_block_number()?
+                }
+            } else {
+                // Otherwise, return what we have on disk for the input block
+                number
+            };
+        self.storage_provider.header_td_by_number(number)
     }
 
     fn headers_range(

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::BlockHashOrNumber;
-use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
 use core::fmt;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::RwLock;
@@ -636,6 +636,14 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
             |static_file| static_file.header_by_number(num),
             || self.provider()?.header_by_number(num),
         )
+    }
+
+    fn header_td(&self, hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        self.provider()?.header_td(hash)
+    }
+
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
+        self.provider()?.header_td_by_number(number)
     }
 
     fn headers_range(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -28,13 +28,13 @@ use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{
     keccak256,
     map::{hash_map, AddressSet, B256Map, HashMap},
-    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256,
+    Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
 };
 use itertools::Itertools;
 use parking_lot::RwLock;
 use rayon::slice::ParallelSliceMut;
 use reth_chain_state::{ComputedTrieData, ExecutedBlock};
-use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec};
+use reth_chainspec::{ChainInfo, ChainSpecProvider, EthChainSpec, EthereumHardforks};
 use reth_db_api::{
     cursor::{DbCursorRO, DbCursorRW, DbDupCursorRO, DbDupCursorRW},
     database::{Database, ReaderTxnTracker},
@@ -1721,6 +1721,31 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
             num,
             |static_file| static_file.header_by_number(num),
             || Ok(self.tx.get::<tables::Headers<Self::Header>>(num)?),
+        )
+    }
+
+    fn header_td(&self, block_hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        if let Some(num) = self.block_number(*block_hash)? {
+            self.header_td_by_number(num)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn header_td_by_number(&self, number: BlockNumber) -> ProviderResult<Option<U256>> {
+        if self.chain_spec.is_paris_active_at_block(number) &&
+            let Some(td) = self.chain_spec.final_paris_total_difficulty()
+        {
+            // if this block is higher than the final paris(merge) block, return the final paris
+            // difficulty
+            return Ok(Some(td));
+        }
+
+        self.static_file_provider.get_with_static_file_or_database(
+            StaticFileSegment::Headers,
+            number,
+            |static_file| static_file.header_td_by_number(number),
+            || Ok(self.tx.get::<tables::HeaderTerminalDifficulties>(number)?.map(|td| td.0)),
         )
     }
 

--- a/crates/storage/provider/src/providers/static_file/jar.rs
+++ b/crates/storage/provider/src/providers/static_file/jar.rs
@@ -8,11 +8,11 @@ use crate::{
 };
 use alloy_consensus::transaction::TransactionMeta;
 use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
-use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
 use reth_chainspec::ChainInfo;
 use reth_db::static_file::{
-    BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TransactionMask,
-    TransactionSenderMask,
+    BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask, StaticFileCursor, TDWithHashMask,
+    TotalDifficultyMask, TransactionMask, TransactionSenderMask,
 };
 use reth_db_api::table::{Decompress, Value};
 use reth_node_types::NodePrimitives;
@@ -163,6 +163,18 @@ impl<N: NodePrimitives<BlockHeader: Value>> HeaderProvider for StaticFileJarProv
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
         self.cursor()?.get_one::<HeaderMask<Self::Header>>(num.into())
+    }
+
+    fn header_td(&self, block_hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        Ok(self
+            .cursor()?
+            .get_two::<TDWithHashMask>(block_hash.into())?
+            .filter(|(_, hash)| hash == block_hash)
+            .map(|(td, _)| td.into()))
+    }
+
+    fn header_td_by_number(&self, num: BlockNumber) -> ProviderResult<Option<U256>> {
+        Ok(self.cursor()?.get_one::<TotalDifficultyMask>(num.into())?.map(Into::into))
     }
 
     fn headers_range(

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -10,7 +10,9 @@ use crate::{
 };
 use alloy_consensus::{transaction::TransactionMeta, Header};
 use alloy_eips::{eip2718::Encodable2718, BlockHashOrNumber};
-use alloy_primitives::{b256, keccak256, Address, BlockHash, BlockNumber, TxHash, TxNumber, B256};
+use alloy_primitives::{
+    b256, keccak256, Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256,
+};
 
 use parking_lot::RwLock;
 use reth_chain_state::ExecutedBlock;
@@ -19,7 +21,8 @@ use reth_db::{
     lockfile::StorageLock,
     static_file::{
         iter_static_files, BlockHashMask, HeaderMask, HeaderWithHashMask, ReceiptMask,
-        StaticFileCursor, StorageChangesetMask, TransactionMask, TransactionSenderMask,
+        StaticFileCursor, StorageChangesetMask, TDWithHashMask, TransactionMask,
+        TransactionSenderMask,
     },
 };
 use reth_db_api::{
@@ -2553,6 +2556,27 @@ impl<N: NodePrimitives<BlockHeader: Value>> HeaderProvider for StaticFileProvide
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
         self.get_segment_provider_for_block(StaticFileSegment::Headers, num, None)
             .and_then(|provider| provider.header_by_number(num))
+            .or_else(|err| {
+                if let ProviderError::MissingStaticFileBlock(_, _) = err {
+                    Ok(None)
+                } else {
+                    Err(err)
+                }
+            })
+    }
+
+    fn header_td(&self, block_hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        self.find_static_file(StaticFileSegment::Headers, |jar_provider| {
+            Ok(jar_provider
+                .cursor()?
+                .get_two::<TDWithHashMask>(block_hash.into())?
+                .and_then(|(td, hash)| (&hash == block_hash).then_some(td.0)))
+        })
+    }
+
+    fn header_td_by_number(&self, num: BlockNumber) -> ProviderResult<Option<U256>> {
+        self.get_segment_provider_for_block(StaticFileSegment::Headers, num, None)
+            .and_then(|provider| provider.header_td_by_number(num))
             .or_else(|err| {
                 if let ProviderError::MissingStaticFileBlock(_, _) = err {
                     Ok(None)

--- a/crates/storage/storage-api/src/header.rs
+++ b/crates/storage/storage-api/src/header.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use alloy_eips::BlockHashOrNumber;
-use alloy_primitives::{BlockHash, BlockNumber};
+use alloy_primitives::{BlockHash, BlockNumber, U256};
 use core::ops::RangeBounds;
 use reth_primitives_traits::{BlockHeader, SealedHeader};
 use reth_storage_errors::provider::ProviderResult;
@@ -32,6 +32,16 @@ pub trait HeaderProvider: Send {
 
     /// Get header by block number
     fn header_by_number(&self, num: u64) -> ProviderResult<Option<Self::Header>>;
+
+    /// Get total difficulty by block hash.
+    fn header_td(&self, _hash: &BlockHash) -> ProviderResult<Option<U256>> {
+        Ok(None)
+    }
+
+    /// Get total difficulty by block number.
+    fn header_td_by_number(&self, _number: BlockNumber) -> ProviderResult<Option<U256>> {
+        Ok(None)
+    }
 
     /// Get header by block number or hash
     fn header_by_hash_or_number(

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -772,6 +772,14 @@ where
         self.pool.blob_store().get(tx_hash)
     }
 
+    fn insert_blob(
+        &self,
+        tx_hash: TxHash,
+        blob: BlobTransactionSidecarVariant,
+    ) -> Result<(), BlobStoreError> {
+        self.pool.blob_store().insert(tx_hash, blob)
+    }
+
     fn get_all_blobs(
         &self,
         tx_hashes: Vec<TxHash>,

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -44,6 +44,9 @@ use tracing::{debug, error, info, trace, warn};
 /// Maximum amount of time non-executable transaction are queued.
 pub const MAX_QUEUED_TRANSACTION_LIFETIME: Duration = Duration::from_secs(3 * 60 * 60);
 
+// The storage time of Sidecar is 19.2 days 19.2*86400/0.75 = 2211840
+const FINALIZED_BLOCK_OFFSET: u64 = 2211840;
+
 /// Additional settings for maintaining the transaction pool
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MaintainPoolConfig {
@@ -233,18 +236,23 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
         // check if we have a new finalized block
         if let Some(finalized) =
             last_finalized_block.update(client.finalized_block_number().ok().flatten()) &&
-            let BlobStoreUpdates::Finalized(blobs) =
-                blob_store_tracker.on_finalized_block(finalized)
+            finalized > FINALIZED_BLOCK_OFFSET
         {
-            metrics.inc_deleted_tracked_blobs(blobs.len());
-            // remove all finalized blobs from the blob store
-            pool.delete_blobs(blobs);
-            // and also do periodic cleanup
-            let pool = pool.clone();
-            task_spawner.spawn_blocking_task(async move {
-                debug!(target: "txpool", finalized_block = %finalized, "cleaning up blob store");
-                pool.cleanup_blobs();
-            });
+            debug!(target: "txpool", finalized_block = %finalized, "finalized block");
+            if let BlobStoreUpdates::Finalized(blobs) =
+                blob_store_tracker.on_finalized_block(finalized - FINALIZED_BLOCK_OFFSET)
+            {
+                let num_blobs = blobs.len();
+                metrics.inc_deleted_tracked_blobs(num_blobs);
+                // remove all finalized blobs from the blob store
+                pool.delete_blobs(blobs);
+                // and also do periodic cleanup
+                let pool = pool.clone();
+                task_spawner.spawn_blocking_task(async move {
+                    debug!(target: "txpool", finalized_block = %finalized, num_blobs = %num_blobs, "cleaning up blob store");
+                    pool.cleanup_blobs();
+                });
+            }
         }
 
         // outcomes of the futures we are waiting on

--- a/crates/transaction-pool/src/noop.rs
+++ b/crates/transaction-pool/src/noop.rs
@@ -343,6 +343,14 @@ impl<T: EthPoolTransaction> TransactionPool for NoopTransactionPool<T> {
         Ok(None)
     }
 
+    fn insert_blob(
+        &self,
+        _tx_hash: TxHash,
+        _blob: BlobTransactionSidecarVariant,
+    ) -> Result<(), BlobStoreError> {
+        Ok(())
+    }
+
     fn get_all_blobs(
         &self,
         _tx_hashes: Vec<TxHash>,

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -722,6 +722,13 @@ pub trait TransactionPool: Clone + Debug + Send + Sync {
         &self,
         versioned_hashes: &[B256],
     ) -> Result<Vec<Option<BlobAndProofV2>>, BlobStoreError>;
+
+    /// Inserts a blob sidecar into the blob store for the given transaction hash.
+    fn insert_blob(
+        &self,
+        tx_hash: TxHash,
+        blob: BlobTransactionSidecarVariant,
+    ) -> Result<(), BlobStoreError>;
 }
 
 /// Extension for [`TransactionPool`] trait that allows to set the current block info.


### PR DESCRIPTION
Port of BSC validator support from the `develop` branch (commit d7582075d).

Adds:
- BSC snapshot table in db-api
- `QueryTd` engine message for querying total difficulty
- `header_td` provider methods across database/static-file/consistent/blockchain providers
- Blob store cleanup using finalized block offset in transaction pool maintain
- `insert_blob` interface on pool traits/noop

**Next:** `30dc6d99b fix: fix storage root in progress when livesync+parallel hash (#36)`