### PR TITLE
fix: fix storage root in progress when livesync+parallel hash

### DIFF
--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -6,10 +6,11 @@ use alloy_consensus::{transaction::TxHashRef, BlockHeader};
 use alloy_primitives::B256;
 use alloy_rpc_types_eth::{BlockId, TransactionInfo};
 use futures::Future;
-use reth_errors::{ProviderError, RethError};
+use reth_chainspec::ChainSpecProvider;
+use reth_errors::ProviderError;
 use reth_evm::{
-    block::BlockExecutor, evm::EvmFactoryExt, tracing::TracingCtx, ConfigureEvm, Database, Evm,
-    EvmEnvFor, EvmFor, HaltReasonFor, InspectorFor, TxEnvFor,
+    evm::EvmFactoryExt, system_calls, tracing::TracingCtx, ConfigureEvm, Database, Evm, EvmEnvFor,
+    EvmFor, HaltReasonFor, InspectorFor, TxEnvFor,
 };
 use reth_primitives_traits::{BlockBody, Recovered, RecoveredBlock};
 use reth_revm::{
@@ -179,7 +180,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
             self.spawn_with_state_at_block(parent_block, move |this, mut db| {
                 let block_txs = block.transactions_recovered();
 
-                this.apply_pre_execution_changes(&block, &mut db)?;
+                this.apply_pre_execution_changes(&block, &mut db, evm_env.clone())?;
 
                 // replay all transactions prior to the targeted transaction
                 this.replay_transactions_until(&mut db, evm_env.clone(), block_txs, *tx.tx_hash())?;
@@ -285,7 +286,7 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                 let block_number = evm_env.block_env.number().saturating_to();
                 let base_fee = evm_env.block_env.basefee();
 
-                this.apply_pre_execution_changes(&block, &mut db)?;
+                this.apply_pre_execution_changes(&block, &mut db, evm_env.clone())?;
 
                 // prepare transactions, we do everything upfront to reduce time spent with open
                 // state
@@ -412,12 +413,15 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
         &self,
         block: &RecoveredBlock<ProviderBlock<Self::Provider>>,
         db: &mut StateCacheDb,
+        evm_env: EvmEnvFor<Self::Evm>,
     ) -> Result<(), Self::Error> {
-        self.evm_config()
-            .executor_for_block(db, block.sealed_block())
-            .map_err(RethError::other)
-            .map_err(Self::Error::from_eth_err)?
-            .apply_pre_execution_changes()
+        // BSC does not have a beacon chain, so we only apply EIP-2935 (blockhashes contract),
+        // not EIP-4788 (beacon root contract). Calling apply_pre_execution_changes on the
+        // executor would also invoke apply_beacon_root_contract_call, which fails for BSC blocks
+        // that have no parent_beacon_block_root set.
+        let mut evm = self.evm_config().evm_with_env(&mut *db, evm_env);
+        system_calls::SystemCaller::new(self.provider().chain_spec())
+            .apply_blockhashes_contract_call(block.parent_hash(), &mut evm)
             .map_err(Self::Error::from_eth_err)?;
         Ok(())
     }

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -141,7 +141,7 @@ where
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 let mut results = Vec::with_capacity(block.body().transactions().len());
 
-                eth_api.apply_pre_execution_changes(&block, &mut db)?;
+                eth_api.apply_pre_execution_changes(&block, &mut db, evm_env.clone())?;
 
                 let mut transactions = block.transactions_recovered().enumerate().peekable();
                 let mut inspector = None;
@@ -253,7 +253,7 @@ where
                 // configure env for the target transaction
                 let tx = transaction.into_recovered();
 
-                eth_api.apply_pre_execution_changes(&block, &mut db)?;
+                eth_api.apply_pre_execution_changes(&block, &mut db, evm_env.clone())?;
 
                 // replay all transactions prior to the targeted transaction
                 let index = eth_api.replay_transactions_until(
@@ -588,7 +588,7 @@ where
         self.eth_api()
             .spawn_with_state_at_block(state_at, move |eth_api, mut db| {
                 // 1. apply pre-execution changes
-                eth_api.apply_pre_execution_changes(&block, &mut db)?;
+                eth_api.apply_pre_execution_changes(&block, &mut db, evm_env.clone())?;
 
                 // 2. replay the required number of transactions
                 eth_api.replay_transactions_until(
@@ -669,7 +669,7 @@ where
                 if replay_block_txs {
                     // only need to replay the transactions in the block if not all transactions are
                     // to be replayed
-                    eth_api.apply_pre_execution_changes(&block, &mut db)?;
+                    eth_api.apply_pre_execution_changes(&block, &mut db, evm_env.clone())?;
 
                     let transactions = block.transactions_recovered().take(num_txs);
 
@@ -1067,7 +1067,7 @@ where
                 // Enable transition tracking so that merge_transitions works
                 db.transition_state = Some(Default::default());
 
-                eth_api.apply_pre_execution_changes(&block, &mut db)?;
+                eth_api.apply_pre_execution_changes(&block, &mut db, evm_env.clone())?;
 
                 let mut roots = Vec::with_capacity(block.body().transactions().len());
                 for tx in block.transactions_recovered() {

--- a/crates/trie/parallel/src/root.rs
+++ b/crates/trie/parallel/src/root.rs
@@ -119,6 +119,7 @@ where
                         #[cfg(feature = "metrics")]
                         metrics,
                     )
+                    .with_no_threshold()
                     .calculate(retain_updates)?)
                 })();
                 let _ = tx.send(result);
@@ -169,6 +170,7 @@ where
                                 #[cfg(feature = "metrics")]
                                 self.metrics.storage_trie.clone(),
                             )
+                            .with_no_threshold()
                             .calculate(retain_updates)?
                         }
                     };


### PR DESCRIPTION
Port of commits from the \`develop\` branch.

- \`30dc6d99b fix: fix storage root in progress when livesync+parallel hash (#36)\` — adds \`no_threshold\` to parallel trie root calculation
- \`b257a2454 fix: remove EIP-4788 system call (#38)\` — BSC has no beacon chain, so tracing should only apply EIP-2935 (blockhashes) not EIP-4788 (beacon root). In reth v2, the executor's \`apply_pre_execution_changes\` calls both; this fix uses \`SystemCaller::apply_blockhashes_contract_call\` directly to skip the EIP-4788 call that would fail for BSC blocks with no \`parent_beacon_block_root\`.

**Next:** \`393cf4c96 release: prepare for release v0.0.4 (#40)\`