### PR TITLE
feat(db): port BSC db migration tools and engine config fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7736,6 +7736,7 @@ dependencies = [
  "reth-evm",
  "reth-exex",
  "reth-fs-util",
+ "reth-libmdbx",
  "reth-net-nat",
  "reth-network",
  "reth-network-p2p",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -22,6 +22,7 @@ reth-db = { workspace = true, features = ["mdbx"] }
 reth-db-api.workspace = true
 reth-db-common.workspace = true
 reth-downloaders = { workspace = true, features = ["file-client"] }
+reth-libmdbx.workspace = true
 reth-ecies.workspace = true
 reth-eth-wire.workspace = true
 reth-era.workspace = true

--- a/crates/cli/commands/src/db/mdbx_to_mdbx.rs
+++ b/crates/cli/commands/src/db/mdbx_to_mdbx.rs
@@ -1,0 +1,409 @@
+//! MDBX to MDBX copy tool
+//!
+//! Similar to Erigon's mdbx_to_mdbx implementation, this copies data from one
+//! MDBX database to another, table by table.
+//!
+//! Reference: https://github.com/erigontech/erigon/blob/devel/cmd/integration/commands/backup.go
+
+use clap::Parser;
+use reth_db::DatabaseEnv;
+use reth_db_api::{database::Database, transaction::DbTx};
+use reth_libmdbx::WriteFlags;
+use std::{path::PathBuf, time::Instant};
+use tracing::info;
+
+/// Parse byte size from string (e.g., "4GB", "16KB", "1024")
+fn parse_byte_size(s: &str) -> Result<usize, String> {
+    let s = s.trim().to_uppercase();
+
+    let (num_str, unit) = if let Some(pos) = s.find(|c: char| c.is_alphabetic()) {
+        s.split_at(pos)
+    } else {
+        return s.parse().map_err(|_| "Invalid number".to_string());
+    };
+
+    let num: usize = num_str.trim().parse().map_err(|_| "Invalid number".to_string())?;
+
+    let multiplier = match unit.trim() {
+        "B" | "" => 1,
+        "KB" => 1024,
+        "MB" => 1024 * 1024,
+        "GB" => 1024 * 1024 * 1024,
+        "TB" => 1024 * 1024 * 1024 * 1024,
+        _ => return Err(format!("Invalid unit: {unit}. Use B, KB, MB, GB, or TB.")),
+    };
+
+    Ok(num * multiplier)
+}
+
+/// Format byte size to human-readable string
+fn format_byte_size(bytes: usize) -> String {
+    const KB: usize = 1024;
+    const MB: usize = KB * 1024;
+    const GB: usize = MB * 1024;
+    const TB: usize = GB * 1024;
+
+    if bytes >= TB {
+        format!("{:.2} TB", bytes as f64 / TB as f64)
+    } else if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+/// Arguments for the `reth db mdbx-to-mdbx` command
+#[derive(Parser, Debug)]
+#[command(next_help_heading = "Copy Options")]
+pub struct Command {
+    /// The path to the destination database directory.
+    ///
+    /// The destination directory must not exist; it will be created during the copy process.
+    #[arg(long, value_name = "DEST_PATH", verbatim_doc_comment)]
+    to: PathBuf,
+
+    /// List of specific tables to copy (comma-separated).
+    ///
+    /// If not specified, all tables will be copied.
+    ///
+    /// Example: --tables Headers,Bodies,Transactions
+    #[arg(long, value_delimiter = ',', verbatim_doc_comment)]
+    tables: Vec<String>,
+
+    /// Target database page size (e.g., 4KB, 8KB, 16KB).
+    ///
+    /// Supports units: B, KB, MB, GB, TB.
+    ///
+    /// NOTE: Page size can only be set when creating a new database and cannot be changed later.
+    /// The page size must be a power of 2 between 256 bytes and 64KB (typical range: 4KB-16KB).
+    /// If not specified, uses the system default page size (typically 4KB on Linux, 16KB on
+    /// macOS).
+    ///
+    /// Only used in record-by-record mode (not in --fast mode).
+    #[arg(long, value_parser = parse_byte_size, verbatim_doc_comment)]
+    page_size: Option<usize>,
+
+    /// Target database maximum size (e.g., 4TB, 500GB, 8MB).
+    ///
+    /// Supports units: B, KB, MB, GB, TB.
+    /// If not specified, uses the source database's maximum size.
+    /// Only used in record-by-record mode (not in --fast mode).
+    #[arg(long, value_parser = parse_byte_size, verbatim_doc_comment)]
+    max_size: Option<usize>,
+
+    /// Database growth step (e.g., 4GB, 1GB).
+    ///
+    /// Supports units: B, KB, MB, GB, TB.
+    /// Only used in record-by-record mode (not in --fast mode).
+    #[arg(long, default_value = "4GB", value_parser = parse_byte_size, verbatim_doc_comment)]
+    growth_step: usize,
+
+    /// Use fast mode (MDBX native copy).
+    ///
+    /// Fast mode uses the native MDBX copy API which is much faster but
+    /// ignores custom parameters like --page-size, --max-size, and --growth-step.
+    /// The destination database will have identical parameters to the source.
+    ///
+    /// By default, uses record-by-record copy which allows parameter customization
+    /// but is slower.
+    #[arg(long, verbatim_doc_comment)]
+    fast: bool,
+
+    /// Commit transaction every N records.
+    ///
+    /// Controls how often transactions are committed during the copy process.
+    /// Smaller values use less memory but may be slower.
+    /// Only used in record-by-record mode (not in --fast mode).
+    #[arg(long, default_value = "100000", verbatim_doc_comment)]
+    commit_every: usize,
+
+    /// Skip confirmation prompt.
+    #[arg(long, short)]
+    force: bool,
+
+    /// Suppress progress messages.
+    #[arg(long, short)]
+    quiet: bool,
+}
+
+impl Command {
+    /// Execute the mdbx-to-mdbx copy
+    pub fn execute(
+        &self,
+        src_env: &DatabaseEnv,
+        db_args: &reth_db::mdbx::DatabaseArguments,
+    ) -> eyre::Result<()> {
+        use std::io::Write;
+
+        // Determine mode
+        let mode = if self.fast {
+            "fast (MDBX native copy)"
+        } else {
+            "record-by-record (with parameter customization)"
+        };
+
+        if !self.force {
+            print!("Copy database to {:?}? Mode: {}. (y/N): ", self.to, mode);
+            std::io::stdout().flush()?;
+
+            let mut input = String::new();
+            std::io::stdin().read_line(&mut input)?;
+
+            if !input.trim().eq_ignore_ascii_case("y") {
+                info!("Copy aborted!");
+                return Ok(());
+            }
+        }
+
+        // Ensure destination doesn't exist
+        if self.to.exists() {
+            eyre::bail!("Destination {:?} already exists", self.to);
+        }
+
+        // Ensure parent directory exists
+        if let Some(parent) = self.to.parent() &&
+            !parent.exists()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Starting database copy...");
+            info!(target: "reth::cli", "Mode: {}", mode);
+            info!(target: "reth::cli", "Destination: {:?}", self.to);
+        }
+
+        let start = Instant::now();
+
+        if self.fast {
+            // Fast mode: use MDBX native copy
+            self.execute_fast_copy(src_env)?;
+        } else {
+            // Default mode: record-by-record copy with parameter customization
+            self.execute_custom_copy(src_env, db_args)?;
+        }
+
+        let elapsed = start.elapsed();
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Copy completed in {:.2}s", elapsed.as_secs_f64());
+
+            if let Ok(metadata) = std::fs::metadata(&self.to) {
+                info!(
+                    target: "reth::cli",
+                    "Destination size: {}",
+                    format_byte_size(metadata.len() as usize)
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Fast copy using MDBX native copy API
+    fn execute_fast_copy(&self, src_env: &DatabaseEnv) -> eyre::Result<()> {
+        if !self.quiet {
+            info!(target: "reth::cli", "Using MDBX native copy (ignoring custom parameters)");
+        }
+
+        src_env.copy_to_path(&self.to, false, false)?;
+        Ok(())
+    }
+
+    /// Custom copy with parameter customization
+    fn execute_custom_copy(
+        &self,
+        src_env: &DatabaseEnv,
+        base_db_args: &reth_db::mdbx::DatabaseArguments,
+    ) -> eyre::Result<()> {
+        use reth_db::tables::Tables;
+
+        // Get source database parameters for display
+        let src_info = src_env.info()?;
+        let src_stat = src_env.stat()?;
+        let src_page_size = src_stat.page_size();
+        let src_map_size = src_info.map_size();
+
+        // Start with system database arguments (includes log_level, exclusive, max_readers, etc.)
+        // then override with user-specified parameters
+        let client_version = base_db_args.client_version().clone();
+        let mut dst_args = base_db_args.clone();
+
+        // Determine target parameters
+        // Priority: user specified > system config > source database
+        let max_size_bytes = self.max_size.unwrap_or(src_map_size);
+        let growth_step_bytes = self.growth_step;
+
+        dst_args = dst_args
+            .with_geometry_max_size(Some(max_size_bytes))
+            .with_growth_step(Some(growth_step_bytes));
+
+        // Override page size if user specified it
+        if let Some(page_size) = self.page_size {
+            dst_args = dst_args.with_page_size(Some(page_size));
+        }
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Source database parameters:");
+            info!(
+                target: "reth::cli",
+                "  Page size: {}",
+                format_byte_size(src_page_size as usize)
+            );
+            info!(target: "reth::cli", "  Map size: {}", format_byte_size(src_map_size));
+            info!(target: "reth::cli", "Target database parameters:");
+            if let Some(page_size) = self.page_size {
+                info!(
+                    target: "reth::cli",
+                    "  Page size: {} (custom)",
+                    format_byte_size(page_size)
+                );
+            } else {
+                info!(
+                    target: "reth::cli",
+                    "  Page size: {} (using system default)",
+                    format_byte_size(src_page_size as usize)
+                );
+            }
+            info!(target: "reth::cli", "  Map size: {}", format_byte_size(max_size_bytes));
+            info!(
+                target: "reth::cli",
+                "  Growth step: {}",
+                format_byte_size(growth_step_bytes)
+            );
+            info!(
+                target: "reth::cli",
+                "  (Other settings: log_level, exclusive, max_readers, etc. inherited from system config)"
+            );
+        }
+
+        // Create destination database with custom parameters
+        // We use create_db() instead of init_db() because:
+        // - init_db() pre-creates all tables (unnecessary, wastes time)
+        // - Tables will be automatically created when we open them during copy
+        let dst_env = reth_db::create_db(&self.to, dst_args)?;
+
+        // Record client version for compatibility tracking
+        dst_env.record_client_version(client_version)?;
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Destination database created (tables will be created during copy)");
+        }
+
+        // Determine which tables to copy
+        let tables_to_copy: Vec<String> = if self.tables.is_empty() {
+            Tables::ALL.iter().map(|t| t.name().to_string()).collect()
+        } else {
+            // Validate table names
+            let valid_tables: std::collections::HashSet<&str> =
+                Tables::ALL.iter().map(|t| t.name()).collect();
+
+            for table in &self.tables {
+                if !valid_tables.contains(table.as_str()) {
+                    eyre::bail!("Unknown table: {}", table);
+                }
+            }
+
+            self.tables.clone()
+        };
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Copying {} tables", tables_to_copy.len());
+        }
+
+        // Copy each table using table-specific implementations
+        let total_tables = tables_to_copy.len();
+        for (idx, table_name) in tables_to_copy.iter().enumerate() {
+            if !self.quiet {
+                info!(
+                    target: "reth::cli",
+                    "[{}/{}] Copying table: {}",
+                    idx + 1,
+                    total_tables,
+                    table_name
+                );
+            }
+
+            let table_start = Instant::now();
+            let copied = self.copy_table_generic(src_env, &dst_env, table_name)?;
+            let table_elapsed = table_start.elapsed();
+
+            if !self.quiet && copied > 0 {
+                info!(
+                    target: "reth::cli",
+                    "  Copied {} records in {:.2}s ({:.0} rec/s)",
+                    copied,
+                    table_elapsed.as_secs_f64(),
+                    copied as f64 / table_elapsed.as_secs_f64()
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Copy a table using generic byte-level copying
+    /// This works for all tables but doesn't validate table-specific types
+    fn copy_table_generic(
+        &self,
+        src_env: &DatabaseEnv,
+        dst_env: &DatabaseEnv,
+        table_name: &str,
+    ) -> eyre::Result<usize> {
+        let src_tx = src_env.tx()?;
+        let mut dst_tx = dst_env.tx_mut()?;
+
+        // Open the databases (tables) by name
+        let src_db = src_tx.inner().open_db(Some(table_name))?;
+        let dst_db = dst_tx.inner().open_db(Some(table_name))?;
+
+        // Get cursor for source and destination
+        let src_cursor = src_tx.inner().cursor(src_db.dbi())?;
+        let mut dst_cursor = dst_tx.inner().cursor(dst_db.dbi())?;
+
+        let mut copied = 0usize;
+        let mut batch_count = 0usize;
+        let mut last_progress = Instant::now();
+
+        // Iterate through all records as byte slices
+        for item in src_cursor.iter_slices() {
+            let (key, value) = item?;
+
+            // Insert into destination (convert Cow to slice)
+            // Use APPEND flag for better performance (assumes ordered insert)
+            dst_tx.inner().put(dst_db.dbi(), &key, &value, WriteFlags::APPEND)?;
+            copied += 1;
+            batch_count += 1;
+
+            // Periodic commit
+            if batch_count >= self.commit_every {
+                drop(dst_cursor);
+                dst_tx.commit()?;
+
+                // Start new transaction
+                dst_tx = dst_env.tx_mut()?;
+                let dst_db = dst_tx.inner().open_db(Some(table_name))?;
+                dst_cursor = dst_tx.inner().cursor(dst_db.dbi())?;
+                batch_count = 0;
+
+                // Progress logging
+                if !self.quiet && last_progress.elapsed().as_secs() >= 5 {
+                    info!(target: "reth::cli", "    Progress: {} records", copied);
+                    last_progress = Instant::now();
+                }
+            }
+        }
+
+        // Final commit
+        if batch_count > 0 {
+            drop(dst_cursor);
+            dst_tx.commit()?;
+        }
+
+        Ok(copied)
+    }
+}

--- a/crates/cli/commands/src/db/mdbx_to_mdbx.rs
+++ b/crates/cli/commands/src/db/mdbx_to_mdbx.rs
@@ -3,7 +3,7 @@
 //! Similar to Erigon's mdbx_to_mdbx implementation, this copies data from one
 //! MDBX database to another, table by table.
 //!
-//! Reference: https://github.com/erigontech/erigon/blob/devel/cmd/integration/commands/backup.go
+//! Reference: <https://github.com/erigontech/erigon/blob/devel/cmd/integration/commands/backup.go>
 
 use clap::Parser;
 use reth_db::DatabaseEnv;

--- a/crates/cli/commands/src/db/migrate.rs
+++ b/crates/cli/commands/src/db/migrate.rs
@@ -1,0 +1,329 @@
+//! Database migration tool
+//!
+//! Copies data from one MDBX database to another, table by table.
+//! Allows customization of database parameters (page size, max size, growth step, etc.).
+
+use clap::Parser;
+use reth_db::DatabaseEnv;
+use reth_db_api::{database::Database, transaction::DbTx};
+use reth_libmdbx::WriteFlags;
+use reth_node_core::args::{parse_byte_size, ByteSize};
+use std::{path::PathBuf, time::Instant};
+use tracing::info;
+
+/// Format byte size to human-readable string
+fn format_byte_size(bytes: usize) -> String {
+    ByteSize(bytes).to_string()
+}
+
+/// Arguments for the `reth db migrate` command
+#[derive(Parser, Debug)]
+#[command(next_help_heading = "Copy Options")]
+pub struct Command {
+    /// Destination database directory (must not exist).
+    #[arg(long, value_name = "DEST_PATH")]
+    to: PathBuf,
+
+    /// Specific tables to copy (comma-separated). Example: --tables Headers,Bodies
+    #[arg(long, value_delimiter = ',')]
+    tables: Vec<String>,
+
+    /// Page size (e.g., 4KB, 8KB). Default: system default (typically 4KB).
+    /// NOTE: Can only be set when creating a new database.
+    #[arg(long, value_parser = parse_byte_size, verbatim_doc_comment)]
+    page_size: Option<usize>,
+
+    /// Maximum database size (e.g., 4TB, 12TB). Default: source database size.
+    #[arg(long, value_parser = parse_byte_size)]
+    max_size: Option<usize>,
+
+    /// Database growth step (e.g., 4GB, 8GB).
+    #[arg(long, default_value = "4GB", value_parser = parse_byte_size)]
+    growth_step: usize,
+
+    /// Commit every N records. Smaller = less memory, slower.
+    #[arg(long, default_value = "100000")]
+    commit_every: usize,
+
+    /// Suppress progress messages.
+    #[arg(long, short)]
+    quiet: bool,
+}
+
+impl Command {
+    /// Execute the database migration
+    pub fn execute(
+        &self,
+        src_env: &DatabaseEnv,
+        db_args: &reth_db::mdbx::DatabaseArguments,
+    ) -> eyre::Result<()> {
+        // Ensure destination doesn't exist
+        if self.to.exists() {
+            eyre::bail!("Destination {:?} already exists", self.to);
+        }
+
+        // Ensure parent directory exists
+        if let Some(parent) = self.to.parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Starting database migration...");
+            info!(target: "reth::cli", "Destination: {:?}", self.to);
+        }
+
+        let start = Instant::now();
+        self.execute_custom_copy(src_env, db_args)?;
+
+        let elapsed = start.elapsed();
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Copy completed in {:.2}s", elapsed.as_secs_f64());
+            
+            // Display size comparison
+            let src_size = src_env.info()?.map_size();
+            if let Ok(dst_metadata) = std::fs::metadata(&self.to.join("mdbx.dat")) {
+                let dst_size = dst_metadata.len() as usize;
+                info!(target: "reth::cli", "Source database map size: {}", format_byte_size(src_size));
+                info!(target: "reth::cli", "Destination file size: {}", format_byte_size(dst_size));
+                
+                if dst_size < src_size {
+                    let reduction = ((src_size - dst_size) as f64 / src_size as f64) * 100.0;
+                    info!(target: "reth::cli", 
+                          "Size reduction: {} ({:.2}% smaller due to defragmentation)",
+                          format_byte_size(src_size - dst_size),
+                          reduction);
+                    info!(target: "reth::cli", 
+                          "  Note: This is normal. The copy process eliminates fragmentation,");
+                    info!(target: "reth::cli", 
+                          "  empty pages, and compacts the data structure.");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Execute database copy with parameter customization
+    fn execute_custom_copy(
+        &self,
+        src_env: &DatabaseEnv,
+        base_db_args: &reth_db::mdbx::DatabaseArguments,
+    ) -> eyre::Result<()> {
+        use reth_db::tables::Tables;
+        
+        // Get source database parameters for display
+        let src_info = src_env.info()?;
+        let src_stat = src_env.stat()?;
+        let src_page_size = src_stat.page_size();
+        let src_map_size = src_info.map_size();
+        
+        // Start with system database arguments (includes log_level, exclusive, max_readers, etc.)
+        // then override with user-specified parameters
+        let mut dst_args = base_db_args.clone();
+        
+        // Determine target parameters
+        // Priority: user specified > source database
+        let max_size_bytes = self.max_size.unwrap_or(src_map_size);
+        let growth_step_bytes = self.growth_step;
+        
+        dst_args = dst_args
+            .with_geometry_max_size(Some(max_size_bytes))
+            .with_growth_step(Some(growth_step_bytes));
+        
+        // Override page size if user specified it
+        if let Some(page_size) = self.page_size {
+            dst_args = dst_args.with_page_size(Some(page_size));
+        }
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Source database parameters:");
+            info!(target: "reth::cli", "  Page size: {}", format_byte_size(src_page_size as usize));
+            info!(target: "reth::cli", "  Map size: {}", format_byte_size(src_map_size));
+            info!(target: "reth::cli", "Target database parameters:");
+            if let Some(page_size) = self.page_size {
+                info!(target: "reth::cli", "  Page size: {} (custom)", format_byte_size(page_size));
+            } else {
+                info!(target: "reth::cli", "  Page size: {} (using system default)", 
+                      format_byte_size(src_page_size as usize));
+            }
+            info!(target: "reth::cli", "  Map size: {}", format_byte_size(max_size_bytes));
+            info!(target: "reth::cli", "  Growth step: {}", format_byte_size(growth_step_bytes));
+            info!(target: "reth::cli", "  (Other settings: log_level, exclusive, max_readers, etc. inherited from system config)");
+        }
+
+        // Create destination database and initialize all tables
+        // Using init_db() to properly create all tables and record client version
+        let dst_env = reth_db::init_db(&self.to, dst_args)?;
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Destination database initialized");
+        }
+
+        // Determine which tables to copy
+        let tables_to_copy: Vec<String> = if self.tables.is_empty() {
+            Tables::ALL.iter().map(|t| t.name().to_string()).collect()
+        } else {
+            // Validate table names
+            let valid_tables: std::collections::HashSet<&str> = 
+                Tables::ALL.iter().map(|t| t.name()).collect();
+            
+            for table in &self.tables {
+                if !valid_tables.contains(table.as_str()) {
+                    eyre::bail!("Unknown table: {}", table);
+                }
+            }
+            
+            self.tables.clone()
+        };
+
+        if !self.quiet {
+            info!(target: "reth::cli", "Copying {} tables", tables_to_copy.len());
+            if !self.tables.is_empty() {
+                info!(target: "reth::cli", "  Note: Only copying selected tables. Other tables will be empty.");
+            }
+        }
+
+        // Copy each table using table-specific implementations
+        let total_tables = tables_to_copy.len();
+        for (idx, table_name) in tables_to_copy.iter().enumerate() {
+            if !self.quiet {
+                info!(target: "reth::cli", "[{}/{}] Copying table: {}", 
+                      idx + 1, total_tables, table_name);
+            }
+            
+            self.copy_table_generic(src_env, &dst_env, table_name)?;
+        }
+
+        Ok(())
+    }
+
+    /// Copy a table using generic byte-level copying
+    /// This works for all tables but doesn't validate table-specific types
+    fn copy_table_generic(
+        &self,
+        src_env: &DatabaseEnv,
+        dst_env: &DatabaseEnv,
+        table_name: &str,
+    ) -> eyre::Result<usize> {
+        let mut src_tx = src_env.tx()?;
+        
+        // Disable timeout for long-running read transaction during copy
+        // This is necessary because copying large tables can take a very long time
+        src_tx.disable_long_read_transaction_safety();
+        
+        let mut dst_tx = dst_env.tx_mut()?;
+        
+        // Open the databases (tables) by name
+        // Source: read-only, use open_db() - table must exist
+        let src_db = src_tx.inner.open_db(Some(table_name))?;
+        // Destination: tables are already created by init_db(), just open them
+        let dst_db = dst_tx.inner.open_db(Some(table_name))?;
+        
+        // Clear destination table before copying
+        // This is necessary because:
+        // 1. init_db() may have pre-populated some tables (e.g., VersionHistory)
+        // 2. APPEND flag requires an empty table or strictly ordered keys
+        dst_tx.inner.clear_db(dst_db.dbi())?;
+        
+        // Get total number of entries for progress calculation
+        let total_entries = src_tx.inner.db_stat(&src_db)?.entries();
+        
+        if !self.quiet {
+            info!(
+                target: "reth::cli",
+                "  Starting copy of table '{}' ({} records)",
+                table_name,
+                total_entries
+            );
+        }
+        
+        // Get cursor for source and destination
+        let src_cursor = src_tx.inner.cursor(&src_db)?;
+        let mut dst_cursor = dst_tx.inner.cursor(&dst_db)?;
+        
+        let mut copied = 0usize;
+        let mut batch_count = 0usize;
+        let mut last_progress = Instant::now();
+        let start_time = Instant::now();
+        
+        // Iterate through all records as byte slices
+        for item in src_cursor.iter_slices() {
+            let (key, value) = item?;
+            
+            // Insert into destination (convert Cow to slice)
+            // Use APPEND flag for better performance (assumes ordered insert)
+            dst_tx.inner.put(dst_db.dbi(), &key, &value, WriteFlags::APPEND)?;
+            copied += 1;
+            batch_count += 1;
+            
+            // Periodic commit
+            if batch_count >= self.commit_every {
+                drop(dst_cursor);
+                dst_tx.commit()?;
+                
+                // Start new transaction
+                dst_tx = dst_env.tx_mut()?;
+                // Re-open destination table (already created, but need handle in new transaction)
+                let dst_db = dst_tx.inner.open_db(Some(table_name))?;
+                dst_cursor = dst_tx.inner.cursor(&dst_db)?;
+                batch_count = 0;
+                
+                // Progress logging
+                if !self.quiet && last_progress.elapsed().as_secs() >= 5 {
+                    let percentage = if total_entries > 0 {
+                        (copied as f64 / total_entries as f64 * 100.0).min(100.0)
+                    } else {
+                        0.0
+                    };
+                    info!(
+                        target: "reth::cli", 
+                        "    Progress: {}/{} records ({:.2}%)", 
+                        copied, 
+                        total_entries,
+                        percentage
+                    );
+                    last_progress = Instant::now();
+                }
+            }
+        }
+        
+        // Final commit
+        if batch_count > 0 {
+            drop(dst_cursor);
+            dst_tx.commit()?;
+        }
+        
+        // Log completion
+        if !self.quiet {
+            let elapsed = start_time.elapsed();
+            let rate = if elapsed.as_secs() > 0 {
+                copied as f64 / elapsed.as_secs() as f64
+            } else {
+                copied as f64
+            };
+            
+            if copied == 0 {
+                info!(
+                    target: "reth::cli",
+                    "  Completed table '{}': empty table",
+                    table_name
+                );
+            } else {
+                info!(
+                    target: "reth::cli",
+                    "  Completed table '{}': {} records in {:.2}s ({:.0} records/sec)",
+                    table_name,
+                    copied,
+                    elapsed.as_secs_f64(),
+                    rate
+                );
+            }
+        }
+        
+        Ok(copied)
+    }
+}
+

--- a/crates/cli/commands/src/db/migrate.rs
+++ b/crates/cli/commands/src/db/migrate.rs
@@ -63,10 +63,10 @@ impl Command {
         }
 
         // Ensure parent directory exists
-        if let Some(parent) = self.to.parent() {
-            if !parent.exists() {
-                std::fs::create_dir_all(parent)?;
-            }
+        if let Some(parent) = self.to.parent() &&
+            !parent.exists()
+        {
+            std::fs::create_dir_all(parent)?;
         }
 
         if !self.quiet {
@@ -81,14 +81,14 @@ impl Command {
 
         if !self.quiet {
             info!(target: "reth::cli", "Copy completed in {:.2}s", elapsed.as_secs_f64());
-            
+
             // Display size comparison
             let src_size = src_env.info()?.map_size();
-            if let Ok(dst_metadata) = std::fs::metadata(&self.to.join("mdbx.dat")) {
+            if let Ok(dst_metadata) = std::fs::metadata(self.to.join("mdbx.dat")) {
                 let dst_size = dst_metadata.len() as usize;
                 info!(target: "reth::cli", "Source database map size: {}", format_byte_size(src_size));
                 info!(target: "reth::cli", "Destination file size: {}", format_byte_size(dst_size));
-                
+
                 if dst_size < src_size {
                     let reduction = ((src_size - dst_size) as f64 / src_size as f64) * 100.0;
                     info!(target: "reth::cli", 
@@ -113,26 +113,26 @@ impl Command {
         base_db_args: &reth_db::mdbx::DatabaseArguments,
     ) -> eyre::Result<()> {
         use reth_db::tables::Tables;
-        
+
         // Get source database parameters for display
         let src_info = src_env.info()?;
         let src_stat = src_env.stat()?;
         let src_page_size = src_stat.page_size();
         let src_map_size = src_info.map_size();
-        
+
         // Start with system database arguments (includes log_level, exclusive, max_readers, etc.)
         // then override with user-specified parameters
         let mut dst_args = base_db_args.clone();
-        
+
         // Determine target parameters
         // Priority: user specified > source database
         let max_size_bytes = self.max_size.unwrap_or(src_map_size);
         let growth_step_bytes = self.growth_step;
-        
+
         dst_args = dst_args
             .with_geometry_max_size(Some(max_size_bytes))
             .with_growth_step(Some(growth_step_bytes));
-        
+
         // Override page size if user specified it
         if let Some(page_size) = self.page_size {
             dst_args = dst_args.with_page_size(Some(page_size));
@@ -167,15 +167,15 @@ impl Command {
             Tables::ALL.iter().map(|t| t.name().to_string()).collect()
         } else {
             // Validate table names
-            let valid_tables: std::collections::HashSet<&str> = 
+            let valid_tables: std::collections::HashSet<&str> =
                 Tables::ALL.iter().map(|t| t.name()).collect();
-            
+
             for table in &self.tables {
                 if !valid_tables.contains(table.as_str()) {
                     eyre::bail!("Unknown table: {}", table);
                 }
             }
-            
+
             self.tables.clone()
         };
 
@@ -193,7 +193,7 @@ impl Command {
                 info!(target: "reth::cli", "[{}/{}] Copying table: {}", 
                       idx + 1, total_tables, table_name);
             }
-            
+
             self.copy_table_generic(src_env, &dst_env, table_name)?;
         }
 
@@ -209,28 +209,28 @@ impl Command {
         table_name: &str,
     ) -> eyre::Result<usize> {
         let mut src_tx = src_env.tx()?;
-        
+
         // Disable timeout for long-running read transaction during copy
         // This is necessary because copying large tables can take a very long time
         src_tx.disable_long_read_transaction_safety();
-        
+
         let mut dst_tx = dst_env.tx_mut()?;
-        
+
         // Open the databases (tables) by name
         // Source: read-only, use open_db() - table must exist
-        let src_db = src_tx.inner.open_db(Some(table_name))?;
+        let src_db = src_tx.inner().open_db(Some(table_name))?;
         // Destination: tables are already created by init_db(), just open them
-        let dst_db = dst_tx.inner.open_db(Some(table_name))?;
-        
+        let dst_db = dst_tx.inner().open_db(Some(table_name))?;
+
         // Clear destination table before copying
         // This is necessary because:
         // 1. init_db() may have pre-populated some tables (e.g., VersionHistory)
         // 2. APPEND flag requires an empty table or strictly ordered keys
-        dst_tx.inner.clear_db(dst_db.dbi())?;
-        
+        dst_tx.inner().clear_db(dst_db.dbi())?;
+
         // Get total number of entries for progress calculation
-        let total_entries = src_tx.inner.db_stat(&src_db)?.entries();
-        
+        let total_entries = src_tx.inner().db_stat(src_db.dbi())?.entries();
+
         if !self.quiet {
             info!(
                 target: "reth::cli",
@@ -239,38 +239,38 @@ impl Command {
                 total_entries
             );
         }
-        
+
         // Get cursor for source and destination
-        let src_cursor = src_tx.inner.cursor(&src_db)?;
-        let mut dst_cursor = dst_tx.inner.cursor(&dst_db)?;
-        
+        let src_cursor = src_tx.inner().cursor(src_db.dbi())?;
+        let mut dst_cursor = dst_tx.inner().cursor(dst_db.dbi())?;
+
         let mut copied = 0usize;
         let mut batch_count = 0usize;
         let mut last_progress = Instant::now();
         let start_time = Instant::now();
-        
+
         // Iterate through all records as byte slices
         for item in src_cursor.iter_slices() {
             let (key, value) = item?;
-            
+
             // Insert into destination (convert Cow to slice)
             // Use APPEND flag for better performance (assumes ordered insert)
-            dst_tx.inner.put(dst_db.dbi(), &key, &value, WriteFlags::APPEND)?;
+            dst_tx.inner().put(dst_db.dbi(), &key, &value, WriteFlags::APPEND)?;
             copied += 1;
             batch_count += 1;
-            
+
             // Periodic commit
             if batch_count >= self.commit_every {
                 drop(dst_cursor);
                 dst_tx.commit()?;
-                
+
                 // Start new transaction
                 dst_tx = dst_env.tx_mut()?;
                 // Re-open destination table (already created, but need handle in new transaction)
-                let dst_db = dst_tx.inner.open_db(Some(table_name))?;
-                dst_cursor = dst_tx.inner.cursor(&dst_db)?;
+                let dst_db = dst_tx.inner().open_db(Some(table_name))?;
+                dst_cursor = dst_tx.inner().cursor(dst_db.dbi())?;
                 batch_count = 0;
-                
+
                 // Progress logging
                 if !self.quiet && last_progress.elapsed().as_secs() >= 5 {
                     let percentage = if total_entries > 0 {
@@ -279,9 +279,9 @@ impl Command {
                         0.0
                     };
                     info!(
-                        target: "reth::cli", 
-                        "    Progress: {}/{} records ({:.2}%)", 
-                        copied, 
+                        target: "reth::cli",
+                        "    Progress: {}/{} records ({:.2}%)",
+                        copied,
                         total_entries,
                         percentage
                     );
@@ -289,13 +289,13 @@ impl Command {
                 }
             }
         }
-        
+
         // Final commit
         if batch_count > 0 {
             drop(dst_cursor);
             dst_tx.commit()?;
         }
-        
+
         // Log completion
         if !self.quiet {
             let elapsed = start_time.elapsed();
@@ -304,7 +304,7 @@ impl Command {
             } else {
                 copied as f64
             };
-            
+
             if copied == 0 {
                 info!(
                     target: "reth::cli",
@@ -322,8 +322,7 @@ impl Command {
                 );
             }
         }
-        
+
         Ok(copied)
     }
 }
-

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -16,6 +16,7 @@ mod copy;
 mod diff;
 mod get;
 mod list;
+mod migrate;
 mod prune_checkpoints;
 mod repair_trie;
 mod settings;
@@ -59,6 +60,8 @@ pub enum Subcommands {
     },
     /// Deletes all table entries
     Clear(clear::Command),
+    /// Migrate database to another location
+    Migrate(migrate::Command),
     /// Verifies trie consistency and outputs any inconsistencies
     RepairTrie(repair_trie::Command),
     /// Reads and displays the static file segment header
@@ -174,6 +177,13 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
             Subcommands::Clear(command) => {
                 db_exec!(self.env, tool, N, AccessRights::RW, {
                     command.execute(&tool)?;
+                });
+            }
+            Subcommands::Migrate(command) => {
+                // Get database arguments from system configuration
+                let db_args = self.env.db.database_args();
+                db_ro_exec!(self.env, tool, N, {
+                    command.execute(tool.provider_factory.db_ref(), &db_args)?;
                 });
             }
             Subcommands::RepairTrie(command) => {

--- a/crates/cli/commands/src/db/mod.rs
+++ b/crates/cli/commands/src/db/mod.rs
@@ -16,6 +16,7 @@ mod copy;
 mod diff;
 mod get;
 mod list;
+mod mdbx_to_mdbx;
 mod migrate;
 mod prune_checkpoints;
 mod repair_trie;
@@ -62,6 +63,8 @@ pub enum Subcommands {
     Clear(clear::Command),
     /// Migrate database to another location
     Migrate(migrate::Command),
+    /// Copy database to another location (mdbx-to-mdbx)
+    MdbxToMdbx(mdbx_to_mdbx::Command),
     /// Verifies trie consistency and outputs any inconsistencies
     RepairTrie(repair_trie::Command),
     /// Reads and displays the static file segment header
@@ -182,7 +185,14 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
             Subcommands::Migrate(command) => {
                 // Get database arguments from system configuration
                 let db_args = self.env.db.database_args();
-                db_ro_exec!(self.env, tool, N, {
+                db_exec!(self.env, tool, N, AccessRights::RO, {
+                    command.execute(tool.provider_factory.db_ref(), &db_args)?;
+                });
+            }
+            Subcommands::MdbxToMdbx(command) => {
+                // Get database arguments from system configuration
+                let db_args = self.env.db.database_args();
+                db_exec!(self.env, tool, N, AccessRights::RO, {
                     command.execute(tool.provider_factory.db_ref(), &db_args)?;
                 });
             }

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -67,6 +67,31 @@ const fn default_cross_block_cache_size() -> usize {
     }
 }
 
+/// Minimum number of workers we allow configuring explicitly.
+pub const MIN_WORKER_COUNT: usize = 32;
+
+/// Returns the default number of storage worker threads based on available parallelism.
+fn default_storage_worker_count() -> usize {
+    #[cfg(feature = "std")]
+    {
+        std::thread::available_parallelism().map_or(8, |n| n.get() * 2).min(MIN_WORKER_COUNT)
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        8
+    }
+}
+
+/// Returns the default number of account worker threads.
+///
+/// Set to the same count as storage workers for simplicity.
+fn default_account_worker_count() -> usize {
+    default_storage_worker_count()
+}
+
+/// Default minimum blocks for pipeline run (32 blocks = `EPOCH_SLOTS`)
+pub const DEFAULT_MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = 32;
+
 /// Determines if the host has enough parallelism to run the payload processor.
 ///
 /// It requires at least 5 parallel threads:
@@ -175,6 +200,20 @@ pub struct TreeConfig {
     /// before starting a proof calculation.
     #[cfg(feature = "trie-debug")]
     proof_jitter: Option<Duration>,
+    /// Number of storage proof worker threads.
+    storage_worker_count: usize,
+    /// Number of account proof worker threads.
+    account_worker_count: usize,
+    /// Whether to enable V2 storage proofs.
+    enable_proof_v2: bool,
+    /// Skip state root validation for fastnode mode.
+    /// This disables validation of state root hashes during live sync.
+    skip_state_root_validation: bool,
+    /// The minimum number of blocks required to trigger a pipeline run for backfilling.
+    ///
+    /// When the local head is behind the forkchoice head by more than this threshold,
+    /// the pipeline will be used to backfill blocks instead of downloading them individually.
+    min_blocks_for_pipeline_run: u64,
 }
 
 impl Default for TreeConfig {
@@ -214,6 +253,11 @@ impl Default for TreeConfig {
             share_sparse_trie_with_payload_builder: false,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
+            storage_worker_count: default_storage_worker_count(),
+            account_worker_count: default_account_worker_count(),
+            enable_proof_v2: false,
+            skip_state_root_validation: false,
+            min_blocks_for_pipeline_run: DEFAULT_MIN_BLOCKS_FOR_PIPELINE_RUN,
         }
     }
 }
@@ -249,6 +293,11 @@ impl TreeConfig {
         state_root_task_timeout: Option<Duration>,
         share_execution_cache_with_payload_builder: bool,
         share_sparse_trie_with_payload_builder: bool,
+        storage_worker_count: usize,
+        account_worker_count: usize,
+        enable_proof_v2: bool,
+        skip_state_root_validation: bool,
+        min_blocks_for_pipeline_run: u64,
     ) -> Self {
         assert_backpressure_threshold_invariant(
             persistence_threshold,
@@ -285,6 +334,11 @@ impl TreeConfig {
             share_sparse_trie_with_payload_builder,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
+            storage_worker_count,
+            account_worker_count,
+            enable_proof_v2,
+            skip_state_root_validation,
+            min_blocks_for_pipeline_run,
         }
     }
 
@@ -527,6 +581,69 @@ impl TreeConfig {
         self.allow_unwind_canonical_header = unwind_canonical_header;
         self
     }
+
+
+    /// Returns the number of storage proof worker threads.
+    pub const fn storage_worker_count(&self) -> usize {
+        self.storage_worker_count
+    }
+
+    /// Setter for the number of storage proof worker threads.
+    pub fn with_storage_worker_count(mut self, storage_worker_count: usize) -> Self {
+        self.storage_worker_count = storage_worker_count;
+        self
+    }
+
+    /// Returns the number of account proof worker threads.
+    pub const fn account_worker_count(&self) -> usize {
+        self.account_worker_count
+    }
+
+    /// Setter for the number of account proof worker threads.
+    pub fn with_account_worker_count(mut self, account_worker_count: usize) -> Self {
+        self.account_worker_count = account_worker_count;
+        self
+    }
+
+    /// Returns whether V2 storage proofs are enabled.
+    pub const fn enable_proof_v2(&self) -> bool {
+        self.enable_proof_v2
+    }
+
+    /// Setter for whether to enable V2 storage proofs.
+    pub const fn with_enable_proof_v2(mut self, enable_proof_v2: bool) -> Self {
+        self.enable_proof_v2 = enable_proof_v2;
+        self
+    }
+
+    /// Setter for whether to skip state root validation.
+    pub const fn with_skip_state_root_validation(
+        mut self,
+        skip_state_root_validation: bool,
+    ) -> Self {
+        self.skip_state_root_validation = skip_state_root_validation;
+        self
+    }
+
+    /// Returns whether state root validation should be skipped.
+    pub const fn skip_state_root_validation(&self) -> bool {
+        self.skip_state_root_validation
+    }
+
+    /// Returns the minimum number of blocks required to trigger a pipeline run.
+    pub const fn min_blocks_for_pipeline_run(&self) -> u64 {
+        self.min_blocks_for_pipeline_run
+    }
+
+    /// Setter for minimum number of blocks required to trigger a pipeline run.
+    pub const fn with_min_blocks_for_pipeline_run(
+        mut self,
+        min_blocks_for_pipeline_run: u64,
+    ) -> Self {
+        self.min_blocks_for_pipeline_run = min_blocks_for_pipeline_run;
+        self
+    }
+
 
     /// Whether or not to use state root task
     pub const fn use_state_root_task(&self) -> bool {

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -582,14 +582,13 @@ impl TreeConfig {
         self
     }
 
-
     /// Returns the number of storage proof worker threads.
     pub const fn storage_worker_count(&self) -> usize {
         self.storage_worker_count
     }
 
     /// Setter for the number of storage proof worker threads.
-    pub fn with_storage_worker_count(mut self, storage_worker_count: usize) -> Self {
+    pub const fn with_storage_worker_count(mut self, storage_worker_count: usize) -> Self {
         self.storage_worker_count = storage_worker_count;
         self
     }
@@ -600,7 +599,7 @@ impl TreeConfig {
     }
 
     /// Setter for the number of account proof worker threads.
-    pub fn with_account_worker_count(mut self, account_worker_count: usize) -> Self {
+    pub const fn with_account_worker_count(mut self, account_worker_count: usize) -> Self {
         self.account_worker_count = account_worker_count;
         self
     }
@@ -643,7 +642,6 @@ impl TreeConfig {
         self.min_blocks_for_pipeline_run = min_blocks_for_pipeline_run;
         self
     }
-
 
     /// Whether or not to use state root task
     pub const fn use_state_root_task(&self) -> bool {

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -6,9 +6,8 @@ use crate::{
     tree::{error::InsertPayloadError, payload_validator::TreeCtx},
 };
 use alloy_consensus::BlockHeader;
-use alloy_eips::{eip1898::BlockWithParent, merge::EPOCH_SLOTS, BlockNumHash, NumHash};
-use alloy_evm::block::StateChangeSource;
-use alloy_primitives::{B256, BlockHash, BlockNumber};
+use alloy_eips::{eip1898::BlockWithParent, BlockNumHash, NumHash};
+use alloy_primitives::{BlockHash, BlockNumber, B256};
 use alloy_rpc_types_engine::{
     ForkchoiceState, PayloadStatus, PayloadStatusEnum, PayloadValidationError,
 };
@@ -88,8 +87,8 @@ pub mod state;
 /// an epoch has slots), then this exceeds the threshold at which the pipeline should be used to
 /// backfill this gap.
 ///
-/// This is kept for backwards compatibility with tests. Use `TreeConfig::min_blocks_for_pipeline_run()`
-/// for configurable threshold.
+/// This is kept for backwards compatibility with tests. Use
+/// `TreeConfig::min_blocks_for_pipeline_run()` for configurable threshold.
 #[cfg(test)]
 pub(crate) const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = DEFAULT_MIN_BLOCKS_FOR_PIPELINE_RUN;
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -7,7 +7,8 @@ use crate::{
 };
 use alloy_consensus::BlockHeader;
 use alloy_eips::{eip1898::BlockWithParent, merge::EPOCH_SLOTS, BlockNumHash, NumHash};
-use alloy_primitives::{BlockHash, BlockNumber, B256};
+use alloy_evm::block::StateChangeSource;
+use alloy_primitives::{B256, BlockHash, BlockNumber};
 use alloy_rpc_types_engine::{
     ForkchoiceState, PayloadStatus, PayloadStatusEnum, PayloadValidationError,
 };
@@ -70,7 +71,7 @@ pub use metrics::EngineApiMetrics;
 pub use payload_processor::*;
 pub use payload_validator::{BasicEngineValidator, EngineValidator};
 pub use persistence_state::PersistenceState;
-pub use reth_engine_primitives::TreeConfig;
+pub use reth_engine_primitives::{TreeConfig, DEFAULT_MIN_BLOCKS_FOR_PIPELINE_RUN};
 pub use reth_execution_cache::{
     CachedStateMetrics, CachedStateProvider, ExecutionCache, PayloadExecutionCache, SavedCache,
 };
@@ -86,7 +87,11 @@ pub mod state;
 /// E.g.: Local head `block.number` is 100 and the forkchoice head `block.number` is 133 (more than
 /// an epoch has slots), then this exceeds the threshold at which the pipeline should be used to
 /// backfill this gap.
-pub(crate) const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = EPOCH_SLOTS;
+///
+/// This is kept for backwards compatibility with tests. Use `TreeConfig::min_blocks_for_pipeline_run()`
+/// for configurable threshold.
+#[cfg(test)]
+pub(crate) const MIN_BLOCKS_FOR_PIPELINE_RUN: u64 = DEFAULT_MIN_BLOCKS_FOR_PIPELINE_RUN;
 
 /// The minimum number of blocks to retain in the changeset cache after eviction.
 ///
@@ -2462,8 +2467,8 @@ where
     ///
     /// If the `local_tip` is greater than the `block`, then this will return false.
     #[inline]
-    const fn exceeds_backfill_run_threshold(&self, local_tip: u64, block: u64) -> bool {
-        block > local_tip && block - local_tip > MIN_BLOCKS_FOR_PIPELINE_RUN
+    fn exceeds_backfill_run_threshold(&self, local_tip: u64, block: u64) -> bool {
+        block > local_tip && block - local_tip > self.config.min_blocks_for_pipeline_run()
     }
 
     /// Returns how far the local tip is from the given block. If the local tip is at the same

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2466,7 +2466,7 @@ where
     ///
     /// If the `local_tip` is greater than the `block`, then this will return false.
     #[inline]
-    fn exceeds_backfill_run_threshold(&self, local_tip: u64, block: u64) -> bool {
+    const fn exceeds_backfill_run_threshold(&self, local_tip: u64, block: u64) -> bool {
         block > local_tip && block - local_tip > self.config.min_blocks_for_pipeline_run()
     }
 

--- a/crates/node/core/src/args/database.rs
+++ b/crates/node/core/src/args/database.rs
@@ -84,6 +84,7 @@ impl DatabaseArgs {
             .with_log_level(self.log_level)
             .with_exclusive(self.exclusive)
             .with_max_read_transaction_duration(max_read_transaction_duration)
+            .with_page_size(self.page_size)
             .with_geometry_max_size(self.max_size)
             .with_geometry_page_size(self.page_size)
             .with_growth_step(self.growth_step)
@@ -199,7 +200,7 @@ impl fmt::Display for ByteSize {
 }
 
 /// Value parser function that supports various formats.
-fn parse_byte_size(s: &str) -> Result<usize, String> {
+pub fn parse_byte_size(s: &str) -> Result<usize, String> {
     s.parse::<ByteSize>().map(Into::into)
 }
 

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -13,6 +13,7 @@ use crate::node_config::{
     DEFAULT_CROSS_BLOCK_CACHE_SIZE_MB, DEFAULT_MEMORY_BLOCK_BUFFER_TARGET,
     DEFAULT_PERSISTENCE_THRESHOLD, DEFAULT_RESERVED_CPU_CORES,
 };
+use reth_engine_primitives::DEFAULT_MIN_BLOCKS_FOR_PIPELINE_RUN;
 
 /// Global static engine defaults
 static ENGINE_DEFAULTS: OnceLock<DefaultEngineValues> = OnceLock::new();
@@ -49,6 +50,8 @@ pub struct DefaultEngineValues {
     state_root_task_timeout: Option<String>,
     share_execution_cache_with_payload_builder: bool,
     share_sparse_trie_with_payload_builder: bool,
+    /// Whether to enable V2 storage proofs by default.
+    enable_proof_v2: bool,
 }
 
 impl DefaultEngineValues {
@@ -226,6 +229,12 @@ impl DefaultEngineValues {
         self.share_sparse_trie_with_payload_builder = v;
         self
     }
+
+    /// Set whether to enable V2 storage proofs by default
+    pub const fn with_enable_proof_v2(mut self, v: bool) -> Self {
+        self.enable_proof_v2 = v;
+        self
+    }
 }
 
 impl Default for DefaultEngineValues {
@@ -258,6 +267,7 @@ impl Default for DefaultEngineValues {
             state_root_task_timeout: Some("1s".to_string()),
             share_execution_cache_with_payload_builder: false,
             share_sparse_trie_with_payload_builder: false,
+            enable_proof_v2: false,
         }
     }
 }
@@ -471,6 +481,20 @@ pub struct EngineArgs {
         value_parser = humantime::parse_duration,
     )]
     pub proof_jitter: Option<Duration>,
+
+    /// Skip state root validation for fastnode mode.
+    #[arg(long = "engine.skip-state-root-validation", default_value_t = false)]
+    pub skip_state_root_validation: bool,
+
+    /// Configure the minimum number of blocks required to trigger a pipeline run for backfilling.
+    /// When the local head is behind the forkchoice head by more than this threshold,
+    /// the pipeline will be used to backfill blocks instead of downloading them individually.
+    #[arg(long = "engine.min-blocks-for-pipeline-run", default_value_t = DEFAULT_MIN_BLOCKS_FOR_PIPELINE_RUN)]
+    pub min_blocks_for_pipeline_run: u64,
+
+    /// Enable V2 storage proofs for state root calculations
+    #[arg(long = "engine.enable-proof-v2", default_value_t = DefaultEngineValues::get_global().enable_proof_v2)]
+    pub enable_proof_v2: bool,
 }
 
 #[allow(deprecated)]
@@ -504,6 +528,7 @@ impl Default for EngineArgs {
             state_root_task_timeout,
             share_execution_cache_with_payload_builder,
             share_sparse_trie_with_payload_builder,
+            enable_proof_v2,
         } = DefaultEngineValues::get_global().clone();
         Self {
             persistence_threshold,
@@ -541,6 +566,9 @@ impl Default for EngineArgs {
             share_sparse_trie_with_payload_builder,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
+            skip_state_root_validation: false,
+            min_blocks_for_pipeline_run: DEFAULT_MIN_BLOCKS_FOR_PIPELINE_RUN,
+            enable_proof_v2,
         }
     }
 }
@@ -559,7 +587,7 @@ impl EngineArgs {
 
     /// Creates a [`TreeConfig`] from the engine arguments.
     pub fn tree_config(&self) -> TreeConfig {
-        let config = TreeConfig::default()
+        let mut config = TreeConfig::default()
             .with_persistence_threshold(self.persistence_threshold)
             .with_persistence_backpressure_threshold(self.persistence_backpressure_threshold)
             .with_memory_block_buffer_target(self.memory_block_buffer_target)
@@ -588,7 +616,16 @@ impl EngineArgs {
             )
             .with_share_sparse_trie_with_payload_builder(
                 self.share_sparse_trie_with_payload_builder,
-            );
+            )
+            .with_skip_state_root_validation(self.skip_state_root_validation)
+            .with_min_blocks_for_pipeline_run(self.min_blocks_for_pipeline_run)
+            .with_enable_proof_v2(self.enable_proof_v2);
+        if let Some(count) = self.storage_worker_count {
+            config = config.with_storage_worker_count(count);
+        }
+        if let Some(count) = self.account_worker_count {
+            config = config.with_account_worker_count(count);
+        }
         #[cfg(feature = "trie-debug")]
         let config = config.with_proof_jitter(self.proof_jitter);
         config
@@ -651,6 +688,9 @@ mod tests {
             share_sparse_trie_with_payload_builder: false,
             #[cfg(feature = "trie-debug")]
             proof_jitter: None,
+            skip_state_root_validation: false,
+            min_blocks_for_pipeline_run: DEFAULT_MIN_BLOCKS_FOR_PIPELINE_RUN,
+            enable_proof_v2: false,
         };
 
         let parsed_args = CommandParser::<EngineArgs>::parse_from([

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -18,7 +18,7 @@ pub use debug::{DebugArgs, InvalidBlockHookType, InvalidBlockSelection};
 
 /// DatabaseArgs struct for configuring the database
 mod database;
-pub use database::DatabaseArgs;
+pub use database::{parse_byte_size, ByteSize, DatabaseArgs};
 
 /// LogArgs struct for configuring the logger
 mod log;

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -647,7 +647,7 @@ impl DatabaseEnv {
 
     /// Copy the database to the specified path.
     ///
-    /// This is a wrapper around MDBX's native copy, similar to Erigon's mdbx_to_mdbx
+    /// This is a wrapper around MDBX's native copy, similar to Erigon's `mdbx_to_mdbx`
     /// but using the high-performance C implementation instead of record-by-record copying.
     pub fn copy_to_path(
         &self,

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -198,6 +198,16 @@ impl DatabaseArguments {
         self
     }
 
+    /// Sets the page size for the database.
+    ///
+    /// Note: Page size can only be set when creating a new database and cannot be changed later.
+    pub const fn with_page_size(mut self, page_size: Option<usize>) -> Self {
+        if let Some(page_size) = page_size {
+            self.geometry.page_size = Some(PageSize::Set(page_size));
+        }
+        self
+    }
+
     /// Set the log level.
     pub const fn with_log_level(mut self, log_level: Option<LogLevel>) -> Self {
         self.log_level = log_level;

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -645,6 +645,21 @@ impl DatabaseEnv {
         }
     }
 
+    /// Copy the database to the specified path.
+    ///
+    /// This is a wrapper around MDBX's native copy, similar to Erigon's mdbx_to_mdbx
+    /// but using the high-performance C implementation instead of record-by-record copying.
+    pub fn copy_to_path(
+        &self,
+        dest_path: &Path,
+        compact: bool,
+        force_dynamic: bool,
+    ) -> Result<(), DatabaseError> {
+        self.inner
+            .copy_to_path(dest_path, compact, force_dynamic)
+            .map_err(|e| DatabaseError::Other(format!("Failed to copy database: {}", e)))
+    }
+
     /// Records version that accesses the database with write privileges.
     pub fn record_client_version(&self, version: ClientVersion) -> Result<(), DatabaseError> {
         if version.is_empty() {

--- a/crates/storage/libmdbx-rs/src/environment.rs
+++ b/crates/storage/libmdbx-rs/src/environment.rs
@@ -237,6 +237,33 @@ impl Environment {
 
         Ok(freelist)
     }
+
+    /// Copy the environment to the specified path.
+    ///
+    /// This uses MDBX's native copy functionality for optimal performance.
+    /// Similar to Erigon's `mdbx_to_mdbx` but uses the underlying C implementation.
+    ///
+    /// # Arguments
+    ///
+    /// * `dest_path` - Destination path for the copied database
+    /// * `compact` - If true, omit free pages (compaction)
+    /// * `force_dynamic` - If true, make the copy resizable
+    pub fn copy_to_path(&self, dest_path: &Path, compact: bool, force_dynamic: bool) -> Result<()> {
+        let dest =
+            CString::new(dest_path.to_str().ok_or(Error::Invalid)?).map_err(|_| Error::Invalid)?;
+
+        let mut flags = 0u32;
+        if compact {
+            flags |= ffi::MDBX_CP_COMPACT;
+        }
+        if force_dynamic {
+            flags |= ffi::MDBX_CP_FORCE_DYNAMIC_SIZE;
+        }
+
+        mdbx_result(unsafe { ffi::mdbx_env_copy(self.env_ptr(), dest.as_ptr(), flags) })?;
+
+        Ok(())
+    }
 }
 
 /// Container type for Environment internals.

--- a/docs/vocs/docs/pages/cli/SUMMARY.mdx
+++ b/docs/vocs/docs/pages/cli/SUMMARY.mdx
@@ -22,6 +22,8 @@
       - [`reth db clear`](./reth/db/clear.mdx)
         - [`reth db clear mdbx`](./reth/db/clear/mdbx.mdx)
         - [`reth db clear static-file`](./reth/db/clear/static-file.mdx)
+      - [`reth db migrate`](./reth/db/migrate.mdx)
+      - [`reth db mdbx-to-mdbx`](./reth/db/mdbx-to-mdbx.mdx)
       - [`reth db repair-trie`](./reth/db/repair-trie.mdx)
       - [`reth db static-file-header`](./reth/db/static-file-header.mdx)
         - [`reth db static-file-header block`](./reth/db/static-file-header/block.mdx)

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -17,6 +17,8 @@ Commands:
   get                 Gets the content of a table for the given key
   drop                Deletes all database entries
   clear               Deletes all table entries
+  migrate             Migrate database to another location
+  mdbx-to-mdbx        Copy database to another location (mdbx-to-mdbx)
   repair-trie         Verifies trie consistency and outputs any inconsistencies
   static-file-header  Reads and displays the static file segment header
   version             Lists current and local database versions

--- a/docs/vocs/docs/pages/cli/reth/db/mdbx-to-mdbx.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/mdbx-to-mdbx.mdx
@@ -1,0 +1,228 @@
+# reth db mdbx-to-mdbx
+
+Copy database to another location (mdbx-to-mdbx)
+
+```bash
+$ reth db mdbx-to-mdbx --help
+```
+```txt
+Usage: reth db mdbx-to-mdbx [OPTIONS] --to <DEST_PATH>
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+Copy Options:
+      --to <DEST_PATH>
+          The path to the destination database directory.
+
+          The destination directory must not exist; it will be created during the copy process.
+
+      --tables <TABLES>
+          List of specific tables to copy (comma-separated).
+
+          If not specified, all tables will be copied.
+
+          Example: --tables Headers,Bodies,Transactions
+
+      --page-size <PAGE_SIZE>
+          Target database page size (e.g., 4KB, 8KB, 16KB).
+
+          Supports units: B, KB, MB, GB, TB.
+
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB (typical range: 4KB-16KB).
+          If not specified, uses the system default page size (typically 4KB on Linux, 16KB on
+          macOS).
+
+          Only used in record-by-record mode (not in --fast mode).
+
+      --max-size <MAX_SIZE>
+          Target database maximum size (e.g., 4TB, 500GB, 8MB).
+
+          Supports units: B, KB, MB, GB, TB.
+          If not specified, uses the source database's maximum size.
+          Only used in record-by-record mode (not in --fast mode).
+
+      --growth-step <GROWTH_STEP>
+          Database growth step (e.g., 4GB, 1GB).
+
+          Supports units: B, KB, MB, GB, TB.
+          Only used in record-by-record mode (not in --fast mode).
+
+          [default: 4GB]
+
+      --fast
+          Use fast mode (MDBX native copy).
+
+          Fast mode uses the native MDBX copy API which is much faster but
+          ignores custom parameters like --page-size, --max-size, and --growth-step.
+          The destination database will have identical parameters to the source.
+
+          By default, uses record-by-record copy which allows parameter customization
+          but is slower.
+
+      --commit-every <COMMIT_EVERY>
+          Commit transaction every N records.
+
+          Controls how often transactions are committed during the copy process.
+          Smaller values use less memory but may be slower.
+          Only used in record-by-record mode (not in --fast mode).
+
+          [default: 100000]
+
+  -f, --force
+          Skip confirmation prompt
+
+  -q, --quiet
+          Suppress progress messages
+
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
+Logging:
+      --log.stdout.format <FORMAT>
+          The format to use for logs written to stdout
+
+          Possible values:
+          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
+          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
+          - terminal: Represents terminal-friendly formatting for logs
+
+          [default: terminal]
+
+      --log.stdout.filter <FILTER>
+          The filter to use for logs written to stdout
+
+          [default: ""]
+
+      --log.file.format <FORMAT>
+          The format to use for logs written to the log file
+
+          Possible values:
+          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
+          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
+          - terminal: Represents terminal-friendly formatting for logs
+
+          [default: terminal]
+
+      --log.file.filter <FILTER>
+          The filter to use for logs written to the log file
+
+          [default: debug]
+
+      --log.file.directory <PATH>
+          The path to put log files in
+
+          [default: <CACHE_DIR>/logs]
+
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
+      --log.file.max-size <SIZE>
+          The maximum size (in MB) of one log file
+
+          [default: 200]
+
+      --log.file.max-files <COUNT>
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
+
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
+
+      --log.journald
+          Write logs to journald
+
+      --log.journald.filter <FILTER>
+          The filter to use for logs written to journald
+
+          [default: error]
+
+      --color <COLOR>
+          Sets whether or not the formatter emits ANSI terminal escape codes for colors and other text formatting
+
+          Possible values:
+          - always: Colors on
+          - auto:   Auto-detect
+          - never:  Colors off
+
+          [default: always]
+
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
+Display:
+  -v, --verbosity...
+          Set the minimum log level.
+
+          -v      Errors
+          -vv     Warnings
+          -vvv    Info
+          -vvvv   Debug
+          -vvvvv  Traces (warning: very verbose!)
+
+Tracing:
+      --tracing-otlp[=<URL>]
+          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/traces` - gRPC: `http://localhost:4317`
+
+          Example: --tracing-otlp=http://collector:4318/v1/traces
+
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
+
+      --tracing-otlp-protocol <PROTOCOL>
+          OTLP transport protocol to use for exporting traces and logs.
+
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
+
+          Defaults to HTTP if not specified.
+
+          Possible values:
+          - http: HTTP/Protobuf transport, port 4318, requires `/v1/traces` path
+          - grpc: gRPC transport, port 4317
+
+          [env: OTEL_EXPORTER_OTLP_PROTOCOL=]
+          [default: http]
+
+      --tracing-otlp.filter <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
+
+          Defaults to TRACE if not specified.
+
+          [default: debug]
+
+      --tracing-otlp.sample-ratio <RATIO>
+          Trace sampling ratio to control the percentage of traces to export.
+
+          Valid range: 0.0 to 1.0 - 1.0, default: Sample all traces - 0.01: Sample 1% of traces - 0.0: Disable sampling
+
+          Example: --tracing-otlp.sample-ratio=0.0.
+
+          [env: OTEL_TRACES_SAMPLER_ARG=]
+```

--- a/docs/vocs/docs/pages/cli/reth/db/migrate.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/migrate.mdx
@@ -1,0 +1,190 @@
+# reth db migrate
+
+Migrate database to another location
+
+```bash
+$ reth db migrate --help
+```
+```txt
+Usage: reth db migrate [OPTIONS] --to <DEST_PATH>
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+Copy Options:
+      --to <DEST_PATH>
+          Destination database directory (must not exist)
+
+      --tables <TABLES>
+          Specific tables to copy (comma-separated). Example: --tables Headers,Bodies
+
+      --page-size <PAGE_SIZE>
+          Page size (e.g., 4KB, 8KB). Default: system default (typically 4KB).
+          NOTE: Can only be set when creating a new database.
+
+      --max-size <MAX_SIZE>
+          Maximum database size (e.g., 4TB, 12TB). Default: source database size
+
+      --growth-step <GROWTH_STEP>
+          Database growth step (e.g., 4GB, 8GB)
+
+          [default: 4GB]
+
+      --commit-every <COMMIT_EVERY>
+          Commit every N records. Smaller = less memory, slower
+
+          [default: 100000]
+
+  -q, --quiet
+          Suppress progress messages
+
+Datadir:
+      --chain <CHAIN_OR_PATH>
+          The chain this node is running.
+          Possible values are either a built-in chain or the path to a chain specification file.
+
+          Built-in chains:
+              mainnet, sepolia, holesky, hoodi, dev
+
+          [default: mainnet]
+
+Logging:
+      --log.stdout.format <FORMAT>
+          The format to use for logs written to stdout
+
+          Possible values:
+          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
+          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
+          - terminal: Represents terminal-friendly formatting for logs
+
+          [default: terminal]
+
+      --log.stdout.filter <FILTER>
+          The filter to use for logs written to stdout
+
+          [default: ""]
+
+      --log.file.format <FORMAT>
+          The format to use for logs written to the log file
+
+          Possible values:
+          - json:     Represents JSON formatting for logs. This format outputs log records as JSON objects, making it suitable for structured logging
+          - log-fmt:  Represents logfmt (key=value) formatting for logs. This format is concise and human-readable, typically used in command-line applications
+          - terminal: Represents terminal-friendly formatting for logs
+
+          [default: terminal]
+
+      --log.file.filter <FILTER>
+          The filter to use for logs written to the log file
+
+          [default: debug]
+
+      --log.file.directory <PATH>
+          The path to put log files in
+
+          [default: <CACHE_DIR>/logs]
+
+      --log.file.name <NAME>
+          The prefix name of the log files
+
+          [default: reth.log]
+
+      --log.file.max-size <SIZE>
+          The maximum size (in MB) of one log file
+
+          [default: 200]
+
+      --log.file.max-files <COUNT>
+          The maximum amount of log files that will be stored. If set to 0, background file logging is disabled.
+
+          Default: 5 for `node` command, 0 for non-node utility subcommands.
+
+      --log.journald
+          Write logs to journald
+
+      --log.journald.filter <FILTER>
+          The filter to use for logs written to journald
+
+          [default: error]
+
+      --color <COLOR>
+          Sets whether or not the formatter emits ANSI terminal escape codes for colors and other text formatting
+
+          Possible values:
+          - always: Colors on
+          - auto:   Auto-detect
+          - never:  Colors off
+
+          [default: always]
+
+      --logs-otlp[=<URL>]
+          Enable `Opentelemetry` logs export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/logs` - gRPC: `http://localhost:4317`
+
+          Example: --logs-otlp=http://collector:4318/v1/logs
+
+          [env: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=]
+
+      --logs-otlp.filter <FILTER>
+          Set a filter directive for the OTLP logs exporter. This controls the verbosity of logs sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --logs-otlp.filter=info,reth=debug
+
+          Defaults to INFO if not specified.
+
+          [default: info]
+
+Display:
+  -v, --verbosity...
+          Set the minimum log level.
+
+          -v      Errors
+          -vv     Warnings
+          -vvv    Info
+          -vvvv   Debug
+          -vvvvv  Traces (warning: very verbose!)
+
+Tracing:
+      --tracing-otlp[=<URL>]
+          Enable `Opentelemetry` tracing export to an OTLP endpoint.
+
+          If no value provided, defaults based on protocol: - HTTP: `http://localhost:4318/v1/traces` - gRPC: `http://localhost:4317`
+
+          Example: --tracing-otlp=http://collector:4318/v1/traces
+
+          [env: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=]
+
+      --tracing-otlp-protocol <PROTOCOL>
+          OTLP transport protocol to use for exporting traces and logs.
+
+          - `http`: expects endpoint path to end with `/v1/traces` or `/v1/logs` - `grpc`: expects endpoint without a path
+
+          Defaults to HTTP if not specified.
+
+          Possible values:
+          - http: HTTP/Protobuf transport, port 4318, requires `/v1/traces` path
+          - grpc: gRPC transport, port 4317
+
+          [env: OTEL_EXPORTER_OTLP_PROTOCOL=]
+          [default: http]
+
+      --tracing-otlp.filter <FILTER>
+          Set a filter directive for the OTLP tracer. This controls the verbosity of spans and events sent to the OTLP endpoint. It follows the same syntax as the `RUST_LOG` environment variable.
+
+          Example: --tracing-otlp.filter=info,reth=debug,hyper_util=off
+
+          Defaults to TRACE if not specified.
+
+          [default: debug]
+
+      --tracing-otlp.sample-ratio <RATIO>
+          Trace sampling ratio to control the percentage of traces to export.
+
+          Valid range: 0.0 to 1.0 - 1.0, default: Sample all traces - 0.01: Sample 1% of traces - 0.0: Disable sampling
+
+          Example: --tracing-otlp.sample-ratio=0.0.
+
+          [env: OTEL_TRACES_SAMPLER_ARG=]
+```

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1043,6 +1043,17 @@ Engine:
 
           The builder also anchors the trie at the built block's state root, so if the next `newPayload` is not on top of that block, the trie cache is invalidated and cleared.
 
+      --engine.skip-state-root-validation
+          Skip state root validation for fastnode mode
+
+      --engine.min-blocks-for-pipeline-run <MIN_BLOCKS_FOR_PIPELINE_RUN>
+          Configure the minimum number of blocks required to trigger a pipeline run for backfilling. When the local head is behind the forkchoice head by more than this threshold, the pipeline will be used to backfill blocks instead of downloading them individually
+
+          [default: 32]
+
+      --engine.enable-proof-v2
+          Enable V2 storage proofs for state root calculations
+
 ERA:
       --era.enable
           Enable import from ERA1 files

--- a/docs/vocs/sidebar-cli-reth.ts
+++ b/docs/vocs/sidebar-cli-reth.ts
@@ -108,6 +108,14 @@ export const rethCliSidebar: SidebarItem = {
                     ]
                 },
                 {
+                    text: "reth db migrate",
+                    link: "/cli/reth/db/migrate"
+                },
+                {
+                    text: "reth db mdbx-to-mdbx",
+                    link: "/cli/reth/db/mdbx-to-mdbx"
+                },
+                {
                     text: "reth db repair-trie",
                     link: "/cli/reth/db/repair-trie"
                 },


### PR DESCRIPTION
Ports BSC-specific commits onto `develop-v2`:

- `393cf4c96` release: prepare for release v0.0.4 (#40)
- `e85daceb7` feat: add db convert

Next commit to port: `e5111edb3 feat: add db_convert tool`

**Changes:**
- Adds `migrate.rs` — table-by-table MDBX copy with configurable page/max size
- Adds `mdbx_to_mdbx.rs` — fast-mode native MDBX copy (wraps `copy_to_path`)
- Wires both into `reth db migrate` and `reth db mdbx-to-mdbx` subcommands
- Adds `copy_to_path` to `DatabaseEnv` and `libmdbx-rs::Environment`
- Extends `TreeConfig` with BSC fields: `storage_worker_count`, `account_worker_count`, `enable_proof_v2`, `skip_state_root_validation`, `min_blocks_for_pipeline_run`
- Extends `EngineArgs` and `DefaultEngineValues` with corresponding CLI flags

**Conflict resolution notes:**
- Kept all reth v2 fields in `TreeConfig` and `EngineArgs`; added BSC-specific fields alongside them
- Fixed private field accesses (`tx.inner` → `tx.inner()`), undefined macro (`db_ro_exec!` → `db_exec!` with `AccessRights::RO`), and cursor API mismatch (`cursor(&db)` → `cursor(db.dbi())`)