### PR TITLE
feat: support db.page-size init option

### DIFF
--- a/crates/cli/commands/src/db/migrate.rs
+++ b/crates/cli/commands/src/db/migrate.rs
@@ -1,9 +1,7 @@
 //! Database migration tool
 //!
-//! This tool copies data from one MDBX database to another, table by table.
-//! It supports two modes:
-//! - Fast mode: uses MDBX native copy API for maximum speed
-//! - Custom mode: allows parameter customization (page size, max size, etc.)
+//! Copies data from one MDBX database to another, table by table.
+//! Allows customization of database parameters (page size, max size, growth step, etc.).
 
 use clap::Parser;
 use reth_db::DatabaseEnv;
@@ -43,17 +41,9 @@ pub struct Command {
     #[arg(long, default_value = "4GB", value_parser = parse_byte_size)]
     growth_step: usize,
 
-    /// Use fast mode (native MDBX copy, ignores custom parameters).
-    #[arg(long)]
-    fast: bool,
-
     /// Commit every N records. Smaller = less memory, slower.
     #[arg(long, default_value = "100000")]
     commit_every: usize,
-
-    /// Skip confirmation prompt.
-    #[arg(long, short)]
-    force: bool,
 
     /// Suppress progress messages.
     #[arg(long, short)]
@@ -67,28 +57,6 @@ impl Command {
         src_env: &DatabaseEnv,
         db_args: &reth_db::mdbx::DatabaseArguments,
     ) -> eyre::Result<()> {
-        use std::io::Write;
-
-        // Determine mode
-        let mode = if self.fast {
-            "fast (MDBX native copy)"
-        } else {
-            "record-by-record (with parameter customization)"
-        };
-
-        if !self.force {
-            print!("Copy database to {:?}? Mode: {}. (y/N): ", self.to, mode);
-            std::io::stdout().flush()?;
-
-            let mut input = String::new();
-            std::io::stdin().read_line(&mut input)?;
-
-            if !input.trim().eq_ignore_ascii_case("y") {
-                info!("Copy aborted!");
-                return Ok(());
-            }
-        }
-
         // Ensure destination doesn't exist
         if self.to.exists() {
             eyre::bail!("Destination {:?} already exists", self.to);
@@ -102,20 +70,12 @@ impl Command {
         }
 
         if !self.quiet {
-            info!(target: "reth::cli", "Starting database copy...");
-            info!(target: "reth::cli", "Mode: {}", mode);
+            info!(target: "reth::cli", "Starting database migration...");
             info!(target: "reth::cli", "Destination: {:?}", self.to);
         }
 
         let start = Instant::now();
-
-        if self.fast {
-            // Fast mode: use MDBX native copy
-            self.execute_fast_copy(src_env)?;
-        } else {
-            // Default mode: record-by-record copy with parameter customization
-            self.execute_custom_copy(src_env, db_args)?;
-        }
+        self.execute_custom_copy(src_env, db_args)?;
 
         let elapsed = start.elapsed();
 
@@ -131,13 +91,13 @@ impl Command {
 
                 if dst_size < src_size {
                     let reduction = ((src_size - dst_size) as f64 / src_size as f64) * 100.0;
-                    info!(target: "reth::cli", 
+                    info!(target: "reth::cli",
                           "Size reduction: {} ({:.2}% smaller due to defragmentation)",
                           format_byte_size(src_size - dst_size),
                           reduction);
-                    info!(target: "reth::cli", 
+                    info!(target: "reth::cli",
                           "  Note: This is normal. The copy process eliminates fragmentation,");
-                    info!(target: "reth::cli", 
+                    info!(target: "reth::cli",
                           "  empty pages, and compacts the data structure.");
                 }
             }
@@ -146,17 +106,7 @@ impl Command {
         Ok(())
     }
 
-    /// Fast copy using MDBX native copy API
-    fn execute_fast_copy(&self, src_env: &DatabaseEnv) -> eyre::Result<()> {
-        if !self.quiet {
-            info!(target: "reth::cli", "Using MDBX native copy (ignoring custom parameters)");
-        }
-
-        src_env.copy_to_path(&self.to, false, false)?;
-        Ok(())
-    }
-
-    /// Custom copy with parameter customization
+    /// Execute database copy with parameter customization
     fn execute_custom_copy(
         &self,
         src_env: &DatabaseEnv,
@@ -172,7 +122,6 @@ impl Command {
 
         // Start with system database arguments (includes log_level, exclusive, max_readers, etc.)
         // then override with user-specified parameters
-        let client_version = base_db_args.client_version().clone();
         let mut dst_args = base_db_args.clone();
 
         // Determine target parameters
@@ -191,49 +140,26 @@ impl Command {
 
         if !self.quiet {
             info!(target: "reth::cli", "Source database parameters:");
-            info!(
-                target: "reth::cli",
-                "  Page size: {}",
-                format_byte_size(src_page_size as usize)
-            );
+            info!(target: "reth::cli", "  Page size: {}", format_byte_size(src_page_size as usize));
             info!(target: "reth::cli", "  Map size: {}", format_byte_size(src_map_size));
             info!(target: "reth::cli", "Target database parameters:");
             if let Some(page_size) = self.page_size {
-                info!(
-                    target: "reth::cli",
-                    "  Page size: {} (custom)",
-                    format_byte_size(page_size)
-                );
+                info!(target: "reth::cli", "  Page size: {} (custom)", format_byte_size(page_size));
             } else {
-                info!(
-                    target: "reth::cli",
-                    "  Page size: {} (using system default)",
-                    format_byte_size(src_page_size as usize)
-                );
+                info!(target: "reth::cli", "  Page size: {} (using system default)",
+                      format_byte_size(src_page_size as usize));
             }
             info!(target: "reth::cli", "  Map size: {}", format_byte_size(max_size_bytes));
-            info!(
-                target: "reth::cli",
-                "  Growth step: {}",
-                format_byte_size(growth_step_bytes)
-            );
-            info!(
-                target: "reth::cli",
-                "  (Other settings: log_level, exclusive, max_readers, etc. inherited from system config)"
-            );
+            info!(target: "reth::cli", "  Growth step: {}", format_byte_size(growth_step_bytes));
+            info!(target: "reth::cli", "  (Other settings: log_level, exclusive, max_readers, etc. inherited from system config)");
         }
 
-        // Create destination database with custom parameters
-        // We use create_db() instead of init_db() because:
-        // - init_db() pre-creates all tables (unnecessary, wastes time)
-        // - Tables will be automatically created when we open them during copy
-        let dst_env = reth_db::create_db(&self.to, dst_args)?;
-
-        // Record client version for compatibility tracking
-        dst_env.record_client_version(client_version)?;
+        // Create destination database and initialize all tables
+        // Using init_db() to properly create all tables and record client version
+        let dst_env = reth_db::init_db(&self.to, dst_args)?;
 
         if !self.quiet {
-            info!(target: "reth::cli", "Destination database created (tables will be created during copy)");
+            info!(target: "reth::cli", "Destination database initialized");
         }
 
         // Determine which tables to copy
@@ -255,34 +181,20 @@ impl Command {
 
         if !self.quiet {
             info!(target: "reth::cli", "Copying {} tables", tables_to_copy.len());
+            if !self.tables.is_empty() {
+                info!(target: "reth::cli", "  Note: Only copying selected tables. Other tables will be empty.");
+            }
         }
 
         // Copy each table using table-specific implementations
         let total_tables = tables_to_copy.len();
         for (idx, table_name) in tables_to_copy.iter().enumerate() {
             if !self.quiet {
-                info!(
-                    target: "reth::cli",
-                    "[{}/{}] Copying table: {}",
-                    idx + 1,
-                    total_tables,
-                    table_name
-                );
+                info!(target: "reth::cli", "[{}/{}] Copying table: {}",
+                      idx + 1, total_tables, table_name);
             }
 
-            let table_start = Instant::now();
-            let copied = self.copy_table_generic(src_env, &dst_env, table_name)?;
-            let table_elapsed = table_start.elapsed();
-
-            if !self.quiet && copied > 0 {
-                info!(
-                    target: "reth::cli",
-                    "  Copied {} records in {:.2}s ({:.0} rec/s)",
-                    copied,
-                    table_elapsed.as_secs_f64(),
-                    copied as f64 / table_elapsed.as_secs_f64()
-                );
-            }
+            self.copy_table_generic(src_env, &dst_env, table_name)?;
         }
 
         Ok(())

--- a/crates/cli/commands/src/db/migrate.rs
+++ b/crates/cli/commands/src/db/migrate.rs
@@ -9,115 +9,46 @@ use clap::Parser;
 use reth_db::DatabaseEnv;
 use reth_db_api::{database::Database, transaction::DbTx};
 use reth_libmdbx::WriteFlags;
+use reth_node_core::args::{parse_byte_size, ByteSize};
 use std::{path::PathBuf, time::Instant};
 use tracing::info;
 
-/// Parse byte size from string (e.g., "4GB", "16KB", "1024")
-fn parse_byte_size(s: &str) -> Result<usize, String> {
-    let s = s.trim().to_uppercase();
-
-    let (num_str, unit) = if let Some(pos) = s.find(|c: char| c.is_alphabetic()) {
-        s.split_at(pos)
-    } else {
-        return s.parse().map_err(|_| "Invalid number".to_string());
-    };
-
-    let num: usize = num_str.trim().parse().map_err(|_| "Invalid number".to_string())?;
-
-    let multiplier = match unit.trim() {
-        "B" | "" => 1,
-        "KB" => 1024,
-        "MB" => 1024 * 1024,
-        "GB" => 1024 * 1024 * 1024,
-        "TB" => 1024 * 1024 * 1024 * 1024,
-        _ => return Err(format!("Invalid unit: {unit}. Use B, KB, MB, GB, or TB.")),
-    };
-
-    Ok(num * multiplier)
-}
-
 /// Format byte size to human-readable string
 fn format_byte_size(bytes: usize) -> String {
-    const KB: usize = 1024;
-    const MB: usize = KB * 1024;
-    const GB: usize = MB * 1024;
-    const TB: usize = GB * 1024;
-
-    if bytes >= TB {
-        format!("{:.2} TB", bytes as f64 / TB as f64)
-    } else if bytes >= GB {
-        format!("{:.2} GB", bytes as f64 / GB as f64)
-    } else if bytes >= MB {
-        format!("{:.2} MB", bytes as f64 / MB as f64)
-    } else if bytes >= KB {
-        format!("{:.2} KB", bytes as f64 / KB as f64)
-    } else {
-        format!("{} B", bytes)
-    }
+    ByteSize(bytes).to_string()
 }
 
 /// Arguments for the `reth db migrate` command
 #[derive(Parser, Debug)]
 #[command(next_help_heading = "Copy Options")]
 pub struct Command {
-    /// The path to the destination database directory.
-    ///
-    /// The destination directory must not exist; it will be created during the copy process.
-    #[arg(long, value_name = "DEST_PATH", verbatim_doc_comment)]
+    /// Destination database directory (must not exist).
+    #[arg(long, value_name = "DEST_PATH")]
     to: PathBuf,
 
-    /// List of specific tables to copy (comma-separated).
-    ///
-    /// If not specified, all tables will be copied.
-    ///
-    /// Example: --tables Headers,Bodies,Transactions
-    #[arg(long, value_delimiter = ',', verbatim_doc_comment)]
+    /// Specific tables to copy (comma-separated). Example: --tables Headers,Bodies
+    #[arg(long, value_delimiter = ',')]
     tables: Vec<String>,
 
-    /// Target database page size (e.g., 4KB, 8KB, 16KB).
-    ///
-    /// Supports units: B, KB, MB, GB, TB.
-    ///
-    /// NOTE: Page size can only be set when creating a new database and cannot be changed later.
-    /// The page size must be a power of 2 between 256 bytes and 64KB (typical range: 4KB-16KB).
-    /// If not specified, uses the system default page size (typically 4KB).
-    ///
-    /// Only used in record-by-record mode (not in --fast mode).
+    /// Page size (e.g., 4KB, 8KB). Default: system default (typically 4KB).
+    /// NOTE: Can only be set when creating a new database.
     #[arg(long, value_parser = parse_byte_size, verbatim_doc_comment)]
     page_size: Option<usize>,
 
-    /// Target database maximum size (e.g., 4TB, 12TB, 500GB).
-    ///
-    /// Supports units: B, KB, MB, GB, TB.
-    /// If not specified, uses the source database's maximum size.
-    /// Only used in record-by-record mode (not in --fast mode).
-    #[arg(long, value_parser = parse_byte_size, verbatim_doc_comment)]
+    /// Maximum database size (e.g., 4TB, 12TB). Default: source database size.
+    #[arg(long, value_parser = parse_byte_size)]
     max_size: Option<usize>,
 
     /// Database growth step (e.g., 4GB, 8GB).
-    ///
-    /// Supports units: B, KB, MB, GB, TB.
-    /// Only used in record-by-record mode (not in --fast mode).
-    #[arg(long, default_value = "4GB", value_parser = parse_byte_size, verbatim_doc_comment)]
+    #[arg(long, default_value = "4GB", value_parser = parse_byte_size)]
     growth_step: usize,
 
-    /// Use fast mode (MDBX native copy).
-    ///
-    /// Fast mode uses the native MDBX copy API which is much faster but
-    /// ignores custom parameters like --page-size, --max-size, and --growth-step.
-    /// The destination database will have identical parameters to the source.
-    ///
-    /// By default, uses record-by-record copy which allows parameter customization
-    /// but is slower.
-    #[arg(long, verbatim_doc_comment)]
+    /// Use fast mode (native MDBX copy, ignores custom parameters).
+    #[arg(long)]
     fast: bool,
 
-    /// Commit transaction every N records.
-    ///
-    /// Controls how often transactions are committed during the copy process.
-    /// Smaller values use less memory but may be slower.
-    /// Only used in record-by-record mode (not in --fast mode).
-    #[arg(long, default_value = "100000", verbatim_doc_comment)]
+    /// Commit every N records. Smaller = less memory, slower.
+    #[arg(long, default_value = "100000")]
     commit_every: usize,
 
     /// Skip confirmation prompt.

--- a/crates/node/core/src/args/database.rs
+++ b/crates/node/core/src/args/database.rs
@@ -35,15 +35,17 @@ pub struct DatabaseArgs {
     pub max_size: Option<usize>,
     /// Database page size (e.g., 4KB, 8KB, 16KB).
     ///
-    /// Specifies the page size used by the MDBX database.
+    /// NOTE: Page size can only be set when creating a new database and cannot be changed later.
+    /// The page size must be a power of 2 between 256 bytes and 64KB.
+    /// If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
     ///
     /// The page size determines the maximum database size.
     /// MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
     /// database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
     ///
-    /// WARNING: This setting is only configurable at database creation; changing
-    /// it later requires re-syncing.
-    #[arg(long = "db.page-size", value_parser = parse_byte_size)]
+    /// WARNING: Changing page size on an existing database will cause errors.
+    /// Only use this flag when initializing a new node.
+    #[arg(long = "db.page-size", value_parser = parse_byte_size, verbatim_doc_comment)]
     pub page_size: Option<usize>,
     /// Database growth step (e.g., 4GB, 4KB)
     #[arg(long = "db.growth-step", value_parser = parse_byte_size)]

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -645,21 +645,6 @@ impl DatabaseEnv {
         }
     }
 
-    /// Copy the database to the specified path.
-    ///
-    /// This is a wrapper around MDBX's native copy, similar to Erigon's `mdbx_to_mdbx`
-    /// but using the high-performance C implementation instead of record-by-record copying.
-    pub fn copy_to_path(
-        &self,
-        dest_path: &Path,
-        compact: bool,
-        force_dynamic: bool,
-    ) -> Result<(), DatabaseError> {
-        self.inner
-            .copy_to_path(dest_path, compact, force_dynamic)
-            .map_err(|e| DatabaseError::Other(format!("Failed to copy database: {}", e)))
-    }
-
     /// Records version that accesses the database with write privileges.
     pub fn record_client_version(&self, version: ClientVersion) -> Result<(), DatabaseError> {
         if version.is_empty() {

--- a/crates/storage/db/src/implementation/mdbx/mod.rs
+++ b/crates/storage/db/src/implementation/mdbx/mod.rs
@@ -201,7 +201,6 @@ impl DatabaseArguments {
     /// Sets the page size for the database.
     ///
     /// Note: Page size can only be set when creating a new database and cannot be changed later.
-    /// The page size must be a power of 2 between the minimum and maximum values supported by MDBX.
     pub const fn with_page_size(mut self, page_size: Option<usize>) -> Self {
         if let Some(page_size) = page_size {
             self.geometry.page_size = Some(PageSize::Set(page_size));

--- a/docs/vocs/docs/pages/cli/reth/db.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db.mdx
@@ -95,11 +95,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/db/diff.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/diff.mdx
@@ -44,11 +44,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/db/migrate.mdx
+++ b/docs/vocs/docs/pages/cli/reth/db/migrate.mdx
@@ -14,64 +14,27 @@ Options:
 
 Copy Options:
       --to <DEST_PATH>
-          The path to the destination database directory.
-
-          The destination directory must not exist; it will be created during the copy process.
+          Destination database directory (must not exist)
 
       --tables <TABLES>
-          List of specific tables to copy (comma-separated).
-
-          If not specified, all tables will be copied.
-
-          Example: --tables Headers,Bodies,Transactions
+          Specific tables to copy (comma-separated). Example: --tables Headers,Bodies
 
       --page-size <PAGE_SIZE>
-          Target database page size (e.g., 4KB, 8KB, 16KB).
-
-          Supports units: B, KB, MB, GB, TB.
-
-          NOTE: Page size can only be set when creating a new database and cannot be changed later.
-          The page size must be a power of 2 between 256 bytes and 64KB (typical range: 4KB-16KB).
-          If not specified, uses the system default page size (typically 4KB).
-
-          Only used in record-by-record mode (not in --fast mode).
+          Page size (e.g., 4KB, 8KB). Default: system default (typically 4KB).
+          NOTE: Can only be set when creating a new database.
 
       --max-size <MAX_SIZE>
-          Target database maximum size (e.g., 4TB, 12TB, 500GB).
-
-          Supports units: B, KB, MB, GB, TB.
-          If not specified, uses the source database's maximum size.
-          Only used in record-by-record mode (not in --fast mode).
+          Maximum database size (e.g., 4TB, 12TB). Default: source database size
 
       --growth-step <GROWTH_STEP>
-          Database growth step (e.g., 4GB, 8GB).
-
-          Supports units: B, KB, MB, GB, TB.
-          Only used in record-by-record mode (not in --fast mode).
+          Database growth step (e.g., 4GB, 8GB)
 
           [default: 4GB]
 
-      --fast
-          Use fast mode (MDBX native copy).
-
-          Fast mode uses the native MDBX copy API which is much faster but
-          ignores custom parameters like --page-size, --max-size, and --growth-step.
-          The destination database will have identical parameters to the source.
-
-          By default, uses record-by-record copy which allows parameter customization
-          but is slower.
-
       --commit-every <COMMIT_EVERY>
-          Commit transaction every N records.
-
-          Controls how often transactions are committed during the copy process.
-          Smaller values use less memory but may be slower.
-          Only used in record-by-record mode (not in --fast mode).
+          Commit every N records. Smaller = less memory, slower
 
           [default: 100000]
-
-  -f, --force
-          Skip confirmation prompt
 
   -q, --quiet
           Suppress progress messages

--- a/docs/vocs/docs/pages/cli/reth/download.mdx
+++ b/docs/vocs/docs/pages/cli/reth/download.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/export-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/export-era.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/import-era.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import-era.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/import.mdx
+++ b/docs/vocs/docs/pages/cli/reth/import.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/init-state.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init-state.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/init.mdx
+++ b/docs/vocs/docs/pages/cli/reth/init.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -800,11 +800,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/prune.mdx
+++ b/docs/vocs/docs/pages/cli/reth/prune.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/re-execute.mdx
+++ b/docs/vocs/docs/pages/cli/reth/re-execute.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/drop.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/dump.mdx
@@ -81,11 +81,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/stage/run.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/run.mdx
@@ -74,11 +74,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)

--- a/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
+++ b/docs/vocs/docs/pages/cli/reth/stage/unwind.mdx
@@ -79,11 +79,16 @@ Database:
       --db.page-size <PAGE_SIZE>
           Database page size (e.g., 4KB, 8KB, 16KB).
 
-          Specifies the page size used by the MDBX database.
+          NOTE: Page size can only be set when creating a new database and cannot be changed later.
+          The page size must be a power of 2 between 256 bytes and 64KB.
+          If not specified, uses the system default (typically 4KB on Linux, 16KB on macOS).
 
-          The page size determines the maximum database size. MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
+          The page size determines the maximum database size.
+          MDBX supports up to 2^31 pages, so with the default 4KB page size, the maximum
+          database size is 8TB. To allow larger databases, increase this value to 8KB or higher.
 
-          WARNING: This setting is only configurable at database creation; changing it later requires re-syncing.
+          WARNING: Changing page size on an existing database will cause errors.
+          Only use this flag when initializing a new node.
 
       --db.growth-step <GROWTH_STEP>
           Database growth step (e.g., 4GB, 4KB)


### PR DESCRIPTION
Port of three commits from `origin/develop` adding support for the `--page-size` flag in `reth db migrate`.

Cherry-picked from `origin/develop`:
- `767f11798` — add `with_page_size` to `DatabaseArguments` in `database.rs`
- `68f409698` — wire `page_size` into `migrate` destination db args
- `672f291a8` — complete `--page-size` support in `reth db migrate`

Conflicts resolved by keeping HEAD's implementations (`inner()` method syntax, `copy_to_path`, `drop_orphan_table`).

Next commit to port: `3f6fbbd4c` — fix: fix pend-block rpc return none due to query td failed (#37)