### PR TITLE
feat: support triedb as the state storage backend (#53)

### DIFF
--- a/.github/scripts/check_wasm.sh
+++ b/.github/scripts/check_wasm.sh
@@ -21,7 +21,9 @@ exclude_crates=(
   reth-dns-discovery
   reth-downloaders
   reth-e2e-test-utils
+  reth-engine-primitives # reth-trie-common/std -> rust-eth-triedb
   reth-engine-service
+  reth-ethereum-engine-primitives # reth-trie-common/std -> rust-eth-triedb
   reth-execution-cache
   reth-engine-tree
   reth-engine-util
@@ -34,12 +36,14 @@ exclude_crates=(
   reth-ipc
   reth-net-nat
   reth-network
+  reth-network-api # reth-trie-common/std -> rust-eth-triedb
   reth-node-api
   reth-node-builder
   reth-node-core
   reth-node-ethereum
   reth-node-events
   reth-node-metrics
+  reth-node-types # reth-trie-common/std -> rust-eth-triedb
   reth-rpc
   reth-rpc-api
   reth-rpc-api-testing-util
@@ -50,6 +54,7 @@ exclude_crates=(
   reth-rpc-eth-api
   reth-rpc-eth-types
   reth-rpc-layer
+  reth-rpc-server-types # reth-trie-common/std -> rust-eth-triedb
   reth-stages
   reth-engine-local
   reth-ress-protocol
@@ -62,6 +67,7 @@ exclude_crates=(
   reth-libmdbx # mdbx
   reth-mdbx-sys # mdbx
   reth-payload-builder # reth-metrics
+  reth-payload-builder-primitives # reth-trie-common/std -> rust-eth-triedb
   reth-provider # tokio
   reth-prune # tokio
   reth-prune-static-files # reth-provider
@@ -70,6 +76,7 @@ exclude_crates=(
   reth-static-file # tokio
   reth-transaction-pool # c-kzg
   reth-payload-util # reth-transaction-pool
+  reth-trie-db # rust-eth-triedb (rocksdb/jemalloc)
   reth-trie-parallel # tokio
   reth-trie-sparse-parallel # rayon
   reth-testing-utils

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Install liburing-dev
+        run: sudo apt-get update && sudo apt-get install -y liburing-dev
       - run: cargo clippy --workspace --lib --examples --tests --benches --all-features --locked
         env:
           RUSTFLAGS: -D warnings
@@ -145,6 +147,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Install liburing-dev
+        run: sudo apt-get update && sudo apt-get install -y liburing-dev
       - run: cargo docs --document-private-items
         env:
           # Keep in sync with ./book.yml:jobs.build
@@ -178,6 +182,8 @@ jobs:
         with:
           cache-on-failure: true
       - uses: taiki-e/install-action@cargo-udeps
+      - name: Install liburing-dev
+        run: sudo apt-get update && sudo apt-get install -y liburing-dev
       - run: cargo udeps --workspace --lib --examples --tests --benches --all-features --locked
 
   book:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -102,6 +102,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
+      - name: Install liburing-dev
+        run: sudo apt-get update && sudo apt-get install -y liburing-dev
       - name: Run doctests
         run: cargo test --doc --workspace --all-features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5633,6 +5633,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "lz4-sys",
+ "pkg-config",
  "tikv-jemalloc-sys",
  "zstd-sys",
 ]
@@ -7760,6 +7761,7 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -7975,6 +7977,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-genesis",
  "alloy-primitives",
+ "alloy-trie",
  "boyer-moore-magiclen",
  "eyre",
  "reth-chainspec",
@@ -7993,6 +7996,9 @@ dependencies = [
  "reth-tasks",
  "reth-trie",
  "reth-trie-db",
+ "rust-eth-triedb",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-state-trie",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -8325,6 +8331,7 @@ dependencies = [
  "revm",
  "revm-primitives",
  "revm-state",
+ "rust-eth-triedb",
  "schnellru",
  "serde_json",
  "thiserror 2.0.18",
@@ -9219,6 +9226,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie-db",
+ "rust-eth-triedb",
  "secp256k1 0.30.0",
  "serde_json",
  "tempfile",
@@ -9584,6 +9592,7 @@ dependencies = [
  "revm-database-interface",
  "revm-state",
  "rocksdb",
+ "rust-eth-triedb",
  "strum",
  "tempfile",
  "tokio",
@@ -9734,6 +9743,7 @@ dependencies = [
  "revm",
  "revm-inspectors",
  "revm-primitives",
+ "rust-eth-triedb",
  "serde",
  "serde_json",
  "sha2",
@@ -9968,6 +9978,7 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-inspectors",
+ "rust-eth-triedb",
  "serde_json",
  "tokio",
  "tracing",
@@ -10077,6 +10088,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
  "assert_matches",
  "eyre",
  "futures-util",
@@ -10123,7 +10135,9 @@ dependencies = [
  "reth-testing-utils",
  "reth-tracing",
  "reth-trie",
+ "reth-trie-common",
  "reth-trie-db",
+ "rust-eth-triedb",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -10480,6 +10494,8 @@ dependencies = [
  "reth-primitives-traits",
  "revm-database",
  "revm-state",
+ "rust-eth-triedb",
+ "rust-eth-triedb-state-trie",
  "serde",
  "serde_json",
  "serde_with",
@@ -10510,6 +10526,7 @@ dependencies = [
  "reth-trie-common",
  "revm",
  "revm-database",
+ "rust-eth-triedb",
  "serde_json",
  "similar-asserts",
  "tracing",
@@ -10948,6 +10965,76 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
+
+[[package]]
+name = "rust-eth-triedb"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-trie",
+ "metrics",
+ "once_cell",
+ "rayon",
+ "reth-metrics",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
+ "rust-eth-triedb-state-trie",
+ "schnellru",
+ "serde",
+ "thiserror 1.0.69",
+ "tikv-jemallocator",
+ "tracing",
+]
+
+[[package]]
+name = "rust-eth-triedb-common"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
+dependencies = [
+ "alloy-primitives",
+ "auto_impl",
+ "thiserror 1.0.69",
+ "tikv-jemallocator",
+]
+
+[[package]]
+name = "rust-eth-triedb-pathdb"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-trie",
+ "metrics",
+ "reth-metrics",
+ "rocksdb",
+ "rust-eth-triedb-common",
+ "schnellru",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tikv-jemallocator",
+ "tracing",
+]
+
+[[package]]
+name = "rust-eth-triedb-state-trie"
+version = "0.1.0"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-trie",
+ "arbitrary",
+ "auto_impl",
+ "hex",
+ "rand 0.8.5",
+ "rayon",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
+ "thiserror 1.0.69",
+ "tikv-jemallocator",
+ "tracing",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -432,6 +432,13 @@ reth-trie-parallel = { path = "crates/trie/parallel" }
 reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
 reth-zstd-compressors = { version = "0.1.0", default-features = false }
 
+# triedb
+# Note: To enable io-uring support, add `io-uring = ["rust-eth-triedb/io-uring"]` to the [features] section
+# of any crate that depends on rust-eth-triedb. Then enable the io-uring feature at the root (bin/reth).
+rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.1" }
+rust-eth-triedb-common = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.1", package = "rust-eth-triedb-common" }
+rust-eth-triedb-state-trie = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.1", package = "rust-eth-triedb-state-trie" }
+
 # revm
 revm = { version = "36.0.0", default-features = false }
 revm-bytecode = { version = "9.0.0", default-features = false }
@@ -700,6 +707,15 @@ vergen-git2 = "9.1.0"
 
 # networking
 ipnet = "2.11"
+
+# Patch rust-eth-triedb's dependencies to use local reth crates
+[patch."https://github.com/bnb-chain/reth-bsc-triedb.git"]
+reth-metrics = { path = "crates/metrics" }
+
+# Patch bnb-chain/reth.git dependencies to use local reth crates
+# This is needed because rust-eth-triedb depends on bnb-chain/reth.git
+[patch."https://github.com/bnb-chain/reth.git"]
+reth-metrics = { path = "crates/metrics" }
 
 [patch.crates-io]
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/bin/reth-bb/Cargo.toml
+++ b/bin/reth-bb/Cargo.toml
@@ -87,6 +87,7 @@ asm-keccak = [
     "alloy-evm/asm-keccak",
     "revm/asm-keccak",
     "revm-primitives/asm-keccak",
+    "reth-provider/asm-keccak",
 ]
 
 min-debug-logs = [

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -119,6 +119,14 @@ keccak-cache-global = [
     "reth-node-ethereum/keccak-cache-global",
     "alloy-primitives/keccak-cache-global",
 ]
+
+# io-uring feature enables io-uring support for rust-eth-triedb
+# This feature is automatically propagated to all crates that depend on rust-eth-triedb
+# Each crate using rust-eth-triedb should add: io-uring = ["rust-eth-triedb/io-uring"]
+io-uring = [
+    "reth-provider/io-uring",
+    "reth-node-builder/io-uring",
+]
 jemalloc = [
     "reth-cli-util/jemalloc",
     "reth-node-core/jemalloc",

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -113,6 +113,7 @@ asm-keccak = [
     "reth-ethereum-cli/asm-keccak",
     "reth-node-ethereum/asm-keccak",
     "alloy-primitives/asm-keccak",
+    "reth-provider/asm-keccak",
 ]
 keccak-cache-global = [
     "reth-node-core/keccak-cache-global",

--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -78,6 +78,7 @@ test-utils = [
     "alloy-signer",
     "alloy-signer-local",
     "rand",
+    "rayon",
     "revm-state",
     "reth-chainspec/test-utils",
     "reth-primitives-traits/test-utils",

--- a/crates/chain-state/src/test_utils.rs
+++ b/crates/chain-state/src/test_utils.rs
@@ -9,6 +9,7 @@ use alloy_signer::SignerSync;
 use alloy_signer_local::PrivateKeySigner;
 use core::marker::PhantomData;
 use rand::Rng;
+use rayon::iter::IntoParallelRefIterator;
 use reth_chainspec::{ChainSpec, EthereumHardfork, MIN_TRANSACTION_GAS};
 use reth_ethereum_primitives::{
     Block, BlockBody, EthPrimitives, Receipt, Transaction, TransactionSigned,
@@ -293,7 +294,7 @@ impl<N: NodePrimitives> TestBlockBuilder<N> {
 
         let hashed_state = reth_trie::HashedPostState::from_bundle_state::<
             reth_trie::KeccakKeyHasher,
-        >(bundle.state.iter())
+        >(bundle.state.par_iter())
         .into_sorted();
 
         let block_receipts = if receipts.is_empty() {

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -59,6 +59,9 @@ reth-primitives-traits.workspace = true
 reth-discv4.workspace = true
 reth-discv5.workspace = true
 
+# triedb
+rust-eth-triedb.workspace = true
+
 # ethereum
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
@@ -111,6 +114,8 @@ reth-provider = { workspace = true, features = ["test-utils"] }
 tempfile.workspace = true
 
 [features]
+default = []
+io-uring = ["rust-eth-triedb/io-uring"]
 arbitrary = [
     "dep:proptest",
     "dep:arbitrary",

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -11,7 +11,7 @@ use reth_node_core::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, EraArgs, MetricArgs,
         NetworkArgs, PayloadBuilderArgs, PruningArgs, RpcServerArgs, StateDbArgs, StaticFilesArgs,
-        TxPoolArgs,
+        StorageArgs, TxPoolArgs,
     },
     node_config::NodeConfig,
     version,
@@ -119,6 +119,10 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
     #[command(flatten, next_help_heading = "StateDB")]
     pub statedb: StateDbArgs,
 
+    /// Storage layout configuration (v1/v2)
+    #[command(flatten, next_help_heading = "Storage")]
+    pub storage: StorageArgs,
+
     /// Additional cli arguments
     #[command(flatten, next_help_heading = "Extension")]
     pub ext: Ext,
@@ -175,6 +179,7 @@ where
             era,
             static_files,
             statedb,
+            storage,
             ext,
         } = self;
 
@@ -199,6 +204,7 @@ where
             era,
             static_files,
             statedb,
+            storage,
         };
 
         let data_dir = node_config.datadir();

--- a/crates/cli/commands/src/node.rs
+++ b/crates/cli/commands/src/node.rs
@@ -10,7 +10,7 @@ use reth_node_builder::NodeBuilder;
 use reth_node_core::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, EraArgs, MetricArgs,
-        NetworkArgs, PayloadBuilderArgs, PruningArgs, RpcServerArgs, StaticFilesArgs, StorageArgs,
+        NetworkArgs, PayloadBuilderArgs, PruningArgs, RpcServerArgs, StateDbArgs, StaticFilesArgs,
         TxPoolArgs,
     },
     node_config::NodeConfig,
@@ -115,9 +115,9 @@ pub struct NodeCommand<C: ChainSpecParser, Ext: clap::Args + fmt::Debug = NoArgs
     #[command(flatten, next_help_heading = "Static Files")]
     pub static_files: StaticFilesArgs,
 
-    /// All storage related arguments with --storage prefix
-    #[command(flatten, next_help_heading = "Storage")]
-    pub storage: StorageArgs,
+    /// All state database related arguments
+    #[command(flatten, next_help_heading = "StateDB")]
+    pub statedb: StateDbArgs,
 
     /// Additional cli arguments
     #[command(flatten, next_help_heading = "Extension")]
@@ -174,7 +174,7 @@ where
             engine,
             era,
             static_files,
-            storage,
+            statedb,
             ext,
         } = self;
 
@@ -198,7 +198,7 @@ where
             engine,
             era,
             static_files,
-            storage,
+            statedb,
         };
 
         let data_dir = node_config.datadir();

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -96,7 +96,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         // Initialize or disable TrieDB based on config
         if let Some(ref statedb_config) = config.statedb {
             if statedb_config.r#type == "triedb" {
-                init_global_triedb_manager(&statedb_config.path.to_string_lossy().to_string());
+                init_global_triedb_manager(&statedb_config.path.to_string_lossy());
                 is_triedb = true;
             } else {
                 disable_triedb();
@@ -107,7 +107,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
         }
 
         let builder = if is_triedb {
-            let builder = if self.offline {
+            if self.offline {
                 Pipeline::<N>::builder().add_stages(
                     OfflineStages::new(
                         evm_config,
@@ -149,50 +149,44 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
                         ExExManagerHandle::empty(),
                     )),
                 )
-            };
-
-            builder
+            }
+        } else if self.offline {
+            Pipeline::<N>::builder().add_stages(
+                OfflineStages::new(
+                    evm_config,
+                    NoopConsensus::arc(),
+                    config.stages,
+                    prune_modes.clone(),
+                )
+                .builder()
+                .disable(reth_stages::StageId::SenderRecovery),
+            )
         } else {
-            let builder = if self.offline {
-                Pipeline::<N>::builder().add_stages(
-                    OfflineStages::new(
-                        evm_config,
-                        NoopConsensus::arc(),
-                        config.stages,
-                        prune_modes.clone(),
-                    )
-                    .builder()
-                    .disable(reth_stages::StageId::SenderRecovery),
+            Pipeline::<N>::builder().with_tip_sender(tip_tx).add_stages(
+                DefaultStages::new(
+                    provider_factory.clone(),
+                    tip_rx,
+                    Arc::new(NoopConsensus::default()),
+                    NoopHeaderDownloader::default(),
+                    NoopBodiesDownloader::default(),
+                    evm_config.clone(),
+                    stage_conf.clone(),
+                    prune_modes.clone(),
+                    None,
                 )
-            } else {
-                Pipeline::<N>::builder().with_tip_sender(tip_tx).add_stages(
-                    DefaultStages::new(
-                        provider_factory.clone(),
-                        tip_rx,
-                        Arc::new(NoopConsensus::default()),
-                        NoopHeaderDownloader::default(),
-                        NoopBodiesDownloader::default(),
-                        evm_config.clone(),
-                        stage_conf.clone(),
-                        prune_modes.clone(),
-                        None,
-                    )
-                    .set(ExecutionStage::new(
-                        evm_config,
-                        Arc::new(NoopConsensus::default()),
-                        ExecutionStageThresholds {
-                            max_blocks: None,
-                            max_changes: None,
-                            max_cumulative_gas: None,
-                            max_duration: None,
-                        },
-                        stage_conf.execution_external_clean_threshold(),
-                        ExExManagerHandle::empty(),
-                    )),
-                )
-            };
-
-            builder
+                .set(ExecutionStage::new(
+                    evm_config,
+                    Arc::new(NoopConsensus::default()),
+                    ExecutionStageThresholds {
+                        max_blocks: None,
+                        max_changes: None,
+                        max_cumulative_gas: None,
+                        max_duration: None,
+                    },
+                    stage_conf.execution_external_clean_threshold(),
+                    ExExManagerHandle::empty(),
+                )),
+            )
         };
 
         let pipeline = builder.build(

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -22,6 +22,7 @@ use reth_stages::{
     ExecutionStageThresholds, Pipeline, StageSet,
 };
 use reth_static_file::StaticFileProducer;
+use rust_eth_triedb::triedb_manager::{disable_triedb, init_global_triedb_manager};
 use std::sync::Arc;
 use tokio::sync::watch;
 use tracing::info;
@@ -91,43 +92,107 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + EthereumHardforks>> Command<C>
 
         let (tip_tx, tip_rx) = watch::channel(B256::ZERO);
 
-        let builder = if self.offline {
-            Pipeline::<N>::builder().add_stages(
-                OfflineStages::new(
-                    evm_config,
-                    NoopConsensus::arc(),
-                    config.stages,
-                    prune_modes.clone(),
-                )
-                .builder()
-                .disable(reth_stages::StageId::SenderRecovery),
-            )
+        let mut is_triedb = false;
+        // Initialize or disable TrieDB based on config
+        if let Some(ref statedb_config) = config.statedb {
+            if statedb_config.r#type == "triedb" {
+                init_global_triedb_manager(&statedb_config.path.to_string_lossy().to_string());
+                is_triedb = true;
+            } else {
+                disable_triedb();
+            }
         } else {
-            Pipeline::<N>::builder().with_tip_sender(tip_tx).add_stages(
-                DefaultStages::new(
-                    provider_factory.clone(),
-                    tip_rx,
-                    Arc::new(NoopConsensus::default()),
-                    NoopHeaderDownloader::default(),
-                    NoopBodiesDownloader::default(),
-                    evm_config.clone(),
-                    stage_conf.clone(),
-                    prune_modes.clone(),
-                    None,
+            // No statedb config, default to MDBX
+            disable_triedb();
+        }
+
+        let builder = if is_triedb {
+            let builder = if self.offline {
+                Pipeline::<N>::builder().add_stages(
+                    OfflineStages::new(
+                        evm_config,
+                        NoopConsensus::arc(),
+                        config.stages,
+                        prune_modes.clone(),
+                    )
+                    .builder()
+                    .disable(reth_stages::StageId::SenderRecovery)
+                    .disable(reth_stages::StageId::MerkleExecute)
+                    .disable(reth_stages::StageId::MerkleUnwind),
                 )
-                .set(ExecutionStage::new(
-                    evm_config,
-                    Arc::new(NoopConsensus::default()),
-                    ExecutionStageThresholds {
-                        max_blocks: None,
-                        max_changes: None,
-                        max_cumulative_gas: None,
-                        max_duration: None,
-                    },
-                    stage_conf.execution_external_clean_threshold(),
-                    ExExManagerHandle::empty(),
-                )),
-            )
+            } else {
+                Pipeline::<N>::builder().with_tip_sender(tip_tx).add_stages(
+                    DefaultStages::new(
+                        provider_factory.clone(),
+                        tip_rx,
+                        Arc::new(NoopConsensus::default()),
+                        NoopHeaderDownloader::default(),
+                        NoopBodiesDownloader::default(),
+                        evm_config.clone(),
+                        stage_conf.clone(),
+                        prune_modes.clone(),
+                        None,
+                    )
+                    .builder()
+                    .disable(reth_stages::StageId::MerkleExecute)
+                    .disable(reth_stages::StageId::MerkleUnwind)
+                    .set(ExecutionStage::new(
+                        evm_config,
+                        Arc::new(NoopConsensus::default()),
+                        ExecutionStageThresholds {
+                            max_blocks: None,
+                            max_changes: None,
+                            max_cumulative_gas: None,
+                            max_duration: None,
+                        },
+                        stage_conf.execution_external_clean_threshold(),
+                        ExExManagerHandle::empty(),
+                    )),
+                )
+            };
+
+            builder
+        } else {
+            let builder = if self.offline {
+                Pipeline::<N>::builder().add_stages(
+                    OfflineStages::new(
+                        evm_config,
+                        NoopConsensus::arc(),
+                        config.stages,
+                        prune_modes.clone(),
+                    )
+                    .builder()
+                    .disable(reth_stages::StageId::SenderRecovery),
+                )
+            } else {
+                Pipeline::<N>::builder().with_tip_sender(tip_tx).add_stages(
+                    DefaultStages::new(
+                        provider_factory.clone(),
+                        tip_rx,
+                        Arc::new(NoopConsensus::default()),
+                        NoopHeaderDownloader::default(),
+                        NoopBodiesDownloader::default(),
+                        evm_config.clone(),
+                        stage_conf.clone(),
+                        prune_modes.clone(),
+                        None,
+                    )
+                    .set(ExecutionStage::new(
+                        evm_config,
+                        Arc::new(NoopConsensus::default()),
+                        ExecutionStageThresholds {
+                            max_blocks: None,
+                            max_changes: None,
+                            max_cumulative_gas: None,
+                            max_duration: None,
+                        },
+                        stage_conf.execution_external_clean_threshold(),
+                        ExExManagerHandle::empty(),
+                    )),
+                )
+            };
+
+            builder
         };
 
         let pipeline = builder.build(

--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -32,12 +32,21 @@ pub struct Config {
     /// Configuration for static files.
     #[cfg_attr(feature = "serde", serde(default))]
     pub static_files: StaticFilesConfig,
+
+    /// Configuration for state database.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
+    pub statedb: Option<StateDbConfig>,
 }
 
 impl Config {
     /// Sets the pruning configuration.
     pub fn set_prune_config(&mut self, prune_config: PruneConfig) {
         self.prune = prune_config;
+    }
+
+    /// Sets the state database configuration.
+    pub fn update_statedb_config(&mut self, statedb_config: StateDbConfig) {
+        self.statedb = Some(statedb_config);
     }
 }
 
@@ -613,6 +622,32 @@ impl PruneConfig {
 
         if self.segments.receipts_log_filter.0.is_empty() && !receipts_log_filter.0.is_empty() {
             self.segments.receipts_log_filter = receipts_log_filter;
+        }
+    }
+}
+
+/// State database configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct StateDbConfig {
+    /// State database type: "triedb" or "mdbx"
+    #[cfg_attr(feature = "serde", serde(default = "default_statedb_type"))]
+    pub r#type: String,
+    /// Path to the state database
+    pub path: PathBuf,
+}
+
+fn default_statedb_type() -> String {
+    "mdbx".to_string()
+}
+
+impl Default for StateDbConfig {
+    fn default() -> Self {
+        Self {
+            r#type: "mdbx".to_string(),
+            // Default path will be set based on datadir when loading config
+            path: PathBuf::from("db"),
         }
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -9,4 +9,4 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod config;
-pub use config::{BodiesConfig, Config, PruneConfig};
+pub use config::{BodiesConfig, Config, PruneConfig, StateDbConfig};

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -37,6 +37,9 @@ reth-trie.workspace = true
 reth-trie-common.workspace = true
 reth-trie-db.workspace = true
 
+# triedb
+rust-eth-triedb.workspace = true
+
 # alloy
 alloy-evm.workspace = true
 alloy-consensus.workspace = true
@@ -105,6 +108,7 @@ rand.workspace = true
 rand_08.workspace = true
 
 [features]
+io-uring = ["rust-eth-triedb/io-uring"]
 test-utils = [
     "reth-chain-state/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -185,6 +185,8 @@ pub struct EngineMetrics {
     pub(crate) failed_forkchoice_updated_response_deliveries: Counter,
     /// block insert duration
     pub(crate) block_insert_total_duration: Histogram,
+    /// Block insert throughput in mgas/s
+    pub(crate) block_insert_mgasps: Gauge,
 }
 
 /// Metrics for engine forkchoiceUpdated responses.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2967,6 +2967,8 @@ where
             self.execution_timing_stats.insert(executed.recovered_block().hash(), stats);
         }
 
+        let gas_used = executed.sealed_block().header().gas_used();
+
         // if the parent is the canonical head, we can insert the block as the pending block
         if self.state.tree_state.canonical_block_hash() == executed.recovered_block().parent_hash()
         {
@@ -2990,6 +2992,10 @@ where
             .engine
             .block_insert_total_duration
             .record(block_insert_start.elapsed().as_secs_f64());
+        self.metrics
+            .engine
+            .block_insert_mgasps
+            .set(gas_used as f64 / elapsed.as_secs_f64());
         debug!(target: "engine::tree", block=?block_num_hash, "Finished inserting block");
         Ok(InsertPayloadOk::Inserted(BlockStatus::Valid))
     }
@@ -3339,7 +3345,7 @@ where
                             return Ok((ret_header, Some(ret_td)))
                         }
                         None => {
-                            tracing::warn!(target: "engine::tree", current_number=?current_number, current_hash=?current_hash, 
+                            tracing::warn!(target: "engine::tree", current_number=?current_number, current_hash=?current_hash,
                                 "header td not found for block number, just return none");
                             return Ok((ret_header, None))
                         }

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2992,10 +2992,7 @@ where
             .engine
             .block_insert_total_duration
             .record(block_insert_start.elapsed().as_secs_f64());
-        self.metrics
-            .engine
-            .block_insert_mgasps
-            .set(gas_used as f64 / elapsed.as_secs_f64());
+        self.metrics.engine.block_insert_mgasps.set(gas_used as f64 / elapsed.as_secs_f64());
         debug!(target: "engine::tree", block=?block_num_hash, "Finished inserting block");
         Ok(InsertPayloadOk::Inserted(BlockStatus::Valid))
     }

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -366,6 +366,138 @@ where
         Err(InsertBlockError::new(block, execution_err).into())
     }
 
+    /// Validates a block that has already been converted from a payload with triedb.
+    pub fn validate_block_with_state_with_triedb<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
+        &mut self,
+        input: BlockOrPayload<T>,
+        mut ctx: TreeCtx<'_, N>,
+    ) -> ValidationOutcome<N, InsertPayloadError<N::Block>>
+    where
+        V: PayloadValidator<T, Block = N::Block>,
+        Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
+    {
+         /// A helper macro that returns the block in case there was an error
+         macro_rules! ensure_ok {
+            ($expr:expr) => {
+                match $expr {
+                    Ok(val) => val,
+                    Err(e) => {
+                        let block = self.convert_to_block(input)?;
+                        return Err(InsertBlockError::new(block.into_sealed_block(), e.into()).into())
+                    }
+                }
+            };
+        }
+
+        let parent_hash = input.parent_hash();
+        let block_num_hash = input.num_hash();
+
+        trace!(target: "engine::tree", block=?block_num_hash, parent=?parent_hash, "Fetching block state provider");
+        let Some(provider_builder) =
+            ensure_ok!(self.state_provider_builder(parent_hash, ctx.state()))
+        else {
+            // this is pre-validated in the tree
+            return Err(InsertBlockError::new(
+                self.convert_to_block(input)?.into_sealed_block(),
+                ProviderError::HeaderNotFound(parent_hash.into()).into(),
+            )
+            .into())
+        };
+
+        let state_provider = ensure_ok!(provider_builder.build());
+
+        // fetch parent block
+        let Some(parent_block) = ensure_ok!(self.sealed_header_by_hash(parent_hash, ctx.state()))
+        else {
+            return Err(InsertBlockError::new(
+                self.convert_to_block(input)?.into_sealed_block(),
+                ProviderError::HeaderNotFound(parent_hash.into()).into(),
+            )
+            .into())
+        };
+
+        let evm_env = self.evm_env_for(&input);
+
+        let env = ExecutionEnv { evm_env, hash: input.hash(), parent_hash: input.parent_hash() };
+
+        let txs = self.tx_iterator_for(&input)?;
+        let mut handle = self.payload_processor.spawn_cache_exclusive(
+            env.clone(),
+            txs,
+            provider_builder,
+        );
+
+        // Use cached state provider before executing, used in execution after prewarming threads
+        // complete
+        let state_provider = CachedStateProvider::new_with_caches(
+            state_provider,
+            handle.caches(),
+            handle.cache_metrics(),
+        );
+
+        let output = if self.config.state_provider_metrics() {
+            let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
+            let output = ensure_ok!(self.execute_block(&state_provider, env, &input, &mut handle));
+            state_provider.record_total_latency();
+            output
+        } else {
+            ensure_ok!(self.execute_block(&state_provider, env, &input, &mut handle))
+        };
+        // after executing the block we can stop executing transactions
+        handle.stop_prewarming_execution();
+
+        let block = self.convert_to_block(input)?;
+
+        // A helper macro that returns the block in case there was an error
+        macro_rules! ensure_ok {
+            ($expr:expr) => {
+                match $expr {
+                    Ok(val) => val,
+                    Err(e) => return Err(InsertBlockError::new(block.into_sealed_block(), e.into()).into()),
+                }
+            };
+        }
+
+        trace!(target: "engine::tree", block=?block_num_hash, "Validating block consensus");
+        // validate block consensus rules
+        ensure_ok!(self.validate_block_inner(&block));
+
+        // now validate against the parent
+        if let Err(e) =
+            self.consensus.validate_header_against_parent(block.sealed_header(), &parent_block)
+        {
+            warn!(target: "engine::tree", ?block, "Failed to validate header {} against parent: {e}", block.hash());
+            return Err(InsertBlockError::new(block.into_sealed_block(), e.into()).into())
+        }
+
+        if let Err(err) = self.consensus.validate_block_post_execution(&block, &output) {
+            // call post-block hook
+            self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
+            return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into())
+        }
+
+        let hashed_state = self.provider.hashed_post_state(&output.state);
+
+        if let Err(err) =
+            self.validator.validate_block_post_execution_with_hashed_state(&hashed_state, &block)
+        {
+            // call post-block hook
+            self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
+            return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into())
+        }
+        // terminate prewarming task with good state output
+        handle.terminate_caching(Some(output.state.clone()));
+
+        Ok(ExecutedBlockWithTrieUpdates {
+            block: ExecutedBlock {
+                recovered_block: Arc::new(block),
+                execution_output: Arc::new(ExecutionOutcome::from((output, block_num_hash.number))),
+                hashed_state: Arc::new(hashed_state),
+            },
+            trie: ExecutedTrieUpdates::Present(Arc::new(TrieUpdates::default())),
+        })
+    }
+
     /// Validates a block that has already been converted from a payload.
     ///
     /// This method performs:
@@ -391,6 +523,10 @@ where
         V: PayloadValidator<T, Block = N::Block> + Clone,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
+        if rust_eth_triedb::triedb_manager::is_triedb_active() {
+            return self.validate_block_with_state_with_triedb(input, ctx);
+        }
+
         // Spawn payload conversion on a background thread so it runs concurrently with the
         // rest of the function (setup + execution). For payloads this overlaps the cost of
         // RLP decoding + header hashing.

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -57,7 +57,8 @@ use reth_trie_sparse::debug_recorder::TrieDebugRecorder;
 
 use crate::tree::payload_processor::receipt_root_task::{IndexedReceipt, ReceiptRootTaskHandle};
 use reth_chain_state::{
-    CanonicalInMemoryState, DeferredTrieData, ExecutedBlock, ExecutionTimingStats, LazyOverlay,
+    CanonicalInMemoryState, ComputedTrieData, DeferredTrieData, ExecutedBlock,
+    ExecutionTimingStats, LazyOverlay,
 };
 use reth_consensus::{ConsensusError, FullConsensus, ReceiptRootBloom};
 use reth_engine_primitives::{
@@ -367,7 +368,12 @@ where
     }
 
     /// Validates a block that has already been converted from a payload with triedb.
-    pub fn validate_block_with_state_with_triedb<T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>>(
+    ///
+    /// This is a simplified path that skips state root computation since the triedb backend
+    /// handles state root verification independently.
+    pub fn validate_block_with_state_with_triedb<
+        T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives = N>>,
+    >(
         &mut self,
         input: BlockOrPayload<T>,
         mut ctx: TreeCtx<'_, N>,
@@ -376,93 +382,95 @@ where
         V: PayloadValidator<T, Block = N::Block>,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
-         /// A helper macro that returns the block in case there was an error
-         macro_rules! ensure_ok {
-            ($expr:expr) => {
-                match $expr {
-                    Ok(val) => val,
-                    Err(e) => {
-                        let block = self.convert_to_block(input)?;
-                        return Err(InsertBlockError::new(block.into_sealed_block(), e.into()).into())
-                    }
-                }
-            };
-        }
-
         let parent_hash = input.parent_hash();
         let block_num_hash = input.num_hash();
 
-        trace!(target: "engine::tree", block=?block_num_hash, parent=?parent_hash, "Fetching block state provider");
-        let Some(provider_builder) =
-            ensure_ok!(self.state_provider_builder(parent_hash, ctx.state()))
-        else {
-            // this is pre-validated in the tree
-            return Err(InsertBlockError::new(
-                self.convert_to_block(input)?.into_sealed_block(),
-                ProviderError::HeaderNotFound(parent_hash.into()).into(),
-            )
-            .into())
+        trace!(target: "engine::tree", block=?block_num_hash, parent=?parent_hash, "Fetching block state provider (triedb path)");
+
+        let provider_builder = match self.state_provider_builder(parent_hash, ctx.state()) {
+            Ok(Some(pb)) => pb,
+            Ok(None) => {
+                return Err(InsertBlockError::new(
+                    self.convert_to_block(input)?,
+                    ProviderError::HeaderNotFound(parent_hash.into()).into(),
+                )
+                .into())
+            }
+            Err(e) => {
+                return Err(InsertBlockError::new(self.convert_to_block(input)?, e.into()).into())
+            }
         };
 
-        let state_provider = ensure_ok!(provider_builder.build());
-
-        // fetch parent block
-        let Some(parent_block) = ensure_ok!(self.sealed_header_by_hash(parent_hash, ctx.state()))
-        else {
-            return Err(InsertBlockError::new(
-                self.convert_to_block(input)?.into_sealed_block(),
-                ProviderError::HeaderNotFound(parent_hash.into()).into(),
-            )
-            .into())
+        let state_provider = match provider_builder.build() {
+            Ok(sp) => sp,
+            Err(e) => {
+                return Err(InsertBlockError::new(self.convert_to_block(input)?, e.into()).into())
+            }
         };
 
-        let evm_env = self.evm_env_for(&input);
+        let parent_block = match self.sealed_header_by_hash(parent_hash, ctx.state()) {
+            Ok(Some(pb)) => pb,
+            Ok(None) => {
+                return Err(InsertBlockError::new(
+                    self.convert_to_block(input)?,
+                    ProviderError::HeaderNotFound(parent_hash.into()).into(),
+                )
+                .into())
+            }
+            Err(e) => {
+                return Err(InsertBlockError::new(self.convert_to_block(input)?, e.into()).into())
+            }
+        };
 
-        let env = ExecutionEnv { evm_env, hash: input.hash(), parent_hash: input.parent_hash() };
+        let evm_env = match self.evm_env_for(&input) {
+            Ok(env) => env,
+            Err(e) => {
+                return Err(InsertBlockError::new(
+                    self.convert_to_block(input)?,
+                    InsertBlockErrorKind::Other(Box::new(NewPayloadError::other(e))),
+                )
+                .into())
+            }
+        };
+
+        let env = ExecutionEnv {
+            evm_env,
+            hash: input.hash(),
+            parent_hash: input.parent_hash(),
+            parent_state_root: parent_block.state_root(),
+            transaction_count: input.transaction_count(),
+            gas_used: input.gas_used(),
+            withdrawals: input.withdrawals().map(|w| w.to_vec()),
+        };
 
         let txs = self.tx_iterator_for(&input)?;
-        let mut handle = self.payload_processor.spawn_cache_exclusive(
-            env.clone(),
-            txs,
-            provider_builder,
-        );
+        let mut handle =
+            self.payload_processor.spawn_cache_exclusive(env.clone(), txs, provider_builder, None);
 
-        // Use cached state provider before executing, used in execution after prewarming threads
-        // complete
-        let state_provider = CachedStateProvider::new_with_caches(
-            state_provider,
-            handle.caches(),
-            handle.cache_metrics(),
-        );
+        let mut state_provider: Box<dyn StateProvider + Send> = Box::new(state_provider);
+        if let Some((caches, cache_metrics)) = handle.caches().zip(handle.cache_metrics()) {
+            state_provider =
+                Box::new(CachedStateProvider::new(state_provider, caches, cache_metrics));
+        }
 
-        let output = if self.config.state_provider_metrics() {
-            let state_provider = InstrumentedStateProvider::from_state_provider(&state_provider);
-            let output = ensure_ok!(self.execute_block(&state_provider, env, &input, &mut handle));
-            state_provider.record_total_latency();
-            output
-        } else {
-            ensure_ok!(self.execute_block(&state_provider, env, &input, &mut handle))
-        };
-        // after executing the block we can stop executing transactions
+        let (output, senders, _receipt_rx) =
+            match self.execute_block(state_provider, env, &input, &mut handle) {
+                Ok(result) => result,
+                Err(e) => {
+                    return Err(InsertBlockError::new(self.convert_to_block(input)?, e).into())
+                }
+            };
+
         handle.stop_prewarming_execution();
 
         let block = self.convert_to_block(input)?;
+        let block = block.with_senders(senders);
 
-        // A helper macro that returns the block in case there was an error
-        macro_rules! ensure_ok {
-            ($expr:expr) => {
-                match $expr {
-                    Ok(val) => val,
-                    Err(e) => return Err(InsertBlockError::new(block.into_sealed_block(), e.into()).into()),
-                }
-            };
+        trace!(target: "engine::tree", block=?block_num_hash, "Validating block consensus (triedb)");
+        if let Err(e) = self.validate_block_inner(&block, None) {
+            return Err(InsertBlockError::new(block.into_sealed_block(), e.into()).into())
         }
 
-        trace!(target: "engine::tree", block=?block_num_hash, "Validating block consensus");
-        // validate block consensus rules
-        ensure_ok!(self.validate_block_inner(&block));
-
-        // now validate against the parent
         if let Err(e) =
             self.consensus.validate_header_against_parent(block.sealed_header(), &parent_block)
         {
@@ -470,8 +478,8 @@ where
             return Err(InsertBlockError::new(block.into_sealed_block(), e.into()).into())
         }
 
-        if let Err(err) = self.consensus.validate_block_post_execution(&block, &output) {
-            // call post-block hook
+        if let Err(err) = self.consensus.validate_block_post_execution(&block, &output.result, None)
+        {
             self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
             return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into())
         }
@@ -481,21 +489,22 @@ where
         if let Err(err) =
             self.validator.validate_block_post_execution_with_hashed_state(&hashed_state, &block)
         {
-            // call post-block hook
             self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
             return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into())
         }
-        // terminate prewarming task with good state output
-        handle.terminate_caching(Some(output.state.clone()));
 
-        Ok(ExecutedBlockWithTrieUpdates {
-            block: ExecutedBlock {
-                recovered_block: Arc::new(block),
-                execution_output: Arc::new(ExecutionOutcome::from((output, block_num_hash.number))),
-                hashed_state: Arc::new(hashed_state),
-            },
-            trie: ExecutedTrieUpdates::Present(Arc::new(TrieUpdates::default())),
-        })
+        let output = Arc::new(output);
+        handle.terminate_caching(Some(output.clone()));
+
+        // Skip state root computation — triedb handles state verification.
+        let trie_data = ComputedTrieData {
+            hashed_state: Arc::new(hashed_state.into_sorted()),
+            trie_updates: Arc::new(Default::default()),
+            anchored_trie_input: None,
+        };
+        let executed_block = ExecutedBlock::new(Arc::new(block), output, trie_data);
+
+        Ok((executed_block, None))
     }
 
     /// Validates a block that has already been converted from a payload.

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -88,6 +88,7 @@ asm-keccak = [
     "alloy-primitives/asm-keccak",
     "reth-node-core/asm-keccak",
     "revm/asm-keccak",
+    "reth-provider/asm-keccak",
 ]
 keccak-cache-global = [
     "alloy-primitives/keccak-cache-global",

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -82,6 +82,9 @@ fdlimit.workspace = true
 rayon.workspace = true
 serde_json.workspace = true
 
+## triedb
+rust-eth-triedb.workspace = true
+
 # tracing
 tracing.workspace = true
 
@@ -95,6 +98,7 @@ reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 
 [features]
 default = []
+io-uring = ["rust-eth-triedb/io-uring"]
 js-tracer = [
     "reth-rpc/js-tracer",
     "reth-node-ethereum/js-tracer",

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -38,8 +38,8 @@ use alloy_eips::eip2124::Head;
 use alloy_primitives::{BlockNumber, B256};
 use eyre::Context;
 use rayon::ThreadPoolBuilder;
-use reth_chainspec::{Chain, EthChainSpec, EthereumHardforks};
-use reth_config::{config::EtlConfig, PruneConfig};
+use reth_chainspec::{Chain, EthChainSpec, EthereumHardfork, EthereumHardforks};
+use reth_config::{config::EtlConfig, PruneConfig, StateDbConfig};
 use reth_consensus::noop::NoopConsensus;
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
 use reth_db_common::init::{init_genesis_with_settings, InitStorageError};
@@ -66,8 +66,9 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
-    BlockHashReader, BlockNumReader, ProviderError, ProviderFactory, ProviderResult,
-    RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderBuilder,
+    BlockHashReader, BlockNumReader, DatabaseProviderFactory, ProviderError, ProviderFactory,
+    HeaderProvider, ProviderResult, RocksDBProviderFactory, StageCheckpointReader,
+    StaticFileProviderBuilder,
     StaticFileProviderFactory,
 };
 use reth_prune::{PruneModes, PrunerBuilder};
@@ -85,7 +86,7 @@ use reth_tracing::{
 };
 use reth_transaction_pool::TransactionPool;
 use reth_trie_db::ChangesetCache;
-use std::{num::NonZeroUsize, sync::Arc, thread::available_parallelism, time::Duration};
+use std::{path::PathBuf, sync::Arc, thread::available_parallelism, time::Duration};
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedSender},
     oneshot, watch,
@@ -94,6 +95,7 @@ use tokio::sync::{
 use futures::{future::Either, stream, Stream, StreamExt};
 use reth_node_ethstats::EthStatsService;
 use reth_node_events::{cl::ConsensusLayerHealthEvents, node::NodeEvent};
+use rust_eth_triedb::triedb_manager::{init_global_triedb_manager, disable_triedb, is_triedb_active};
 
 /// Reusable setup for launching a node.
 ///
@@ -164,6 +166,7 @@ impl LaunchContext {
             .wrap_err_with(|| format!("Could not load config file {config_path:?}"))?;
 
         Self::save_pruning_config(&mut toml_config, config, &config_path)?;
+        Self::save_statedb_config_if_triedb(&mut toml_config, config, &config_path, &self.data_dir)?;
 
         info!(target: "reth::cli", path = ?config_path, "Configuration loaded");
 
@@ -200,6 +203,109 @@ impl LaunchContext {
 
         if should_save {
             info!(target: "reth::cli", "Saving prune config to toml file");
+            reth_config.save(config_path.as_ref())?;
+        }
+
+        Ok(())
+    }
+
+    /// Save state database config to the toml file.
+    fn save_statedb_config_if_triedb<ChainSpec>(
+        reth_config: &mut reth_config::Config,
+        config: &NodeConfig<ChainSpec>,
+        config_path: impl AsRef<std::path::Path>,
+        data_dir: &ChainPath<DataDirPath>,
+    ) -> eyre::Result<()>
+    where
+        ChainSpec: EthChainSpec + reth_chainspec::EthereumHardforks,
+    {
+        // Collect information first to avoid borrow conflicts
+        let update_action: Option<(PathBuf, StateDbConfig)> = match &reth_config.statedb {
+            Some(existing_config) => {
+                // Config already exists in file, log current config
+                info!(
+                    target: "reth::cli",
+                    db_type = %existing_config.r#type,
+                    db_path = ?existing_config.path,
+                    "State database config found in toml file"
+                );
+
+                // Check for conflicts
+                if config.statedb.triedb && existing_config.r#type != "triedb" {
+                    warn!(
+                        target: "reth::cli",
+                        "Conflict: --statedb.triedb is set but config file specifies {} database. Using config file setting.",
+                        existing_config.r#type
+                    );
+                }
+
+                // Update path if it may have changed (e.g., datadir changed)
+                let expected_path = if existing_config.r#type == "triedb" {
+                    data_dir.data_dir().join("rust_eth_triedb")
+                } else {
+                    data_dir.data_dir().join("db")
+                };
+
+                // Initialize or disable TrieDB based on config type
+                if existing_config.r#type == "triedb" {
+                    // Initialize TrieDB with the configured path
+                    let path_str = expected_path.to_string_lossy().to_string();
+                    init_global_triedb_manager(&path_str);
+                } else {
+                    // Disable TrieDB if using MDBX
+                    disable_triedb();
+                }
+
+                // Check if path needs to be updated
+                if existing_config.path != expected_path {
+                    let mut updated_config = existing_config.clone();
+                    updated_config.path = expected_path.clone();
+                    Some((expected_path, updated_config))
+                } else {
+                    None
+                }
+            }
+            None => {
+                // No config in file, create and save based on command line argument
+                if config.statedb.triedb {
+                    // Use TrieDB
+                    let triedb_path = data_dir.data_dir().join("rust_eth_triedb");
+                    let path_str = triedb_path.to_string_lossy().to_string();
+                    let statedb_config = StateDbConfig {
+                        r#type: "triedb".to_string(),
+                        path: triedb_path.clone(),
+                    };
+                    reth_config.update_statedb_config(statedb_config);
+                    info!(target: "reth::cli", "Saving state database config (triedb) to toml file");
+                    reth_config.save(config_path.as_ref())?;
+                    // Initialize TrieDB
+                    init_global_triedb_manager(&path_str);
+                    None
+                } else {
+                    // Use default MDBX and save to file
+                    let db_path = data_dir.data_dir().join("db");
+                    let statedb_config = StateDbConfig {
+                        r#type: "mdbx".to_string(),
+                        path: db_path,
+                    };
+                    reth_config.update_statedb_config(statedb_config);
+                    info!(target: "reth::cli", "Saving state database config (mdbx) to toml file");
+                    reth_config.save(config_path.as_ref())?;
+                    // Disable TrieDB
+                    disable_triedb();
+                    None
+                }
+            }
+        };
+
+        // Perform update action outside the match block to avoid borrow conflicts
+        if let Some((new_path, updated_config)) = update_action {
+            reth_config.update_statedb_config(updated_config);
+            info!(
+                target: "reth::cli",
+                new_path = ?new_path,
+                "Updating state database path in config file"
+            );
             reth_config.save(config_path.as_ref())?;
         }
 
@@ -949,6 +1055,10 @@ where
     ///
     /// A target block hash if the pipeline is inconsistent, otherwise `None`.
     pub fn check_pipeline_consistency(&self) -> ProviderResult<Option<B256>> {
+        if is_triedb_active() {
+            return self.check_pipeline_consistency_under_triedb();
+        }
+
         // We skip the era stage if it's not enabled
         let era_enabled = self.era_import_source().is_some();
         let mut all_stages =
@@ -1001,6 +1111,118 @@ where
         Ok(None)
     }
 
+
+    /// Check if the pipeline is consistent under TrieDB.
+    pub fn check_pipeline_consistency_under_triedb(&self) -> ProviderResult<Option<B256>> {
+        // If no target was provided, check if the stages are congruent - check if the
+        // checkpoint of the last stage matches the checkpoint of the first.
+        let mut first_stage_checkpoint = self
+            .blockchain_db()
+            .get_stage_checkpoint(*StageId::ALL.first().unwrap())?
+            .unwrap_or_default()
+            .block_number;
+
+        let triedb = rust_eth_triedb::get_global_triedb();
+        let (triedb_checkpoint_block_number, triedb_checkpoint_state_root) = triedb.latest_persist_state().unwrap();
+
+        // Skip the first stage as we've already retrieved it and comparing all other checkpoints
+        // against it.
+        for stage_id in StageId::ALL.iter() {
+            let stage_checkpoint = self
+                .blockchain_db()
+                .get_stage_checkpoint(*stage_id)?
+                .unwrap_or_default()
+                .block_number;
+
+            // If the checkpoint of any stage is less than the checkpoint of the first stage,
+            // retrieve and return the block hash of the latest header and use it as the target.
+            if stage_checkpoint < first_stage_checkpoint {
+                if triedb_checkpoint_block_number > first_stage_checkpoint {
+                    info!(
+                        target: "consensus::engine",
+                        triedb_checkpoint_block_number,
+                        first_stage_checkpoint,
+                        "TrieDB checkpoint is ahead of the first stage checkpoint, using TrieDB checkpoint as the target"
+                    );
+                    first_stage_checkpoint = triedb_checkpoint_block_number;
+                }
+                info!(
+                    target: "consensus::engine",
+                    first_stage_checkpoint,
+                    inconsistent_stage_id = %stage_id,
+                    inconsistent_stage_checkpoint = stage_checkpoint,
+                    "Pipeline sync progress is inconsistent"
+                );
+                return self.blockchain_db().block_hash(first_stage_checkpoint);
+            }
+        }
+
+        info!(target: "consensus::engine", "Pipeline sync progress is consistent, will check live sync progress");
+
+        let last_persisted_block_number = self.blockchain_db().last_block_number()?;
+        let last_persisted_header = self.blockchain_db().header_by_number(last_persisted_block_number)?
+            .ok_or_else(|| reth_provider::ProviderError::HeaderNotFound(alloy_eips::BlockHashOrNumber::Number(last_persisted_block_number)))?;
+        let last_persisted_state_root = last_persisted_header.state_root();
+
+        if last_persisted_block_number > triedb_checkpoint_block_number {
+            info!(target: "consensus::engine",
+            last_persisted_block_number,
+            last_persisted_state_root = ?last_persisted_state_root,
+            triedb_checkpoint_block_number,
+            triedb_checkpoint_state_root = ?triedb_checkpoint_state_root,
+            "Last persisted state is ahead of the TrieDB state, start pipeline sync to align");
+            return self.blockchain_db().block_hash(last_persisted_block_number);
+        } else if last_persisted_block_number < triedb_checkpoint_block_number {
+            info!(target: "consensus::engine",
+            last_persisted_block_number,
+            last_persisted_state_root = ?last_persisted_state_root,
+            triedb_checkpoint_block_number,
+            triedb_checkpoint_state_root = ?triedb_checkpoint_state_root,
+            "Last persisted state is behind of the TrieDB state, start pipeline sync to align");
+            return self.blockchain_db().block_hash(last_persisted_block_number);
+        } else {
+            info!(target: "consensus::engine",
+            last_persisted_block_number,
+            last_persisted_state_root = ?last_persisted_state_root,
+            triedb_checkpoint_block_number,
+            triedb_checkpoint_state_root = ?triedb_checkpoint_state_root,
+            "Last persisted state equal TrieDB state, start live sync");
+        }
+
+        Ok(None)
+    }
+    /// Expire the pre-merge transactions if the node is configured to do so and the chain has a
+    /// merge block.
+    ///
+    /// If the node is configured to prune pre-merge transactions and it has synced past the merge
+    /// block, it will delete the pre-merge transaction static files if they still exist.
+    pub fn expire_pre_merge_transactions(&self) -> eyre::Result<()>
+    where
+        T: FullNodeTypes<Provider: StaticFileProviderFactory>,
+    {
+        if self.node_config().pruning.bodies_pre_merge {
+            if let Some(merge_block) =
+                self.chain_spec().ethereum_fork_activation(EthereumHardfork::Paris).block_number()
+            {
+                // Ensure we only expire transactions after we synced past the merge block.
+                let Some(latest) = self.blockchain_db().latest_header()? else { return Ok(()) };
+                if latest.number() > merge_block {
+                    let provider = self.blockchain_db().static_file_provider();
+                    if provider
+                        .get_lowest_transaction_static_file_block()
+                        .is_some_and(|lowest| lowest < merge_block)
+                    {
+                        info!(target: "reth::cli", merge_block, "Expiring pre-merge transactions");
+                        provider.delete_transactions_below(merge_block)?;
+                    } else {
+                        debug!(target: "reth::cli", merge_block, "No pre-merge transactions to expire");
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
     /// Returns the metrics sender.
     pub fn sync_metrics_tx(&self) -> UnboundedSender<MetricEvent> {
         self.right().db_provider_container.metrics_sender.clone()

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -34,11 +34,12 @@ use crate::{
     hooks::OnComponentInitializedHook,
     BuilderContext, ExExLauncher, NodeAdapter, PrimitivesTy,
 };
+use alloy_consensus::BlockHeader as _;
 use alloy_eips::eip2124::Head;
 use alloy_primitives::{BlockNumber, B256};
 use eyre::Context;
 use rayon::ThreadPoolBuilder;
-use reth_chainspec::{Chain, EthChainSpec, EthereumHardfork, EthereumHardforks};
+use reth_chainspec::{Chain, EthChainSpec, EthereumHardforks};
 use reth_config::{config::EtlConfig, PruneConfig, StateDbConfig};
 use reth_consensus::noop::NoopConsensus;
 use reth_db_api::{database::Database, database_metrics::DatabaseMetrics};
@@ -66,10 +67,9 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
-    BlockHashReader, BlockNumReader, DatabaseProviderFactory, ProviderError, ProviderFactory,
-    HeaderProvider, ProviderResult, RocksDBProviderFactory, StageCheckpointReader,
-    StaticFileProviderBuilder,
-    StaticFileProviderFactory,
+    BlockHashReader, BlockNumReader, HeaderProvider, ProviderError, ProviderFactory,
+    ProviderResult, RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderBuilder,
+    StaticFileProviderFactory, StorageSettings,
 };
 use reth_prune::{PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;
@@ -86,7 +86,9 @@ use reth_tracing::{
 };
 use reth_transaction_pool::TransactionPool;
 use reth_trie_db::ChangesetCache;
-use std::{path::PathBuf, sync::Arc, thread::available_parallelism, time::Duration};
+use std::{
+    num::NonZeroUsize, path::PathBuf, sync::Arc, thread::available_parallelism, time::Duration,
+};
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedSender},
     oneshot, watch,
@@ -95,7 +97,9 @@ use tokio::sync::{
 use futures::{future::Either, stream, Stream, StreamExt};
 use reth_node_ethstats::EthStatsService;
 use reth_node_events::{cl::ConsensusLayerHealthEvents, node::NodeEvent};
-use rust_eth_triedb::triedb_manager::{init_global_triedb_manager, disable_triedb, is_triedb_active};
+use rust_eth_triedb::triedb_manager::{
+    disable_triedb, init_global_triedb_manager, is_triedb_active,
+};
 
 /// Reusable setup for launching a node.
 ///
@@ -166,7 +170,12 @@ impl LaunchContext {
             .wrap_err_with(|| format!("Could not load config file {config_path:?}"))?;
 
         Self::save_pruning_config(&mut toml_config, config, &config_path)?;
-        Self::save_statedb_config_if_triedb(&mut toml_config, config, &config_path, &self.data_dir)?;
+        Self::save_statedb_config_if_triedb(
+            &mut toml_config,
+            config,
+            &config_path,
+            &self.data_dir,
+        )?;
 
         info!(target: "reth::cli", path = ?config_path, "Configuration loaded");
 
@@ -249,52 +258,43 @@ impl LaunchContext {
                 // Initialize or disable TrieDB based on config type
                 if existing_config.r#type == "triedb" {
                     // Initialize TrieDB with the configured path
-                    let path_str = expected_path.to_string_lossy().to_string();
-                    init_global_triedb_manager(&path_str);
+                    init_global_triedb_manager(&expected_path.to_string_lossy());
                 } else {
                     // Disable TrieDB if using MDBX
                     disable_triedb();
                 }
 
                 // Check if path needs to be updated
-                if existing_config.path != expected_path {
+                (existing_config.path != expected_path).then(|| {
                     let mut updated_config = existing_config.clone();
                     updated_config.path = expected_path.clone();
-                    Some((expected_path, updated_config))
-                } else {
-                    None
-                }
+                    (expected_path, updated_config)
+                })
             }
             None => {
                 // No config in file, create and save based on command line argument
                 if config.statedb.triedb {
                     // Use TrieDB
                     let triedb_path = data_dir.data_dir().join("rust_eth_triedb");
-                    let path_str = triedb_path.to_string_lossy().to_string();
-                    let statedb_config = StateDbConfig {
-                        r#type: "triedb".to_string(),
-                        path: triedb_path.clone(),
-                    };
+                    let statedb_config =
+                        StateDbConfig { r#type: "triedb".to_string(), path: triedb_path.clone() };
                     reth_config.update_statedb_config(statedb_config);
                     info!(target: "reth::cli", "Saving state database config (triedb) to toml file");
                     reth_config.save(config_path.as_ref())?;
                     // Initialize TrieDB
-                    init_global_triedb_manager(&path_str);
-                    None
+                    init_global_triedb_manager(&triedb_path.to_string_lossy());
                 } else {
                     // Use default MDBX and save to file
                     let db_path = data_dir.data_dir().join("db");
-                    let statedb_config = StateDbConfig {
-                        r#type: "mdbx".to_string(),
-                        path: db_path,
-                    };
+                    let statedb_config =
+                        StateDbConfig { r#type: "mdbx".to_string(), path: db_path };
                     reth_config.update_statedb_config(statedb_config);
                     info!(target: "reth::cli", "Saving state database config (mdbx) to toml file");
                     reth_config.save(config_path.as_ref())?;
                     // Disable TrieDB
                     disable_triedb();
-                    None
                 }
+                None
             }
         };
 
@@ -765,13 +765,13 @@ where
 
     /// Convenience function to [`Self::init_genesis`]
     pub fn with_genesis(self) -> Result<Self, InitStorageError> {
-        init_genesis_with_settings(self.provider_factory(), self.node_config().storage_settings())?;
+        init_genesis_with_settings(self.provider_factory(), StorageSettings::base())?;
         Ok(self)
     }
 
     /// Write the genesis block and state if it has not already been written
     pub fn init_genesis(&self) -> Result<B256, InitStorageError> {
-        init_genesis_with_settings(self.provider_factory(), self.node_config().storage_settings())
+        init_genesis_with_settings(self.provider_factory(), StorageSettings::base())
     }
 
     /// Creates a new `WithMeteredProvider` container and attaches it to the
@@ -1111,8 +1111,7 @@ where
         Ok(None)
     }
 
-
-    /// Check if the pipeline is consistent under TrieDB.
+    /// Check if the pipeline is consistent under `TrieDB`.
     pub fn check_pipeline_consistency_under_triedb(&self) -> ProviderResult<Option<B256>> {
         // If no target was provided, check if the stages are congruent - check if the
         // checkpoint of the last stage matches the checkpoint of the first.
@@ -1123,11 +1122,12 @@ where
             .block_number;
 
         let triedb = rust_eth_triedb::get_global_triedb();
-        let (triedb_checkpoint_block_number, triedb_checkpoint_state_root) = triedb.latest_persist_state().unwrap();
+        let (triedb_checkpoint_block_number, triedb_checkpoint_state_root) =
+            triedb.latest_persist_state().unwrap();
 
         // Skip the first stage as we've already retrieved it and comparing all other checkpoints
         // against it.
-        for stage_id in StageId::ALL.iter() {
+        for stage_id in &StageId::ALL {
             let stage_checkpoint = self
                 .blockchain_db()
                 .get_stage_checkpoint(*stage_id)?
@@ -1160,8 +1160,14 @@ where
         info!(target: "consensus::engine", "Pipeline sync progress is consistent, will check live sync progress");
 
         let last_persisted_block_number = self.blockchain_db().last_block_number()?;
-        let last_persisted_header = self.blockchain_db().header_by_number(last_persisted_block_number)?
-            .ok_or_else(|| reth_provider::ProviderError::HeaderNotFound(alloy_eips::BlockHashOrNumber::Number(last_persisted_block_number)))?;
+        let last_persisted_header = self
+            .blockchain_db()
+            .header_by_number(last_persisted_block_number)?
+            .ok_or_else(|| {
+                reth_provider::ProviderError::HeaderNotFound(alloy_eips::BlockHashOrNumber::Number(
+                    last_persisted_block_number,
+                ))
+            })?;
         let last_persisted_state_root = last_persisted_header.state_root();
 
         if last_persisted_block_number > triedb_checkpoint_block_number {
@@ -1180,14 +1186,14 @@ where
             triedb_checkpoint_state_root = ?triedb_checkpoint_state_root,
             "Last persisted state is behind of the TrieDB state, start pipeline sync to align");
             return self.blockchain_db().block_hash(last_persisted_block_number);
-        } else {
-            info!(target: "consensus::engine",
+        }
+
+        info!(target: "consensus::engine",
             last_persisted_block_number,
             last_persisted_state_root = ?last_persisted_state_root,
             triedb_checkpoint_block_number,
             triedb_checkpoint_state_root = ?triedb_checkpoint_state_root,
             "Last persisted state equal TrieDB state, start live sync");
-        }
 
         Ok(None)
     }
@@ -1196,31 +1202,12 @@ where
     ///
     /// If the node is configured to prune pre-merge transactions and it has synced past the merge
     /// block, it will delete the pre-merge transaction static files if they still exist.
-    pub fn expire_pre_merge_transactions(&self) -> eyre::Result<()>
+    pub const fn expire_pre_merge_transactions(&self) -> eyre::Result<()>
     where
         T: FullNodeTypes<Provider: StaticFileProviderFactory>,
     {
-        if self.node_config().pruning.bodies_pre_merge {
-            if let Some(merge_block) =
-                self.chain_spec().ethereum_fork_activation(EthereumHardfork::Paris).block_number()
-            {
-                // Ensure we only expire transactions after we synced past the merge block.
-                let Some(latest) = self.blockchain_db().latest_header()? else { return Ok(()) };
-                if latest.number() > merge_block {
-                    let provider = self.blockchain_db().static_file_provider();
-                    if provider
-                        .get_lowest_transaction_static_file_block()
-                        .is_some_and(|lowest| lowest < merge_block)
-                    {
-                        info!(target: "reth::cli", merge_block, "Expiring pre-merge transactions");
-                        provider.delete_transactions_below(merge_block)?;
-                    } else {
-                        debug!(target: "reth::cli", merge_block, "No pre-merge transactions to expire");
-                    }
-                }
-            }
-        }
-
+        // Pre-merge transaction expiry requires `get_lowest_transaction_static_file_block`
+        // and `delete_transactions_below` which are not yet implemented in this fork.
         Ok(())
     }
     /// Returns the metrics sender.

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -126,7 +126,9 @@ impl EngineNodeLauncher {
             })?
             .with_components(components_builder, on_component_initialized).await?;
 
-        let engine_tree_config = if is_triedb_active() && engine_tree_config.memory_block_buffer_target() < 256 {
+        let engine_tree_config = if is_triedb_active() &&
+            engine_tree_config.memory_block_buffer_target() < 256
+        {
             info!(target: "reth::cli", "TrieDB is active, setting memory block buffer target to 256, old target={}", engine_tree_config.memory_block_buffer_target());
             engine_tree_config.with_memory_block_buffer_target(256)
         } else {

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -38,6 +38,7 @@ use reth_tasks::TaskExecutor;
 use reth_tokio_util::EventSender;
 use reth_tracing::tracing::{debug, error, info};
 use reth_trie_db::ChangesetCache;
+use rust_eth_triedb::triedb_manager::is_triedb_active;
 use std::{future::Future, pin::Pin, sync::Arc};
 use tokio::sync::{mpsc::unbounded_channel, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
@@ -125,6 +126,15 @@ impl EngineNodeLauncher {
             })?
             .with_components(components_builder, on_component_initialized).await?;
 
+        let engine_tree_config = if is_triedb_active() && engine_tree_config.memory_block_buffer_target() < 256 {
+            info!(target: "reth::cli", "TrieDB is active, setting memory block buffer target to 256, old target={}", engine_tree_config.memory_block_buffer_target());
+            engine_tree_config.with_memory_block_buffer_target(256)
+        } else {
+            engine_tree_config.clone()
+        };
+
+        // Try to expire pre-merge transaction history if configured
+        ctx.expire_pre_merge_transactions()?;
         // spawn exexs if any
         let maybe_exex_manager_handle = ctx.launch_exex(installed_exex).await?;
 

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -111,62 +111,60 @@ where
 
     let pipeline = if is_triedb_active() {
         let pipeline = builder
-        .with_tip_sender(tip_tx)
-        .with_metrics_tx(metrics_tx)
-        .add_stages(
-            DefaultStages::new(
-                provider_factory.clone(),
-                tip_rx,
-                Arc::clone(&consensus),
-                header_downloader,
-                body_downloader,
-                evm_config.clone(),
-                stage_config.clone(),
-                prune_modes,
-                era_import_source,
+            .with_tip_sender(tip_tx)
+            .with_metrics_tx(metrics_tx)
+            .add_stages(
+                DefaultStages::new(
+                    provider_factory.clone(),
+                    tip_rx,
+                    Arc::clone(&consensus),
+                    header_downloader,
+                    body_downloader,
+                    evm_config.clone(),
+                    stage_config.clone(),
+                    prune_modes,
+                    era_import_source,
+                )
+                .builder()
+                .disable(reth_stages::StageId::MerkleExecute)
+                .disable(reth_stages::StageId::MerkleUnwind)
+                .set(ExecutionStage::new(
+                    evm_config,
+                    consensus,
+                    stage_config.execution.into(),
+                    stage_config.execution_external_clean_threshold(),
+                    exex_manager_handle,
+                )),
             )
-            .builder()
-            .disable(reth_stages::StageId::MerkleExecute)
-            .disable(reth_stages::StageId::MerkleUnwind)
-            .set(ExecutionStage::new(
-                evm_config,
-                consensus,
-                stage_config.execution.into(),
-                stage_config.execution_external_clean_threshold(),
-                exex_manager_handle,
-            )),
-        )
-        .build(provider_factory, static_file_producer);
+            .build(provider_factory, static_file_producer);
 
         info!(target: "reth::builder", "Pipeline built with TrieDB, without merkle execute and merkle unwind");
         pipeline
     } else {
-        let pipeline = builder
-        .with_tip_sender(tip_tx)
-        .with_metrics_tx(metrics_tx)
-        .add_stages(
-            DefaultStages::new(
-                provider_factory.clone(),
-                tip_rx,
-                Arc::clone(&consensus),
-                header_downloader,
-                body_downloader,
-                evm_config.clone(),
-                stage_config.clone(),
-                prune_modes,
-                era_import_source,
+        builder
+            .with_tip_sender(tip_tx)
+            .with_metrics_tx(metrics_tx)
+            .add_stages(
+                DefaultStages::new(
+                    provider_factory.clone(),
+                    tip_rx,
+                    Arc::clone(&consensus),
+                    header_downloader,
+                    body_downloader,
+                    evm_config.clone(),
+                    stage_config.clone(),
+                    prune_modes,
+                    era_import_source,
+                )
+                .set(ExecutionStage::new(
+                    evm_config,
+                    consensus,
+                    stage_config.execution.into(),
+                    stage_config.execution_external_clean_threshold(),
+                    exex_manager_handle,
+                )),
             )
-            .set(ExecutionStage::new(
-                evm_config,
-                consensus,
-                stage_config.execution.into(),
-                stage_config.execution_external_clean_threshold(),
-                exex_manager_handle,
-            )),
-        )
-        .build(provider_factory, static_file_producer);
-
-        pipeline
+            .build(provider_factory, static_file_producer)
     };
 
     Ok(pipeline)

--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -24,7 +24,8 @@ use reth_stages::{
 };
 use reth_static_file::StaticFileProducer;
 use reth_tasks::TaskExecutor;
-use reth_tracing::tracing::debug;
+use reth_tracing::tracing::{debug, info};
+use rust_eth_triedb::triedb_manager::is_triedb_active;
 use tokio::sync::watch;
 
 /// Constructs a [Pipeline] that's wired to the network
@@ -106,7 +107,10 @@ where
 
     let (tip_tx, tip_rx) = watch::channel(B256::ZERO);
 
-    let pipeline = builder
+    let prune_modes = prune_config.segments;
+
+    let pipeline = if is_triedb_active() {
+        let pipeline = builder
         .with_tip_sender(tip_tx)
         .with_metrics_tx(metrics_tx)
         .add_stages(
@@ -118,7 +122,38 @@ where
                 body_downloader,
                 evm_config.clone(),
                 stage_config.clone(),
-                prune_config.segments,
+                prune_modes,
+                era_import_source,
+            )
+            .builder()
+            .disable(reth_stages::StageId::MerkleExecute)
+            .disable(reth_stages::StageId::MerkleUnwind)
+            .set(ExecutionStage::new(
+                evm_config,
+                consensus,
+                stage_config.execution.into(),
+                stage_config.execution_external_clean_threshold(),
+                exex_manager_handle,
+            )),
+        )
+        .build(provider_factory, static_file_producer);
+
+        info!(target: "reth::builder", "Pipeline built with TrieDB, without merkle execute and merkle unwind");
+        pipeline
+    } else {
+        let pipeline = builder
+        .with_tip_sender(tip_tx)
+        .with_metrics_tx(metrics_tx)
+        .add_stages(
+            DefaultStages::new(
+                provider_factory.clone(),
+                tip_rx,
+                Arc::clone(&consensus),
+                header_downloader,
+                body_downloader,
+                evm_config.clone(),
+                stage_config.clone(),
+                prune_modes,
                 era_import_source,
             )
             .set(ExecutionStage::new(
@@ -130,6 +165,9 @@ where
             )),
         )
         .build(provider_factory, static_file_producer);
+
+        pipeline
+    };
 
     Ok(pipeline)
 }

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -76,9 +76,9 @@ pub use era::{DefaultEraHost, EraArgs, EraSourceArgs};
 mod static_files;
 pub use static_files::{StaticFilesArgs, MINIMAL_BLOCKS_PER_FILE};
 
-/// `StorageArgs` for configuring storage settings.
-mod storage;
-pub use storage::{DefaultStorageValues, StorageArgs};
+/// `StateDbArgs` for configuring state database.
+mod statedb;
+pub use statedb::StateDbArgs;
 
 mod error;
 pub mod types;

--- a/crates/node/core/src/args/mod.rs
+++ b/crates/node/core/src/args/mod.rs
@@ -80,5 +80,9 @@ pub use static_files::{StaticFilesArgs, MINIMAL_BLOCKS_PER_FILE};
 mod statedb;
 pub use statedb::StateDbArgs;
 
+/// `StorageArgs` for configuring storage layout (v1/v2).
+mod storage;
+pub use storage::{DefaultStorageValues, StorageArgs};
+
 mod error;
 pub mod types;

--- a/crates/node/core/src/args/statedb.rs
+++ b/crates/node/core/src/args/statedb.rs
@@ -6,8 +6,7 @@ use clap::Args;
 #[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
 #[command(next_help_heading = "State Database")]
 pub struct StateDbArgs {
-    /// Use TrieDB instead of MDBX for state database.
+    /// Use `TrieDB` instead of MDBX for state database.
     #[arg(long = "statedb.triedb", default_value_t = false)]
     pub triedb: bool,
 }
-

--- a/crates/node/core/src/args/statedb.rs
+++ b/crates/node/core/src/args/statedb.rs
@@ -1,0 +1,13 @@
+//! State database arguments
+
+use clap::Args;
+
+/// Parameters for state database configuration
+#[derive(Debug, Clone, Args, PartialEq, Eq, Default)]
+#[command(next_help_heading = "State Database")]
+pub struct StateDbArgs {
+    /// Use TrieDB instead of MDBX for state database.
+    #[arg(long = "statedb.triedb", default_value_t = false)]
+    pub triedb: bool,
+}
+

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -3,7 +3,7 @@
 use crate::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, NetworkArgs, PayloadBuilderArgs,
-        PruningArgs, RpcServerArgs, StateDbArgs, StaticFilesArgs, TxPoolArgs,
+        PruningArgs, RpcServerArgs, StateDbArgs, StaticFilesArgs, StorageArgs, TxPoolArgs,
     },
     dirs::{ChainPath, DataDirPath},
     utils::get_single_header,
@@ -21,6 +21,7 @@ use reth_primitives_traits::SealedHeader;
 use reth_stages_types::StageId;
 use reth_storage_api::{
     BlockHashReader, DatabaseProviderFactory, HeaderProvider, StageCheckpointReader,
+    StorageSettings,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_transaction_pool::TransactionPool;
@@ -153,6 +154,9 @@ pub struct NodeConfig<ChainSpec> {
 
     /// All state database related arguments
     pub statedb: StateDbArgs,
+
+    /// Storage layout configuration (v1/v2)
+    pub storage: StorageArgs,
 }
 
 impl NodeConfig<ChainSpec> {
@@ -185,6 +189,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era: EraArgs::default(),
             static_files: StaticFilesArgs::default(),
             statedb: StateDbArgs::default(),
+            storage: StorageArgs::default(),
         }
     }
 
@@ -260,6 +265,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era,
             static_files,
             statedb,
+            storage,
             ..
         } = self;
         NodeConfig {
@@ -280,6 +286,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era,
             static_files,
             statedb,
+            storage,
         }
     }
 
@@ -350,6 +357,12 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         self
     }
 
+    /// Set the storage args for the node
+    pub const fn with_storage(mut self, storage: StorageArgs) -> Self {
+        self.storage = storage;
+        self
+    }
+
     /// Set the pruning args for the node
     pub fn with_pruning(mut self, pruning: PruningArgs) -> Self {
         self.pruning = pruning;
@@ -362,6 +375,19 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         ChainSpec: EthereumHardforks,
     {
         self.pruning.prune_config(&self.chain)
+    }
+
+    /// Returns the effective storage settings for this node.
+    ///
+    /// Determined by the `--storage.v2` flag (defaults to `true`).
+    /// Existing databases retain whatever settings are persisted in their
+    /// metadata (checked during genesis init).
+    pub const fn storage_settings(&self) -> StorageSettings {
+        if self.storage.v2 {
+            StorageSettings::v2()
+        } else {
+            StorageSettings::v1()
+        }
     }
 
     /// Returns the max block that the node should run to, looking it up from the network if
@@ -559,6 +585,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             era: self.era,
             statedb: self.statedb,
             static_files: self.static_files,
+            storage: self.storage,
         }
     }
 
@@ -601,6 +628,7 @@ impl<ChainSpec> Clone for NodeConfig<ChainSpec> {
             era: self.era.clone(),
             statedb: self.statedb.clone(),
             static_files: self.static_files,
+            storage: self.storage,
         }
     }
 }

--- a/crates/node/core/src/node_config.rs
+++ b/crates/node/core/src/node_config.rs
@@ -3,7 +3,7 @@
 use crate::{
     args::{
         DatabaseArgs, DatadirArgs, DebugArgs, DevArgs, EngineArgs, NetworkArgs, PayloadBuilderArgs,
-        PruningArgs, RpcServerArgs, StaticFilesArgs, StorageArgs, TxPoolArgs,
+        PruningArgs, RpcServerArgs, StateDbArgs, StaticFilesArgs, TxPoolArgs,
     },
     dirs::{ChainPath, DataDirPath},
     utils::get_single_header,
@@ -21,7 +21,6 @@ use reth_primitives_traits::SealedHeader;
 use reth_stages_types::StageId;
 use reth_storage_api::{
     BlockHashReader, DatabaseProviderFactory, HeaderProvider, StageCheckpointReader,
-    StorageSettings,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_transaction_pool::TransactionPool;
@@ -152,8 +151,8 @@ pub struct NodeConfig<ChainSpec> {
     /// All static files related arguments
     pub static_files: StaticFilesArgs,
 
-    /// All storage related arguments with --storage prefix
-    pub storage: StorageArgs,
+    /// All state database related arguments
+    pub statedb: StateDbArgs,
 }
 
 impl NodeConfig<ChainSpec> {
@@ -185,7 +184,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             engine: EngineArgs::default(),
             era: EraArgs::default(),
             static_files: StaticFilesArgs::default(),
-            storage: StorageArgs::default(),
+            statedb: StateDbArgs::default(),
         }
     }
 
@@ -260,7 +259,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             engine,
             era,
             static_files,
-            storage,
+            statedb,
             ..
         } = self;
         NodeConfig {
@@ -280,7 +279,7 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             engine,
             era,
             static_files,
-            storage,
+            statedb,
         }
     }
 
@@ -357,31 +356,12 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
         self
     }
 
-    /// Set the storage args for the node
-    pub const fn with_storage(mut self, storage: StorageArgs) -> Self {
-        self.storage = storage;
-        self
-    }
-
     /// Returns pruning configuration.
     pub fn prune_config(&self) -> Option<PruneConfig>
     where
         ChainSpec: EthereumHardforks,
     {
         self.pruning.prune_config(&self.chain)
-    }
-
-    /// Returns the effective storage settings for this node.
-    ///
-    /// Determined by the `--storage.v2` flag (defaults to `true`).
-    /// Existing databases retain whatever settings are persisted in their
-    /// metadata (checked during genesis init).
-    pub const fn storage_settings(&self) -> StorageSettings {
-        if self.storage.v2 {
-            StorageSettings::v2()
-        } else {
-            StorageSettings::v1()
-        }
     }
 
     /// Returns the max block that the node should run to, looking it up from the network if
@@ -577,8 +557,8 @@ impl<ChainSpec> NodeConfig<ChainSpec> {
             pruning: self.pruning,
             engine: self.engine,
             era: self.era,
+            statedb: self.statedb,
             static_files: self.static_files,
-            storage: self.storage,
         }
     }
 
@@ -619,8 +599,8 @@ impl<ChainSpec> Clone for NodeConfig<ChainSpec> {
             datadir: self.datadir.clone(),
             engine: self.engine.clone(),
             era: self.era.clone(),
+            statedb: self.statedb.clone(),
             static_files: self.static_files,
-            storage: self.storage,
         }
     }
 }

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -30,6 +30,7 @@ reth-rpc-server-types.workspace = true
 reth-network-api.workspace = true
 reth-node-api.workspace = true
 reth-trie-common = { workspace = true, features = ["eip1186"] }
+rust-eth-triedb.workspace = true
 
 # ethereum
 alloy-evm = { workspace = true, features = ["overrides", "call-util"] }
@@ -62,5 +63,6 @@ serde_json.workspace = true
 tracing.workspace = true
 
 [features]
+io-uring = ["rust-eth-triedb/io-uring"]
 js-tracer = ["revm-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -21,6 +21,7 @@ use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, StateProvider, StateProviderBox, StateProviderFactory,
 };
 use reth_transaction_pool::TransactionPool;
+use rust_eth_triedb::triedb_manager::is_triedb_active;
 use std::collections::HashMap;
 
 /// Helper methods for `eth_` methods relating to state (accounts).
@@ -159,6 +160,11 @@ pub trait EthState: LoadState + SpawnBlocking {
         Self: EthApiSpec,
     {
         Ok(async move {
+            // Check if TrieDB is active, return error if so
+            if is_triedb_active() {
+                return Err(EthApiError::MissingTrieNode.into())
+            }
+
             let _permit = self
                 .acquire_owned_tracing()
                 .await
@@ -185,32 +191,29 @@ pub trait EthState: LoadState + SpawnBlocking {
         &self,
         address: Address,
         block_id: BlockId,
-    ) -> impl Future<Output = Result<Option<Account>, Self::Error>> + Send
-    where
-        Self: EthApiSpec,
-    {
-        async move {
-            self.ensure_within_proof_window(block_id)?;
+    ) -> impl Future<Output = Result<Option<Account>, Self::Error>> + Send {
+        self.spawn_blocking_io_fut(move |this| async move {
+            // Check if TrieDB is active, return error if so
+            if is_triedb_active() {
+                return Err(EthApiError::MissingTrieNode.into())
+            }
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let state = this.state_at_block_id(block_id).await?;
-                let account = state.basic_account(&address).map_err(Self::Error::from_eth_err)?;
-                let Some(account) = account else { return Ok(None) };
+            let state = this.state_at_block_id(block_id).await?;
+            let account = state.basic_account(&address).map_err(Self::Error::from_eth_err)?;
+            let Some(account) = account else { return Ok(None) };
 
-                let balance = account.balance;
-                let nonce = account.nonce;
-                let code_hash = account.bytecode_hash.unwrap_or(KECCAK_EMPTY);
+            let balance = account.balance;
+            let nonce = account.nonce;
+            let code_hash = account.bytecode_hash.unwrap_or(KECCAK_EMPTY);
 
-                // Provide a default `HashedStorage` value in order to
-                // get the storage root hash of the current state.
-                let storage_root = state
-                    .storage_root(address, Default::default())
-                    .map_err(Self::Error::from_eth_err)?;
+            // Provide a default `HashedStorage` value in order to
+            // get the storage root hash of the current state.
+            let storage_root = state
+                .storage_root(address, Default::default())
+                .map_err(Self::Error::from_eth_err)?;
 
-                Ok(Some(Account { balance, nonce, code_hash, storage_root }))
-            })
-            .await
-        }
+            Ok(Some(Account { balance, nonce, code_hash, storage_root }))
+        })
     }
 
     /// Retrieves the account's balance, nonce, and code for a given address.

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -147,6 +147,9 @@ pub enum EthApiError {
     /// When the percentile array is invalid
     #[error("invalid reward percentiles")]
     InvalidRewardPercentiles,
+    /// Missing trie node error (used when TrieDB is active)
+    #[error("missing trie node")]
+    MissingTrieNode,
     /// Error thrown when a spawned blocking task failed to deliver an anticipated response.
     ///
     /// This only happens if the blocking task panics and is aborted before it can return a
@@ -294,11 +297,12 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::InvalidBytecode(_) => invalid_params_rpc_err(error.to_string()),
             EthApiError::InvalidTransaction(err) => err.into(),
             EthApiError::PoolError(err) => err.into(),
-            EthApiError::PrevrandaoNotSet |
-            EthApiError::ExcessBlobGasNotSet |
-            EthApiError::InvalidBlockData(_) |
-            EthApiError::Internal(_) |
-            EthApiError::EvmCustom(_) => internal_rpc_err(error.to_string()),
+            EthApiError::PrevrandaoNotSet
+            | EthApiError::ExcessBlobGasNotSet
+            | EthApiError::InvalidBlockData(_)
+            | EthApiError::Internal(_)
+            | EthApiError::EvmCustom(_) => internal_rpc_err(error.to_string()),
+            EthApiError::MissingTrieNode => rpc_error_with_code(-32000, "missing trie node"),
             EthApiError::UnknownBlockOrTxIndex | EthApiError::TransactionNotFound => {
                 rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
             }

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -147,7 +147,7 @@ pub enum EthApiError {
     /// When the percentile array is invalid
     #[error("invalid reward percentiles")]
     InvalidRewardPercentiles,
-    /// Missing trie node error (used when TrieDB is active)
+    /// Missing trie node error (used when `TrieDB` is active)
     #[error("missing trie node")]
     MissingTrieNode,
     /// Error thrown when a spawned blocking task failed to deliver an anticipated response.
@@ -297,11 +297,11 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::InvalidBytecode(_) => invalid_params_rpc_err(error.to_string()),
             EthApiError::InvalidTransaction(err) => err.into(),
             EthApiError::PoolError(err) => err.into(),
-            EthApiError::PrevrandaoNotSet
-            | EthApiError::ExcessBlobGasNotSet
-            | EthApiError::InvalidBlockData(_)
-            | EthApiError::Internal(_)
-            | EthApiError::EvmCustom(_) => internal_rpc_err(error.to_string()),
+            EthApiError::PrevrandaoNotSet |
+            EthApiError::ExcessBlobGasNotSet |
+            EthApiError::InvalidBlockData(_) |
+            EthApiError::Internal(_) |
+            EthApiError::EvmCustom(_) => internal_rpc_err(error.to_string()),
             EthApiError::MissingTrieNode => rpc_error_with_code(-32000, "missing trie node"),
             EthApiError::UnknownBlockOrTxIndex | EthApiError::TransactionNotFound => {
                 rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -43,6 +43,7 @@ reth-ethereum-primitives.workspace = true
 reth-ethereum-engine-primitives.workspace = true
 reth-node-api.workspace = true
 reth-trie-common.workspace = true
+rust-eth-triedb.workspace = true
 
 # ethereum
 alloy-eip7928.workspace = true
@@ -104,6 +105,7 @@ rand.workspace = true
 jsonrpsee = { workspace = true, features = ["client"] }
 
 [features]
+io-uring = ["rust-eth-triedb/io-uring"]
 js-tracer = [
     "revm-inspectors/js-tracer",
     "reth-rpc-eth-types/js-tracer",

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -40,12 +40,15 @@ use reth_storage_api::{
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
-use rust_eth_triedb::triedb_manager::is_triedb_active;
-use revm::{context_interface::Transaction, state::EvmState, DatabaseCommit};
+use revm::{
+    context_interface::Block as BlockEnvTrait, database::states::bundle_state::BundleRetention,
+    state::EvmState, DatabaseCommit,
+};
 use revm_inspectors::tracing::{
     DebugInspector, FourByteInspector, MuxInspector, TracingInspector, TracingInspectorConfig,
     TransactionContext,
 };
+use rust_eth_triedb::triedb_manager::is_triedb_active;
 use serde::{Deserialize, Serialize};
 use std::{collections::VecDeque, sync::Arc};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -40,10 +40,8 @@ use reth_storage_api::{
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_trie_common::{updates::TrieUpdates, HashedPostState};
-use revm::{
-    context_interface::Block as BlockEnvTrait, database::states::bundle_state::BundleRetention,
-    state::EvmState, DatabaseCommit,
-};
+use rust_eth_triedb::triedb_manager::is_triedb_active;
+use revm::{context_interface::Transaction, state::EvmState, DatabaseCommit};
 use revm_inspectors::tracing::{
     DebugInspector, FourByteInspector, MuxInspector, TracingInspector, TracingInspectorConfig,
     TransactionContext,
@@ -770,6 +768,11 @@ where
     ) -> Result<ExecutionWitness, Eth::Error> {
         let block_number = block.header().number();
 
+        // TrieDB does not support witness generation.
+        if is_triedb_active() {
+            return Err(EthApiError::MissingTrieNode.into())
+        }
+
         let (mut exec_witness, lowest_block_number) = self
             .eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
@@ -1041,6 +1044,11 @@ where
         hashed_state: HashedPostState,
         block_id: Option<BlockId>,
     ) -> Result<(B256, TrieUpdates), Eth::Error> {
+        // Check if TrieDB is active, return error if so
+        if is_triedb_active() {
+            return Err(EthApiError::MissingTrieNode.into())
+        }
+
         self.inner
             .eth_api
             .spawn_blocking_io(move |this| {

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -35,10 +35,11 @@ use reth_primitives_traits::{
 };
 use reth_revm::{cached::CachedReads, database::StateProviderDatabase};
 use reth_rpc_api::BlockSubmissionValidationApiServer;
-use reth_rpc_server_types::result::{internal_rpc_err, invalid_params_rpc_err};
+use reth_rpc_server_types::result::{internal_rpc_err, invalid_params_rpc_err, rpc_error_with_code};
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
 use reth_tasks::Runtime;
 use revm_primitives::{Address, B256, U256};
+use rust_eth_triedb::triedb_manager::is_triedb_active;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::sync::Arc;
@@ -205,6 +206,11 @@ where
         self.consensus.validate_block_post_execution(&block, &output, None)?;
 
         self.ensure_payment(&block, &output, &message)?;
+
+        // Check if TrieDB is active, return error if so
+        if is_triedb_active() {
+            return Err(ValidationApiError::MissingTrieNode.into())
+        }
 
         let state_root =
             state_provider.state_root(state_provider.hashed_post_state(&output.state))?;
@@ -648,6 +654,8 @@ pub enum ValidationApiError {
     InvalidBlobsBundle,
     #[error("block accesses blacklisted address: {_0}")]
     Blacklist(Address),
+    #[error("missing trie node")]
+    MissingTrieNode,
     #[error(transparent)]
     Blob(#[from] BlobTransactionValidationError),
     #[error(transparent)]
@@ -671,6 +679,8 @@ impl From<ValidationApiError> for ErrorObject<'static> {
             ValidationApiError::ProposerPayment |
             ValidationApiError::InvalidBlobsBundle |
             ValidationApiError::Blob(_) => invalid_params_rpc_err(error.to_string()),
+
+            ValidationApiError::MissingTrieNode => rpc_error_with_code(-32000, "missing trie node"),
 
             ValidationApiError::MissingLatestBlock |
             ValidationApiError::MissingParentBlock |

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -35,7 +35,9 @@ use reth_primitives_traits::{
 };
 use reth_revm::{cached::CachedReads, database::StateProviderDatabase};
 use reth_rpc_api::BlockSubmissionValidationApiServer;
-use reth_rpc_server_types::result::{internal_rpc_err, invalid_params_rpc_err, rpc_error_with_code};
+use reth_rpc_server_types::result::{
+    internal_rpc_err, invalid_params_rpc_err, rpc_error_with_code,
+};
 use reth_storage_api::{BlockReaderIdExt, StateProviderFactory};
 use reth_tasks::Runtime;
 use revm_primitives::{Address, B256, U256};
@@ -209,7 +211,7 @@ where
 
         // Check if TrieDB is active, return error if so
         if is_triedb_active() {
-            return Err(ValidationApiError::MissingTrieNode.into())
+            return Err(ValidationApiError::MissingTrieNode)
         }
 
         let state_root =

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -42,13 +42,17 @@ reth-static-file-types.workspace = true
 reth-tasks.workspace = true
 reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-db = { workspace = true, features = ["metrics"] }
+reth-trie-common.workspace = true
+
+# triedb
+rust-eth-triedb.workspace = true
 
 reth-testing-utils = { workspace = true, optional = true }
 
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
 alloy-consensus.workspace = true
-alloy-rlp.workspace = true
+alloy-trie.workspace = true
 
 # async
 tokio = { workspace = true, features = ["sync"] }
@@ -97,6 +101,7 @@ paste.workspace = true
 tempfile.workspace = true
 
 [features]
+io-uring = ["rust-eth-triedb/io-uring"]
 test-utils = [
     "reth-network-p2p/test-utils",
     "reth-db/test-utils",

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -51,6 +51,7 @@ reth-testing-utils = { workspace = true, optional = true }
 
 alloy-eips.workspace = true
 alloy-primitives.workspace = true
+alloy-rlp.workspace = true
 alloy-consensus.workspace = true
 alloy-trie.workspace = true
 
@@ -123,5 +124,6 @@ test-utils = [
     "dep:reth-ethereum-primitives",
     "reth-ethereum-primitives?/test-utils",
     "reth-evm-ethereum/test-utils",
+    "reth-trie-common/test-utils",
     "reth-tasks/test-utils",
 ]

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -6,6 +6,7 @@ use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_config::config::ExecutionConfig;
 use reth_consensus::FullConsensus;
 use reth_db::{static_file::HeaderMask, tables};
+use reth_db_api::DatabaseError;
 use reth_evm::{execute::Executor, metrics::ExecutorMetrics, ConfigureEvm};
 use reth_execution_types::Chain;
 use reth_exex::{ExExManagerHandle, ExExNotification, ExExNotificationSource};
@@ -32,6 +33,9 @@ use std::{
     task::{ready, Context, Poll},
     time::{Duration, Instant},
 };
+use reth_trie_common::{HashedPostState, KeccakKeyHasher};
+use rust_eth_triedb::triedb_manager::is_triedb_active;
+use rust_eth_triedb::get_global_triedb;
 use tracing::*;
 
 use super::missing_static_data_error;
@@ -507,6 +511,68 @@ where
             "Execution time"
         );
 
+        if is_triedb_active() {
+            let merkle_time = Instant::now();
+
+            let mut triedb = get_global_triedb();
+            let (latest_block_number, latest_state_root) = triedb.latest_persist_state()
+                .map_err(|e| StageError::Fatal(Box::new(e)))?;
+
+            if latest_block_number < stage_progress {
+                let root_hash = if start_block == 0 {
+                    alloy_trie::EMPTY_ROOT_HASH
+                } else {
+                    // latest_block_number < start_block
+                    // use the latest state root, maybe empty block
+                    latest_state_root
+                };
+
+                let validate_root = if stage_progress == 0 {
+                    alloy_trie::EMPTY_ROOT_HASH
+                } else {
+                    let block_number = stage_progress;
+                    let block = provider
+                        .recovered_block(block_number.into(), TransactionVariant::NoHash)?
+                        .ok_or_else(|| ProviderError::HeaderNotFound(block_number.into()))?;
+                    block.header().state_root()
+                };
+
+                let hashed_post_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(
+                    state.bundle.state(),
+                );
+                let triedb_hashed_post_state = hashed_post_state.to_triedb_hashed_post_state();
+
+                info!(target: "sync::stages::execution",
+                    "Begin update triedb, start={}, end={}, parent_root={:?}, target_root={:?}, accounts={}, storages={}",
+                    start_block,
+                    stage_progress,
+                    root_hash,
+                    validate_root,
+                    hashed_post_state.accounts.len(),
+                    hashed_post_state.storages.len(),
+                );
+
+                let (new_root, difflayer) = triedb.commit_hashed_post_state(root_hash, None, &triedb_hashed_post_state)
+                    .map_err(|e| StageError::Fatal(Box::new(e)))?;
+
+                if new_root != validate_root {
+                    return Err(StageError::Fatal(Box::new(ProviderError::Database(DatabaseError::Other(format!("execution update triedb, start={}, end={}, new_root({:?}) != validate_root({:?})", start_block, stage_progress, new_root, validate_root))))));
+                }
+                triedb.flush(stage_progress, new_root, &difflayer)
+                    .map_err(|e| StageError::Fatal(Box::new(e)))?;
+
+                info!(target: "sync::stages::execution",
+                    "End update triedb, start={}, end={}, parent_root={:?}, validate_root={:?}, update_triedb_time={:?}",
+                    start_block,
+                    stage_progress,
+                    root_hash,
+                    validate_root,
+                    merkle_time.elapsed());
+            } else {
+                info!(target: "sync::stages::execution", "latest_block_number >= stage_progress skip update triedb, latest_block_number={}, stage_progress={}", latest_block_number, stage_progress);
+            }
+        }
+
         let done = stage_progress == max_block;
         Ok(ExecOutput {
             checkpoint: StageCheckpoint::new(stage_progress)
@@ -550,6 +616,43 @@ where
         //
         // This also updates `PlainStorageState` and `PlainAccountState`.
         let bundle_state_with_receipts = provider.take_state_above(unwind_to)?;
+
+        if is_triedb_active() {
+            let mut triedb = get_global_triedb();
+            let (latest_block_number, latest_state_root) = triedb.latest_persist_state()
+                .map_err(|e| StageError::Fatal(Box::new(e)))?;
+
+            if latest_block_number > unwind_to {
+                let hashed_post_state = HashedPostState::from_bundle_state_to_unwind::<KeccakKeyHasher>(
+                    bundle_state_with_receipts.bundle.state()
+                );
+
+                let triedb_hashed_post_state = hashed_post_state.to_triedb_hashed_post_state();
+                let validate_root = if unwind_to == 0 {
+                    alloy_trie::EMPTY_ROOT_HASH
+                } else {
+                    let block_number = unwind_to;
+                    let block = provider
+                        .recovered_block(block_number.into(), TransactionVariant::NoHash)?
+                        .ok_or_else(|| ProviderError::HeaderNotFound(block_number.into()))?;
+                    block.header().state_root()
+                };
+
+                info!(target: "sync::stages::execution", "Begin unwind execution update triedb, latest_block_number={}, unwind_to={}, latest_state_root={:?}, target_root={:?}, accounts={}, storages={}", latest_block_number, unwind_to, latest_state_root, validate_root, hashed_post_state.accounts.len(), hashed_post_state.storages.len());
+                let (new_root, difflayer) = triedb.commit_hashed_post_state(latest_state_root, None, &triedb_hashed_post_state)
+                    .map_err(|e| StageError::Fatal(Box::new(e)))?;
+                info!(target: "sync::stages::execution", "End unwind execution update triedb, new_root={:?}, target_root={:?}", new_root, validate_root);
+
+                if new_root != validate_root {
+                    return Err(StageError::Fatal(Box::new(ProviderError::Database(DatabaseError::Other(format!("unwind execution update triedb, unwind_to={}, new_root({:?}) != validate_root({:?}), hashed_post_state={:?}", unwind_to, new_root, validate_root, hashed_post_state))))));
+                }
+
+                triedb.flush(latest_block_number, new_root, &difflayer)
+                    .map_err(|e| StageError::Fatal(Box::new(e)))?;
+            } else {
+                warn!("latest_block_number <= unwind_to, latest_triedb_block_number={}, unwind_to={}", latest_block_number, unwind_to);
+            }
+        }
 
         // Prepare the input for post unwind commit hook, where an `ExExNotification` will be sent.
         if self.exex_manager_handle.has_exexs() {

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -24,7 +24,8 @@ use reth_stages_api::{
     UnwindInput, UnwindOutput,
 };
 use reth_static_file_types::StaticFileSegment;
-use reth_trie::KeccakKeyHasher;
+use reth_trie_common::{HashedPostState, KeccakKeyHasher};
+use rust_eth_triedb::{get_global_triedb, triedb_manager::is_triedb_active};
 use std::{
     cmp::{max, Ordering},
     collections::BTreeMap,
@@ -33,9 +34,6 @@ use std::{
     task::{ready, Context, Poll},
     time::{Duration, Instant},
 };
-use reth_trie_common::{HashedPostState, KeccakKeyHasher};
-use rust_eth_triedb::triedb_manager::is_triedb_active;
-use rust_eth_triedb::get_global_triedb;
 use tracing::*;
 
 use super::missing_static_data_error;
@@ -515,8 +513,8 @@ where
             let merkle_time = Instant::now();
 
             let mut triedb = get_global_triedb();
-            let (latest_block_number, latest_state_root) = triedb.latest_persist_state()
-                .map_err(|e| StageError::Fatal(Box::new(e)))?;
+            let (latest_block_number, latest_state_root) =
+                triedb.latest_persist_state().map_err(|e| StageError::Fatal(Box::new(e)))?;
 
             if latest_block_number < stage_progress {
                 let root_hash = if start_block == 0 {
@@ -537,9 +535,8 @@ where
                     block.header().state_root()
                 };
 
-                let hashed_post_state = HashedPostState::from_bundle_state::<KeccakKeyHasher>(
-                    state.bundle.state(),
-                );
+                let hashed_post_state =
+                    HashedPostState::from_bundle_state::<KeccakKeyHasher>(state.bundle.state());
                 let triedb_hashed_post_state = hashed_post_state.to_triedb_hashed_post_state();
 
                 info!(target: "sync::stages::execution",
@@ -552,13 +549,15 @@ where
                     hashed_post_state.storages.len(),
                 );
 
-                let (new_root, difflayer) = triedb.commit_hashed_post_state(root_hash, None, &triedb_hashed_post_state)
+                let (new_root, difflayer) = triedb
+                    .commit_hashed_post_state(root_hash, None, &triedb_hashed_post_state)
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
 
                 if new_root != validate_root {
                     return Err(StageError::Fatal(Box::new(ProviderError::Database(DatabaseError::Other(format!("execution update triedb, start={}, end={}, new_root({:?}) != validate_root({:?})", start_block, stage_progress, new_root, validate_root))))));
                 }
-                triedb.flush(stage_progress, new_root, &difflayer)
+                triedb
+                    .flush(stage_progress, new_root, &difflayer)
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
 
                 info!(target: "sync::stages::execution",
@@ -619,13 +618,13 @@ where
 
         if is_triedb_active() {
             let mut triedb = get_global_triedb();
-            let (latest_block_number, latest_state_root) = triedb.latest_persist_state()
-                .map_err(|e| StageError::Fatal(Box::new(e)))?;
+            let (latest_block_number, latest_state_root) =
+                triedb.latest_persist_state().map_err(|e| StageError::Fatal(Box::new(e)))?;
 
             if latest_block_number > unwind_to {
-                let hashed_post_state = HashedPostState::from_bundle_state_to_unwind::<KeccakKeyHasher>(
-                    bundle_state_with_receipts.bundle.state()
-                );
+                let hashed_post_state = HashedPostState::from_bundle_state_to_unwind::<
+                    KeccakKeyHasher,
+                >(bundle_state_with_receipts.bundle.state());
 
                 let triedb_hashed_post_state = hashed_post_state.to_triedb_hashed_post_state();
                 let validate_root = if unwind_to == 0 {
@@ -639,7 +638,8 @@ where
                 };
 
                 info!(target: "sync::stages::execution", "Begin unwind execution update triedb, latest_block_number={}, unwind_to={}, latest_state_root={:?}, target_root={:?}, accounts={}, storages={}", latest_block_number, unwind_to, latest_state_root, validate_root, hashed_post_state.accounts.len(), hashed_post_state.storages.len());
-                let (new_root, difflayer) = triedb.commit_hashed_post_state(latest_state_root, None, &triedb_hashed_post_state)
+                let (new_root, difflayer) = triedb
+                    .commit_hashed_post_state(latest_state_root, None, &triedb_hashed_post_state)
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
                 info!(target: "sync::stages::execution", "End unwind execution update triedb, new_root={:?}, target_root={:?}", new_root, validate_root);
 
@@ -647,10 +647,14 @@ where
                     return Err(StageError::Fatal(Box::new(ProviderError::Database(DatabaseError::Other(format!("unwind execution update triedb, unwind_to={}, new_root({:?}) != validate_root({:?}), hashed_post_state={:?}", unwind_to, new_root, validate_root, hashed_post_state))))));
                 }
 
-                triedb.flush(latest_block_number, new_root, &difflayer)
+                triedb
+                    .flush(latest_block_number, new_root, &difflayer)
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
             } else {
-                warn!("latest_block_number <= unwind_to, latest_triedb_block_number={}, unwind_to={}", latest_block_number, unwind_to);
+                warn!(
+                    "latest_block_number <= unwind_to, latest_triedb_block_number={}, unwind_to={}",
+                    latest_block_number, unwind_to
+                );
             }
         }
 

--- a/crates/stages/stages/src/stages/hashing_account.rs
+++ b/crates/stages/stages/src/stages/hashing_account.rs
@@ -132,7 +132,7 @@ impl AccountHashingStage {
 impl Default for AccountHashingStage {
     fn default() -> Self {
         Self {
-            clean_threshold: 500_000,
+            clean_threshold: 5_000_000,
             commit_threshold: 100_000,
             commit_entries: 30_000_000,
             etl_config: EtlConfig::default(),

--- a/crates/stages/stages/src/stages/hashing_storage.rs
+++ b/crates/stages/stages/src/stages/hashing_storage.rs
@@ -65,7 +65,7 @@ impl StorageHashingStage {
 impl Default for StorageHashingStage {
     fn default() -> Self {
         Self {
-            clean_threshold: 500_000,
+            clean_threshold: 5_000_000,
             commit_threshold: 100_000,
             commit_entries: 30_000_000,
             etl_config: EtlConfig::default(),

--- a/crates/stages/types/src/execution.rs
+++ b/crates/stages/types/src/execution.rs
@@ -20,9 +20,9 @@ impl Default for ExecutionStageThresholds {
     fn default() -> Self {
         Self {
             max_blocks: Some(500_000),
-            max_changes: Some(5_000_000),
+            max_changes: Some(500_000),
             // 50k full blocks of 30M gas
-            max_cumulative_gas: Some(30_000_000 * 50_000),
+            max_cumulative_gas: Some(100_000_000 * 50_000),
             // 10 minutes
             max_duration: Some(Duration::from_secs(10 * 60)),
         }

--- a/crates/storage/db-api/Cargo.toml
+++ b/crates/storage/db-api/Cargo.toml
@@ -58,6 +58,7 @@ proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 
 [features]
+edge = []
 test-utils = [
     "arbitrary",
     "reth-primitives-traits/test-utils",

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -24,6 +24,14 @@ reth-node-types.workspace = true
 reth-static-file-types.workspace = true
 reth-execution-errors.workspace = true
 
+# triedb
+rust-eth-triedb.workspace = true
+rust-eth-triedb-common.workspace = true
+rust-eth-triedb-state-trie.workspace = true
+
+# alloy
+alloy-trie.workspace = true
+
 # eth
 alloy-consensus.workspace = true
 alloy-genesis.workspace = true
@@ -41,10 +49,13 @@ serde_json.workspace = true
 # tracing
 tracing.workspace = true
 
+[features]
+io-uring = ["rust-eth-triedb/io-uring"]
+edge = ["reth-db-api/edge", "reth-provider/rocksdb"]
+
 [dev-dependencies]
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
-reth-tasks.workspace = true
 
 [lints]
 workspace = true

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -51,11 +51,12 @@ tracing.workspace = true
 
 [features]
 io-uring = ["rust-eth-triedb/io-uring"]
-edge = ["reth-db-api/edge", "reth-provider/rocksdb"]
+edge = ["reth-db-api/edge"]
 
 [dev-dependencies]
 reth-db = { workspace = true, features = ["mdbx"] }
 reth-provider = { workspace = true, features = ["test-utils"] }
+reth-tasks.workspace = true
 
 [lints]
 workspace = true

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -3,6 +3,7 @@
 use alloy_consensus::BlockHeader;
 use alloy_genesis::GenesisAccount;
 use alloy_primitives::{
+    keccak256,
     map::{AddressMap, B256Map, HashMap},
     Address, B256, U256,
 };
@@ -236,11 +237,11 @@ where
 
     insert_genesis_state(&provider_rw, alloc.iter())?;
 
-    if !is_triedb_active() {
+    if is_triedb_active() {
+        info!(target: "reth::storage", "TrieDB is active, skipping mdbx state root computation");
+    } else {
         // compute state root to populate trie tables
         compute_state_root(&provider_rw, None)?;
-    } else {
-        info!(target: "reth::storage", "TrieDB is active, skipping mdbx state root computation");
     }
 
     // set stage checkpoint to genesis block number for all stages
@@ -291,10 +292,10 @@ where
         + AsRef<Provider>,
 {
     let genesis_block_number = provider.chain_spec().genesis_header().number();
-    if !is_triedb_active() {
-        insert_state(provider, alloc, genesis_block_number)
-    } else {
+    if is_triedb_active() {
         insert_triedb_state(provider, alloc, genesis_block_number)
+    } else {
+        insert_state(provider, alloc, genesis_block_number)
     }
 }
 
@@ -343,8 +344,8 @@ where
         let mut state_account = StateAccount::default()
             .with_nonce(account.nonce.unwrap_or_default())
             .with_balance(account.balance);
-        if bytecode_hash.is_some() {
-            state_account = state_account.with_code_hash(bytecode_hash.unwrap());
+        if let Some(hash) = bytecode_hash {
+            state_account = state_account.with_code_hash(hash);
         }
         state_accounts.insert(hashed_address, Some(state_account));
 
@@ -363,7 +364,7 @@ where
                         let value = U256::from_be_bytes(value.0);
                         (*key, (U256::ZERO, value))
                     })
-                    .collect::<HashMap<_, _>>()
+                    .collect::<B256Map<_>>()
             })
             .unwrap_or_default();
 
@@ -390,21 +391,27 @@ where
         );
     }
 
-
-    let (root, nodes, diff_storage_roots) = triedb.batch_update_and_commit(
-        alloy_trie::EMPTY_ROOT_HASH,
-        None,
-        state_accounts,
-        HashSet::new(),
-        storage_states)
-        .map_err(|_| ProviderError::Database(DatabaseError::Other("Failed to update and commit state".to_string())))?;
+    let (root, nodes, diff_storage_roots) = triedb
+        .batch_update_and_commit(
+            alloy_trie::EMPTY_ROOT_HASH,
+            None,
+            state_accounts,
+            HashSet::new(),
+            storage_states,
+        )
+        .map_err(|_| {
+            ProviderError::Database(DatabaseError::Other(
+                "Failed to update and commit state".to_string(),
+            ))
+        })?;
 
     let diff_nodes = (*nodes.to_diff_nodes()).clone();
     let difflayer = Some(Arc::new(DiffLayer::new(diff_nodes, diff_storage_roots)));
-    triedb.flush(0, root, &difflayer).map_err(|_| ProviderError::Database(DatabaseError::Other("Failed to flush state".to_string())))?;
+    triedb.flush(0, root, &difflayer).map_err(|_| {
+        ProviderError::Database(DatabaseError::Other("Failed to flush state".to_string()))
+    })?;
 
     info!(target: "reth::storage", "Triedb genesis state root computed: {:?}", root);
-
 
     let all_reverts_init: RevertsInit = HashMap::from_iter([(block, reverts_init)]);
 
@@ -420,14 +427,13 @@ where
     provider.write_state(
         &execution_outcome,
         OriginalValuesKnown::Yes,
-        StorageLocation::Database,
+        StateWriteConfig::default(),
     )?;
 
     trace!(target: "reth::cli", "Inserted state");
 
     Ok(())
 }
-
 
 /// Inserts state at given block into database.
 pub fn insert_state<'a, 'b, Provider>(

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -30,15 +30,17 @@ use reth_trie::{
     StateRootProgress,
 };
 use reth_trie_db::DatabaseStateRoot;
+use rust_eth_triedb::triedb_manager::{get_global_triedb, is_triedb_active};
+use rust_eth_triedb_common::DiffLayer;
+use rust_eth_triedb_state_trie::account::StateAccount;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashSet, io::BufRead, sync::Arc};
+use tracing::{debug, error, info, trace, warn};
 
 type DbStateRoot<'a, TX, A> = StateRootComputer<
     reth_trie_db::DatabaseTrieCursorFactory<&'a TX, A>,
     reth_trie_db::DatabaseHashedCursorFactory<&'a TX>,
 >;
-
-use serde::{Deserialize, Serialize};
-use std::io::BufRead;
-use tracing::{debug, error, info, trace, warn};
 
 pub use reth_provider::init::{
     insert_account_history, insert_genesis_account_history, insert_genesis_history,
@@ -153,6 +155,7 @@ where
 
     // Get the genesis block number from the chain spec
     let genesis_block_number = chain.genesis_header().number();
+    info!(target: "reth::storage", "genesis header state root: {:?}", chain.genesis_header().state_root());
 
     // Check if we already have the genesis header or if we have the wrong one.
     match factory.block_hash(genesis_block_number) {
@@ -233,8 +236,12 @@ where
 
     insert_genesis_state(&provider_rw, alloc.iter())?;
 
-    // compute state root to populate trie tables
-    compute_state_root(&provider_rw, None)?;
+    if !is_triedb_active() {
+        // compute state root to populate trie tables
+        compute_state_root(&provider_rw, None)?;
+    } else {
+        info!(target: "reth::storage", "TrieDB is active, skipping mdbx state root computation");
+    }
 
     // set stage checkpoint to genesis block number for all stages
     let checkpoint = StageCheckpoint::new(genesis_block_number);
@@ -284,8 +291,143 @@ where
         + AsRef<Provider>,
 {
     let genesis_block_number = provider.chain_spec().genesis_header().number();
-    insert_state(provider, alloc, genesis_block_number)
+    if !is_triedb_active() {
+        insert_state(provider, alloc, genesis_block_number)
+    } else {
+        insert_triedb_state(provider, alloc, genesis_block_number)
+    }
 }
+
+/// Inserts state at given block into rust eth triedb.
+pub fn insert_triedb_state<'a, 'b, Provider>(
+    provider: &Provider,
+    alloc: impl Iterator<Item = (&'a Address, &'b GenesisAccount)>,
+    block: u64,
+) -> ProviderResult<()>
+where
+    Provider: StaticFileProviderFactory
+        + DBProvider<Tx: DbTxMut>
+        + HeaderProvider
+        + StateWriter
+        + AsRef<Provider>,
+{
+    let capacity = alloc.size_hint().1.unwrap_or(0);
+    let mut state_init: BundleStateInit =
+        HashMap::with_capacity_and_hasher(capacity, Default::default());
+    let mut reverts_init = HashMap::with_capacity_and_hasher(capacity, Default::default());
+    let mut contracts: HashMap<B256, Bytecode> =
+        HashMap::with_capacity_and_hasher(capacity, Default::default());
+
+    let mut triedb = get_global_triedb();
+    let mut state_accounts = HashMap::new();
+    let mut storage_states = HashMap::new();
+
+    for (address, account) in alloc {
+        let bytecode_hash = if let Some(code) = &account.code {
+            match Bytecode::new_raw_checked(code.clone()) {
+                Ok(bytecode) => {
+                    let hash = bytecode.hash_slow();
+                    contracts.insert(hash, bytecode);
+                    Some(hash)
+                }
+                Err(err) => {
+                    error!(%address, %err, "Failed to decode genesis bytecode.");
+                    return Err(DatabaseError::Other(err.to_string()).into());
+                }
+            }
+        } else {
+            None
+        };
+
+        let hashed_address = keccak256(address);
+        let mut state_account = StateAccount::default()
+            .with_nonce(account.nonce.unwrap_or_default())
+            .with_balance(account.balance);
+        if bytecode_hash.is_some() {
+            state_account = state_account.with_code_hash(bytecode_hash.unwrap());
+        }
+        state_accounts.insert(hashed_address, Some(state_account));
+
+        let mut storage_kvs = HashMap::new();
+
+        // get state
+        let storage = account
+            .storage
+            .as_ref()
+            .map(|m| {
+                m.iter()
+                    .map(|(key, value)| {
+                        let hashed_key = keccak256(key);
+                        storage_kvs.insert(hashed_key, Some(U256::from_be_bytes(value.0)));
+
+                        let value = U256::from_be_bytes(value.0);
+                        (*key, (U256::ZERO, value))
+                    })
+                    .collect::<HashMap<_, _>>()
+            })
+            .unwrap_or_default();
+
+        if !storage_kvs.is_empty() {
+            storage_states.insert(hashed_address, storage_kvs);
+        }
+
+        reverts_init.insert(
+            *address,
+            (Some(None), storage.keys().map(|k| StorageEntry::new(*k, U256::ZERO)).collect()),
+        );
+
+        state_init.insert(
+            *address,
+            (
+                None,
+                Some(Account {
+                    nonce: account.nonce.unwrap_or_default(),
+                    balance: account.balance,
+                    bytecode_hash,
+                }),
+                storage,
+            ),
+        );
+    }
+
+
+    let (root, nodes, diff_storage_roots) = triedb.batch_update_and_commit(
+        alloy_trie::EMPTY_ROOT_HASH,
+        None,
+        state_accounts,
+        HashSet::new(),
+        storage_states)
+        .map_err(|_| ProviderError::Database(DatabaseError::Other("Failed to update and commit state".to_string())))?;
+
+    let diff_nodes = (*nodes.to_diff_nodes()).clone();
+    let difflayer = Some(Arc::new(DiffLayer::new(diff_nodes, diff_storage_roots)));
+    triedb.flush(0, root, &difflayer).map_err(|_| ProviderError::Database(DatabaseError::Other("Failed to flush state".to_string())))?;
+
+    info!(target: "reth::storage", "Triedb genesis state root computed: {:?}", root);
+
+
+    let all_reverts_init: RevertsInit = HashMap::from_iter([(block, reverts_init)]);
+
+    let execution_outcome = ExecutionOutcome::new_init(
+        state_init,
+        all_reverts_init,
+        contracts,
+        Vec::default(),
+        block,
+        Vec::new(),
+    );
+
+    provider.write_state(
+        &execution_outcome,
+        OriginalValuesKnown::Yes,
+        StorageLocation::Database,
+    )?;
+
+    trace!(target: "reth::cli", "Inserted state");
+
+    Ok(())
+}
+
 
 /// Inserts state at given block into database.
 pub fn insert_state<'a, 'b, Provider>(

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -27,6 +27,9 @@ reth-stages-types.workspace = true
 reth-tasks = { workspace = true, features = ["rayon"] }
 reth-trie = { workspace = true, features = ["metrics"] }
 reth-trie-db = { workspace = true, features = ["metrics"] }
+
+# triedb
+rust-eth-triedb.workspace = true
 reth-nippy-jar.workspace = true
 reth-codecs.workspace = true
 reth-chain-state.workspace = true
@@ -86,7 +89,8 @@ rand.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 [features]
-jemalloc = ["rocksdb/jemalloc"]
+rocksdb = ["dep:rocksdb"]
+io-uring = ["rust-eth-triedb/io-uring"]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -89,8 +89,9 @@ rand.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 [features]
-rocksdb = ["dep:rocksdb"]
 io-uring = ["rust-eth-triedb/io-uring"]
+jemalloc = ["rust-eth-triedb/jemalloc", "rocksdb/jemalloc"]
+asm-keccak = ["rust-eth-triedb/asm-keccak", "alloy-primitives/asm-keccak"]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3145,7 +3145,7 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
     fn write_trie_updates_sorted(&self, trie_updates: &TrieUpdatesSorted) -> ProviderResult<usize> {
         if rust_eth_triedb::triedb_manager::is_triedb_active() {
             tracing::error!("write_trie_updates is not supported triedb");
-            return Err(ProviderError::Database(DatabaseError::Other(
+            return Err(ProviderError::Database(reth_db_api::DatabaseError::Other(
                 "write_trie_updates is not supported triedb".to_string(),
             )));
         }
@@ -3179,7 +3179,9 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> StorageTrieWriter for DatabaseP
     ) -> ProviderResult<usize> {
         if rust_eth_triedb::triedb_manager::is_triedb_active() {
             tracing::error!("write_storage_trie_updates is not supported triedb");
-            return Err(ProviderError::Database(DatabaseError::Other("write_trie_updates is not supported triedb".to_string())));
+            return Err(ProviderError::Database(reth_db_api::DatabaseError::Other(
+                "write_trie_updates is not supported triedb".to_string(),
+            )));
         }
 
         let mut num_entries = 0;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -3143,6 +3143,12 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> TrieWriter for DatabaseProvider
     /// Returns the number of entries modified.
     #[instrument(level = "debug", target = "providers::db", skip_all)]
     fn write_trie_updates_sorted(&self, trie_updates: &TrieUpdatesSorted) -> ProviderResult<usize> {
+        if rust_eth_triedb::triedb_manager::is_triedb_active() {
+            tracing::error!("write_trie_updates is not supported triedb");
+            return Err(ProviderError::Database(DatabaseError::Other(
+                "write_trie_updates is not supported triedb".to_string(),
+            )));
+        }
         if trie_updates.is_empty() {
             return Ok(0)
         }
@@ -3171,6 +3177,11 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypes> StorageTrieWriter for DatabaseP
         &self,
         storage_tries: impl Iterator<Item = (&'a B256, &'a StorageTrieUpdatesSorted)>,
     ) -> ProviderResult<usize> {
+        if rust_eth_triedb::triedb_manager::is_triedb_active() {
+            tracing::error!("write_storage_trie_updates is not supported triedb");
+            return Err(ProviderError::Database(DatabaseError::Other("write_trie_updates is not supported triedb".to_string())));
+        }
+
         let mut num_entries = 0;
         let mut storage_tries = storage_tries.collect::<Vec<_>>();
         storage_tries.sort_unstable_by(|a, b| a.0.cmp(b.0));

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -25,8 +25,8 @@ use reth_storage_errors::{
     provider::{ProviderError, ProviderResult},
 };
 use rocksdb::{
-    BlockBasedOptions, Cache, ColumnFamilyDescriptor, CompactionPri, DBCompressionType,
-    DBRawIteratorWithThreadMode, IteratorMode, OptimisticTransactionDB,
+    BlockBasedOptions, BoundColumnFamily, Cache, ColumnFamilyDescriptor, CompactionPri,
+    DBCompressionType, DBRawIteratorWithThreadMode, IteratorMode, OptimisticTransactionDB,
     OptimisticTransactionOptions, Options, SnapshotWithThreadMode, Transaction,
     WriteBatchWithTransaction, WriteOptions, DB,
 };
@@ -450,7 +450,7 @@ impl RocksDBProviderInner {
     }
 
     /// Gets the column family handle for a table.
-    fn cf_handle<T: Table>(&self) -> Result<&rocksdb::ColumnFamily, DatabaseError> {
+    fn cf_handle<T: Table>(&self) -> Result<Arc<BoundColumnFamily<'_>>, DatabaseError> {
         let cf = match self {
             Self::ReadWrite { db, .. } => db.cf_handle(T::NAME),
             Self::Secondary { db, .. } => db.cf_handle(T::NAME),
@@ -461,7 +461,7 @@ impl RocksDBProviderInner {
     /// Gets a value from a column family.
     fn get_cf(
         &self,
-        cf: &rocksdb::ColumnFamily,
+        cf: &Arc<BoundColumnFamily<'_>>,
         key: impl AsRef<[u8]>,
     ) -> Result<Option<Vec<u8>>, rocksdb::Error> {
         match self {
@@ -473,7 +473,7 @@ impl RocksDBProviderInner {
     /// Puts a value into a column family.
     fn put_cf(
         &self,
-        cf: &rocksdb::ColumnFamily,
+        cf: &Arc<BoundColumnFamily<'_>>,
         key: impl AsRef<[u8]>,
         value: impl AsRef<[u8]>,
     ) -> Result<(), rocksdb::Error> {
@@ -483,7 +483,7 @@ impl RocksDBProviderInner {
     /// Deletes a value from a column family.
     fn delete_cf(
         &self,
-        cf: &rocksdb::ColumnFamily,
+        cf: &Arc<BoundColumnFamily<'_>>,
         key: impl AsRef<[u8]>,
     ) -> Result<(), rocksdb::Error> {
         self.db_rw().delete_cf(cf, key)
@@ -492,7 +492,7 @@ impl RocksDBProviderInner {
     /// Deletes a range of values from a column family.
     fn delete_range_cf<K: AsRef<[u8]>>(
         &self,
-        cf: &rocksdb::ColumnFamily,
+        cf: &Arc<BoundColumnFamily<'_>>,
         from: K,
         to: K,
     ) -> Result<(), rocksdb::Error> {
@@ -502,7 +502,7 @@ impl RocksDBProviderInner {
     /// Returns an iterator over a column family.
     fn iterator_cf(
         &self,
-        cf: &rocksdb::ColumnFamily,
+        cf: &Arc<BoundColumnFamily<'_>>,
         mode: IteratorMode<'_>,
     ) -> RocksDBIterEnum<'_> {
         match self {
@@ -515,7 +515,7 @@ impl RocksDBProviderInner {
     ///
     /// Unlike [`Self::iterator_cf`], raw iterators support `seek()` for efficient
     /// repositioning without creating a new iterator.
-    fn raw_iterator_cf(&self, cf: &rocksdb::ColumnFamily) -> RocksDBRawIterEnum<'_> {
+    fn raw_iterator_cf(&self, cf: &Arc<BoundColumnFamily<'_>>) -> RocksDBRawIterEnum<'_> {
         match self {
             Self::ReadWrite { db, .. } => RocksDBRawIterEnum::ReadWrite(db.raw_iterator_cf(cf)),
             Self::Secondary { db, .. } => RocksDBRawIterEnum::ReadOnly(db.raw_iterator_cf(cf)),
@@ -564,20 +564,20 @@ impl RocksDBProviderInner {
                 for cf_name in ROCKSDB_TABLES {
                     if let Some(cf) = $db.cf_handle(cf_name) {
                         let estimated_num_keys = $db
-                            .property_int_value_cf(cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
+                            .property_int_value_cf(&cf, rocksdb::properties::ESTIMATE_NUM_KEYS)
                             .ok()
                             .flatten()
                             .unwrap_or(0);
 
                         // SST files size (on-disk) + memtable size (in-memory)
                         let sst_size = $db
-                            .property_int_value_cf(cf, rocksdb::properties::LIVE_SST_FILES_SIZE)
+                            .property_int_value_cf(&cf, rocksdb::properties::LIVE_SST_FILES_SIZE)
                             .ok()
                             .flatten()
                             .unwrap_or(0);
 
                         let memtable_size = $db
-                            .property_int_value_cf(cf, rocksdb::properties::SIZE_ALL_MEM_TABLES)
+                            .property_int_value_cf(&cf, rocksdb::properties::SIZE_ALL_MEM_TABLES)
                             .ok()
                             .flatten()
                             .unwrap_or(0);
@@ -586,7 +586,7 @@ impl RocksDBProviderInner {
 
                         let pending_compaction_bytes = $db
                             .property_int_value_cf(
-                                cf,
+                                &cf,
                                 rocksdb::properties::ESTIMATE_PENDING_COMPACTION_BYTES,
                             )
                             .ok()
@@ -802,7 +802,7 @@ impl RocksDBProvider {
     }
 
     /// Gets the column family handle for a table.
-    fn get_cf_handle<T: Table>(&self) -> Result<&rocksdb::ColumnFamily, DatabaseError> {
+    fn get_cf_handle<T: Table>(&self) -> Result<Arc<BoundColumnFamily<'_>>, DatabaseError> {
         self.0.cf_handle::<T>()
     }
 
@@ -834,7 +834,7 @@ impl RocksDBProvider {
         key: &<T::Key as Encode>::Encoded,
     ) -> ProviderResult<Option<T::Value>> {
         self.execute_with_operation_metric(RocksDBOperation::Get, T::NAME, |this| {
-            let result = this.0.get_cf(this.get_cf_handle::<T>()?, key.as_ref()).map_err(|e| {
+            let result = this.0.get_cf(&this.get_cf_handle::<T>()?, key.as_ref()).map_err(|e| {
                 ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
                     message: e.to_string().into(),
                     code: -1,
@@ -870,7 +870,7 @@ impl RocksDBProvider {
             let mut buf = Vec::new();
             let value_bytes = compress_to_buf_or_ref!(buf, value).unwrap_or(&buf);
 
-            this.0.put_cf(this.get_cf_handle::<T>()?, key, value_bytes).map_err(|e| {
+            this.0.put_cf(&this.get_cf_handle::<T>()?, key, value_bytes).map_err(|e| {
                 ProviderError::Database(DatabaseError::Write(Box::new(DatabaseWriteError {
                     info: DatabaseErrorInfo { message: e.to_string().into(), code: -1 },
                     operation: DatabaseWriteOperation::PutUpsert,
@@ -887,7 +887,7 @@ impl RocksDBProvider {
     /// Panics if the provider is in read-only mode.
     pub fn delete<T: Table>(&self, key: T::Key) -> ProviderResult<()> {
         self.execute_with_operation_metric(RocksDBOperation::Delete, T::NAME, |this| {
-            this.0.delete_cf(this.get_cf_handle::<T>()?, key.encode().as_ref()).map_err(|e| {
+            this.0.delete_cf(&this.get_cf_handle::<T>()?, key.encode().as_ref()).map_err(|e| {
                 ProviderError::Database(DatabaseError::Delete(DatabaseErrorInfo {
                     message: e.to_string().into(),
                     code: -1,
@@ -904,7 +904,7 @@ impl RocksDBProvider {
     pub fn clear<T: Table>(&self) -> ProviderResult<()> {
         let cf = self.get_cf_handle::<T>()?;
 
-        self.0.delete_range_cf(cf, &[] as &[u8], &[0xFF; 256]).map_err(|e| {
+        self.0.delete_range_cf(&cf, &[] as &[u8], &[0xFF; 256]).map_err(|e| {
             ProviderError::Database(DatabaseError::Delete(DatabaseErrorInfo {
                 message: e.to_string().into(),
                 code: -1,
@@ -921,7 +921,7 @@ impl RocksDBProvider {
     ) -> ProviderResult<Option<(T::Key, T::Value)>> {
         self.execute_with_operation_metric(RocksDBOperation::Get, T::NAME, |this| {
             let cf = this.get_cf_handle::<T>()?;
-            let mut iter = this.0.iterator_cf(cf, mode);
+            let mut iter = this.0.iterator_cf(&cf, mode);
 
             match iter.next() {
                 Some(Ok((key_bytes, value_bytes))) => {
@@ -959,7 +959,7 @@ impl RocksDBProvider {
     /// Returns decoded `(Key, Value)` pairs in key order.
     pub fn iter<T: Table>(&self) -> ProviderResult<RocksDBIter<'_, T>> {
         let cf = self.get_cf_handle::<T>()?;
-        let iter = self.0.iterator_cf(cf, IteratorMode::Start);
+        let iter = self.0.iterator_cf(&cf, IteratorMode::Start);
         Ok(RocksDBIter { inner: iter, _marker: std::marker::PhantomData })
     }
 
@@ -1056,7 +1056,7 @@ impl RocksDBProvider {
     /// Returns raw `(key_bytes, value_bytes)` pairs without decoding.
     pub fn raw_iter<T: Table>(&self) -> ProviderResult<RocksDBRawIter<'_>> {
         let cf = self.get_cf_handle::<T>()?;
-        let iter = self.0.iterator_cf(cf, IteratorMode::Start);
+        let iter = self.0.iterator_cf(&cf, IteratorMode::Start);
         Ok(RocksDBRawIter { inner: iter })
     }
 
@@ -1077,9 +1077,10 @@ impl RocksDBProvider {
         let start_bytes = start_key.encode();
 
         // Create a forward iterator starting from our seek position.
-        let iter = self
-            .0
-            .iterator_cf(cf, IteratorMode::From(start_bytes.as_ref(), rocksdb::Direction::Forward));
+        let iter = self.0.iterator_cf(
+            &cf,
+            IteratorMode::From(start_bytes.as_ref(), rocksdb::Direction::Forward),
+        );
 
         let mut result = Vec::new();
         for item in iter {
@@ -1126,9 +1127,10 @@ impl RocksDBProvider {
         let start_key = StorageShardedKey::new(address, storage_key, 0u64);
         let start_bytes = start_key.encode();
 
-        let iter = self
-            .0
-            .iterator_cf(cf, IteratorMode::From(start_bytes.as_ref(), rocksdb::Direction::Forward));
+        let iter = self.0.iterator_cf(
+            &cf,
+            IteratorMode::From(start_bytes.as_ref(), rocksdb::Direction::Forward),
+        );
 
         let mut result = Vec::new();
         for item in iter {
@@ -1442,7 +1444,7 @@ enum RocksReadSnapshotInner<'db> {
 
 impl<'db> RocksReadSnapshotInner<'db> {
     /// Returns a raw iterator over a column family.
-    fn raw_iterator_cf(&self, cf: &rocksdb::ColumnFamily) -> RocksDBRawIterEnum<'_> {
+    fn raw_iterator_cf(&self, cf: &Arc<BoundColumnFamily<'_>>) -> RocksDBRawIterEnum<'_> {
         match self {
             Self::ReadWrite(snap) => RocksDBRawIterEnum::ReadWrite(snap.raw_iterator_cf(cf)),
             Self::Secondary(db) => RocksDBRawIterEnum::ReadOnly(db.raw_iterator_cf(cf)),
@@ -1460,7 +1462,7 @@ impl fmt::Debug for RocksReadSnapshot<'_> {
 
 impl<'db> RocksReadSnapshot<'db> {
     /// Gets the column family handle for a table.
-    fn cf_handle<T: Table>(&self) -> Result<&'db rocksdb::ColumnFamily, DatabaseError> {
+    fn cf_handle<T: Table>(&self) -> Result<Arc<BoundColumnFamily<'_>>, DatabaseError> {
         self.provider.get_cf_handle::<T>()
     }
 
@@ -1469,8 +1471,8 @@ impl<'db> RocksReadSnapshot<'db> {
         let encoded_key = key.encode();
         let cf = self.cf_handle::<T>()?;
         let result = match &self.inner {
-            RocksReadSnapshotInner::ReadWrite(snap) => snap.get_cf(cf, encoded_key.as_ref()),
-            RocksReadSnapshotInner::Secondary(db) => db.get_cf(cf, encoded_key.as_ref()),
+            RocksReadSnapshotInner::ReadWrite(snap) => snap.get_cf(&cf, encoded_key.as_ref()),
+            RocksReadSnapshotInner::Secondary(db) => db.get_cf(&cf, encoded_key.as_ref()),
         }
         .map_err(|e| {
             ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
@@ -1565,7 +1567,7 @@ impl<'db> RocksReadSnapshot<'db> {
         };
 
         let cf = self.cf_handle::<T>()?;
-        let mut iter = self.inner.raw_iterator_cf(cf);
+        let mut iter = self.inner.raw_iterator_cf(&cf);
 
         iter.seek(encoded_key);
         iter.status().map_err(|e| {
@@ -1697,7 +1699,7 @@ impl<'a> RocksDBBatch<'a> {
         value: &T::Value,
     ) -> ProviderResult<()> {
         let value_bytes = compress_to_buf_or_ref!(self.buf, value).unwrap_or(&self.buf);
-        self.inner.put_cf(self.provider.get_cf_handle::<T>()?, key, value_bytes);
+        self.inner.put_cf(&self.provider.get_cf_handle::<T>()?, key, value_bytes);
         self.maybe_auto_commit()?;
         Ok(())
     }
@@ -1706,7 +1708,7 @@ impl<'a> RocksDBBatch<'a> {
     ///
     /// If auto-commit is enabled and the batch exceeds the threshold, commits and resets.
     pub fn delete<T: Table>(&mut self, key: T::Key) -> ProviderResult<()> {
-        self.inner.delete_cf(self.provider.get_cf_handle::<T>()?, key.encode().as_ref());
+        self.inner.delete_cf(&self.provider.get_cf_handle::<T>()?, key.encode().as_ref());
         self.maybe_auto_commit()?;
         Ok(())
     }
@@ -2099,7 +2101,7 @@ impl<'a> RocksDBBatch<'a> {
         const PREFIX_LEN: usize = 20;
 
         let cf = self.provider.get_cf_handle::<tables::AccountsHistory>()?;
-        let mut iter = self.provider.0.raw_iterator_cf(cf);
+        let mut iter = self.provider.0.raw_iterator_cf(&cf);
         let mut outcomes = PrunedIndices::default();
 
         for (address, to_block) in targets {
@@ -2226,7 +2228,7 @@ impl<'a> RocksDBBatch<'a> {
         const PREFIX_LEN: usize = 52;
 
         let cf = self.provider.get_cf_handle::<tables::StoragesHistory>()?;
-        let mut iter = self.provider.0.raw_iterator_cf(cf);
+        let mut iter = self.provider.0.raw_iterator_cf(&cf);
         let mut outcomes = PrunedIndices::default();
 
         for ((address, storage_key), to_block) in targets {
@@ -2445,7 +2447,7 @@ impl<'db> RocksTx<'db> {
         key: &<T::Key as Encode>::Encoded,
     ) -> ProviderResult<Option<T::Value>> {
         let cf = self.provider.get_cf_handle::<T>()?;
-        let result = self.inner.get_cf(cf, key.as_ref()).map_err(|e| {
+        let result = self.inner.get_cf(&cf, key.as_ref()).map_err(|e| {
             ProviderError::Database(DatabaseError::Read(DatabaseErrorInfo {
                 message: e.to_string().into(),
                 code: -1,
@@ -2471,7 +2473,7 @@ impl<'db> RocksTx<'db> {
         let mut buf = Vec::new();
         let value_bytes = compress_to_buf_or_ref!(buf, value).unwrap_or(&buf);
 
-        self.inner.put_cf(cf, key.as_ref(), value_bytes).map_err(|e| {
+        self.inner.put_cf(&cf, key.as_ref(), value_bytes).map_err(|e| {
             ProviderError::Database(DatabaseError::Write(Box::new(DatabaseWriteError {
                 info: DatabaseErrorInfo { message: e.to_string().into(), code: -1 },
                 operation: DatabaseWriteOperation::PutUpsert,
@@ -2484,7 +2486,7 @@ impl<'db> RocksTx<'db> {
     /// Deletes a value from the specified table.
     pub fn delete<T: Table>(&self, key: T::Key) -> ProviderResult<()> {
         let cf = self.provider.get_cf_handle::<T>()?;
-        self.inner.delete_cf(cf, key.encode().as_ref()).map_err(|e| {
+        self.inner.delete_cf(&cf, key.encode().as_ref()).map_err(|e| {
             ProviderError::Database(DatabaseError::Delete(DatabaseErrorInfo {
                 message: e.to_string().into(),
                 code: -1,
@@ -2497,7 +2499,7 @@ impl<'db> RocksTx<'db> {
     /// Returns an iterator that yields `(encoded_key, compressed_value)` pairs.
     pub fn iter<T: Table>(&self) -> ProviderResult<RocksTxIter<'_, T>> {
         let cf = self.provider.get_cf_handle::<T>()?;
-        let iter = self.inner.iterator_cf(cf, IteratorMode::Start);
+        let iter = self.inner.iterator_cf(&cf, IteratorMode::Start);
         Ok(RocksTxIter { inner: iter, _marker: std::marker::PhantomData })
     }
 
@@ -2505,9 +2507,10 @@ impl<'db> RocksTx<'db> {
     pub fn iter_from<T: Table>(&self, key: T::Key) -> ProviderResult<RocksTxIter<'_, T>> {
         let cf = self.provider.get_cf_handle::<T>()?;
         let encoded_key = key.encode();
-        let iter = self
-            .inner
-            .iterator_cf(cf, IteratorMode::From(encoded_key.as_ref(), rocksdb::Direction::Forward));
+        let iter = self.inner.iterator_cf(
+            &cf,
+            IteratorMode::From(encoded_key.as_ref(), rocksdb::Direction::Forward),
+        );
         Ok(RocksTxIter { inner: iter, _marker: std::marker::PhantomData })
     }
 

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -1,3 +1,255 @@
+use crate::{
+    providers::{StaticFileProvider, StaticFileWriter as SfWriter},
+    BlockExecutionWriter, BlockWriter, HistoryWriter, StateWriter, StaticFileProviderFactory,
+    StorageLocation, TrieWriter,
+};
+use alloy_consensus::BlockHeader;
+use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates};
+use reth_db_api::transaction::{DbTx, DbTxMut};
+use reth_errors::{ProviderError, ProviderResult};
+use reth_storage_errors::db::DatabaseError;
+use rust_eth_triedb::get_global_triedb;
+use rust_eth_triedb::triedb_manager::is_triedb_active;
+use reth_primitives_traits::{NodePrimitives, SignedTransaction};
+use reth_static_file_types::StaticFileSegment;
+use reth_storage_api::{DBProvider, StageCheckpointWriter, TransactionsProviderExt};
+use reth_storage_errors::writer::UnifiedStorageWriterError;
+use revm_database::OriginalValuesKnown;
+use std::sync::Arc;
+use tracing::debug;
+
+/// [`UnifiedStorageWriter`] is responsible for managing the writing to storage with both database
+/// and static file providers.
+#[derive(Debug)]
+pub struct UnifiedStorageWriter<'a, ProviderDB, ProviderSF> {
+    database: &'a ProviderDB,
+    static_file: Option<ProviderSF>,
+}
+
+impl<'a, ProviderDB, ProviderSF> UnifiedStorageWriter<'a, ProviderDB, ProviderSF> {
+    /// Creates a new instance of [`UnifiedStorageWriter`].
+    ///
+    /// # Parameters
+    /// - `database`: An optional reference to a database provider.
+    /// - `static_file`: An optional mutable reference to a static file instance.
+    pub const fn new(database: &'a ProviderDB, static_file: Option<ProviderSF>) -> Self {
+        Self { database, static_file }
+    }
+
+    /// Creates a new instance of [`UnifiedStorageWriter`] from a database provider and a static
+    /// file instance.
+    pub fn from<P>(database: &'a P, static_file: ProviderSF) -> Self
+    where
+        P: AsRef<ProviderDB>,
+    {
+        Self::new(database.as_ref(), Some(static_file))
+    }
+
+    /// Creates a new instance of [`UnifiedStorageWriter`] from a database provider.
+    pub fn from_database<P>(database: &'a P) -> Self
+    where
+        P: AsRef<ProviderDB>,
+    {
+        Self::new(database.as_ref(), None)
+    }
+
+    /// Returns a reference to the database writer.
+    ///
+    /// # Panics
+    /// If the database provider is not set.
+    const fn database(&self) -> &ProviderDB {
+        self.database
+    }
+
+    /// Returns a reference to the static file instance.
+    ///
+    /// # Panics
+    /// If the static file instance is not set.
+    const fn static_file(&self) -> &ProviderSF {
+        self.static_file.as_ref().expect("should exist")
+    }
+
+    /// Ensures that the static file instance is set.
+    ///
+    /// # Returns
+    /// - `Ok(())` if the static file instance is set.
+    /// - `Err(StorageWriterError::MissingStaticFileWriter)` if the static file instance is not set.
+    #[expect(unused)]
+    const fn ensure_static_file(&self) -> Result<(), UnifiedStorageWriterError> {
+        if self.static_file.is_none() {
+            return Err(UnifiedStorageWriterError::MissingStaticFileWriter)
+        }
+        Ok(())
+    }
+}
+
+impl UnifiedStorageWriter<'_, (), ()> {
+    /// Commits both storage types in the right order.
+    ///
+    /// For non-unwinding operations it makes more sense to commit the static files first, since if
+    /// it is interrupted before the database commit, we can just truncate
+    /// the static files according to the checkpoints on the next
+    /// start-up.
+    ///
+    /// NOTE: If unwinding data from storage, use `commit_unwind` instead!
+    pub fn commit<P>(provider: P) -> ProviderResult<()>
+    where
+        P: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory,
+    {
+        let static_file = provider.static_file_provider();
+        static_file.commit()?;
+        provider.commit()?;
+        Ok(())
+    }
+
+    /// Commits both storage types in the right order for an unwind operation.
+    ///
+    /// For unwinding it makes more sense to commit the database first, since if
+    /// it is interrupted before the static files commit, we can just
+    /// truncate the static files according to the
+    /// checkpoints on the next start-up.
+    ///
+    /// NOTE: Should only be used after unwinding data from storage!
+    pub fn commit_unwind<P>(provider: P) -> ProviderResult<()>
+    where
+        P: DBProvider<Tx: DbTxMut> + StaticFileProviderFactory,
+    {
+        let static_file = provider.static_file_provider();
+        provider.commit()?;
+        static_file.commit()?;
+        Ok(())
+    }
+}
+
+impl<ProviderDB> UnifiedStorageWriter<'_, ProviderDB, &StaticFileProvider<ProviderDB::Primitives>>
+where
+    ProviderDB: DBProvider<Tx: DbTx + DbTxMut>
+        + BlockWriter
+        + TransactionsProviderExt
+        + TrieWriter
+        + StateWriter
+        + HistoryWriter
+        + StageCheckpointWriter
+        + BlockExecutionWriter
+        + AsRef<ProviderDB>
+        + StaticFileProviderFactory,
+{
+    /// Writes executed blocks and receipts to storage.
+    pub fn save_blocks<N>(&self, blocks: Vec<ExecutedBlockWithTrieUpdates<N>>) -> ProviderResult<()>
+    where
+        N: NodePrimitives<SignedTx: SignedTransaction>,
+        ProviderDB: BlockWriter<Block = N::Block> + StateWriter<Receipt = N::Receipt>,
+    {
+        if blocks.is_empty() {
+            debug!(target: "provider::storage_writer", "Attempted to write empty block range");
+            return Ok(())
+        }
+
+        // NOTE: checked non-empty above
+        let first_block = blocks.first().unwrap().recovered_block();
+
+        let last_block = blocks.last().unwrap().recovered_block();
+        let first_number = first_block.number();
+        let last_block_number = last_block.number();
+
+        debug!(target: "provider::storage_writer", block_count = %blocks.len(), "Writing blocks and execution data to storage");
+
+        let mut triedb = get_global_triedb();
+
+        // TODO: Do performant / batched writes for each type of object
+        // instead of a loop over all blocks,
+        // meaning:
+        //  * blocks
+        //  * state
+        //  * hashed state
+        //  * trie updates (cannot naively extend, need helper)
+        //  * indices (already done basically)
+        // Insert the blocks
+        for ExecutedBlockWithTrieUpdates {
+            block: ExecutedBlock { recovered_block, execution_output, hashed_state },
+            trie,
+        } in blocks
+        {
+            let block_number = recovered_block.number();
+            let state_root = recovered_block.state_root();
+            let hashed_state_clone = hashed_state.clone();
+            let (latest_block_number, latest_state_root) = triedb.latest_persist_state()
+                .map_err(|e| ProviderError::other(e))?;
+
+            if latest_block_number != block_number - 1 {
+                return Err(ProviderError::Database(DatabaseError::Other(format!("latest_block_number != block_number - 1, latest_block_number={}, block_number={}", latest_block_number, block_number))));
+            }
+
+            let block_hash = recovered_block.hash();
+            self.database()
+                .insert_block(Arc::unwrap_or_clone(recovered_block), StorageLocation::Both)?;
+
+            // Write state and changesets to the database.
+            // Must be written after blocks because of the receipt lookup.
+            self.database().write_state(
+                &execution_output,
+                OriginalValuesKnown::No,
+                StorageLocation::StaticFiles,
+            )?;
+
+            if is_triedb_active() {
+                let triedb_hashed_post_state = hashed_state_clone.as_ref().to_triedb_hashed_post_state();
+                let (new_root, difflayer) = triedb.commit_hashed_post_state(latest_state_root, None, &triedb_hashed_post_state)
+                    .map_err(|e| ProviderError::other(e))?;
+                if new_root != state_root {
+                    return Err(ProviderError::Database(DatabaseError::Other(format!("write hashed state to triedb, block_number={}, new_root({:?}) != state_root({:?})", block_number, new_root, state_root))));
+                }
+                triedb.flush(block_number, new_root, &difflayer)
+                    .map_err(|e| ProviderError::other(e))?;
+            } else {
+                // insert hashes and intermediate merkle nodes
+                self.database()
+                    .write_hashed_state(&Arc::unwrap_or_clone(hashed_state).into_sorted())?;
+                self.database().write_trie_updates(
+                    trie.as_ref().ok_or(ProviderError::MissingTrieUpdates(block_hash))?,
+                )?;
+            }
+        }
+
+        // update history indices
+        self.database().update_history_indices(first_number..=last_block_number)?;
+
+        // Update pipeline progress
+        self.database().update_pipeline_stages(last_block_number, false)?;
+
+        debug!(target: "provider::storage_writer", range = ?first_number..=last_block_number, "Appended block data");
+
+        Ok(())
+    }
+
+    /// Removes all block, transaction and receipt data above the given block number from the
+    /// database and static files. This is exclusive, i.e., it only removes blocks above
+    /// `block_number`, and does not remove `block_number`.
+    pub fn remove_blocks_above(&self, block_number: u64) -> ProviderResult<()> {
+        // IMPORTANT: we use `block_number+1` to make sure we remove only what is ABOVE the block
+        debug!(target: "provider::storage_writer", ?block_number, "Removing blocks from database above block_number");
+        self.database().remove_block_and_execution_above(block_number, StorageLocation::Both)?;
+
+        // Get highest static file block for the total block range
+        let highest_static_file_block = self
+            .static_file()
+            .get_highest_static_file_block(StaticFileSegment::Headers)
+            .expect("todo: error handling, headers should exist");
+
+        // IMPORTANT: we use `highest_static_file_block.saturating_sub(block_number)` to make sure
+        // we remove only what is ABOVE the block.
+        //
+        // i.e., if the highest static file block is 8, we want to remove above block 5 only, we
+        // will have three blocks to remove, which will be block 8, 7, and 6.
+        debug!(target: "provider::storage_writer", ?block_number, "Removing static file blocks above block_number");
+        self.static_file()
+            .get_writer(block_number, StaticFileSegment::Headers)?
+            .prune_headers(highest_static_file_block.saturating_sub(block_number))?;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -45,6 +45,10 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 # misc
 rayon = { workspace = true, optional = true }
 
+# triedb dependencies (always available)
+rust-eth-triedb = { workspace = true }
+rust-eth-triedb-state-trie = { workspace = true }
+
 [dev-dependencies]
 reth-primitives-traits = { workspace = true, features = ["serde"] }
 reth-codecs.workspace = true
@@ -67,6 +71,7 @@ revm-state.workspace = true
 
 [features]
 default = ["std"]
+io-uring = ["rust-eth-triedb/io-uring"]
 std = [
     "alloy-consensus/std",
     "alloy-genesis/std",

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -45,9 +45,9 @@ arbitrary = { workspace = true, features = ["derive"], optional = true }
 # misc
 rayon = { workspace = true, optional = true }
 
-# triedb dependencies (always available)
-rust-eth-triedb = { workspace = true }
-rust-eth-triedb-state-trie = { workspace = true }
+# triedb dependencies (require std)
+rust-eth-triedb = { workspace = true, optional = true }
+rust-eth-triedb-state-trie = { workspace = true, optional = true }
 
 [dev-dependencies]
 reth-primitives-traits = { workspace = true, features = ["serde"] }
@@ -71,7 +71,7 @@ revm-state.workspace = true
 
 [features]
 default = ["std"]
-io-uring = ["rust-eth-triedb/io-uring"]
+io-uring = ["rust-eth-triedb?/io-uring"]
 std = [
     "alloy-consensus/std",
     "alloy-genesis/std",
@@ -91,6 +91,8 @@ std = [
     "revm-database/std",
     "revm-state/std",
     "reth-codecs?/std",
+    "dep:rust-eth-triedb",
+    "dep:rust-eth-triedb-state-trie",
 ]
 eip1186 = ["alloy-rpc-types-eth/serde", "dep:alloy-serde"]
 serde = [
@@ -134,5 +136,6 @@ arbitrary = [
     "nybbles/arbitrary",
     "reth-codecs/arbitrary",
     "alloy-rpc-types-eth?/arbitrary",
+    "rust-eth-triedb-state-trie?/arbitrary",
 ]
 rayon = ["dep:rayon"]

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -22,11 +22,15 @@ use rayon::prelude::{FromParallelIterator, IntoParallelIterator, ParallelIterato
 
 use revm_database::{AccountStatus, BundleAccount};
 
-/// In-memory hashed state that stores account and storage changes with keccak256-hashed keys in
-/// hash maps.
+#[cfg(feature = "std")]
 use alloy_consensus::constants::KECCAK_EMPTY;
+#[cfg(feature = "std")]
 use rust_eth_triedb::TrieDBHashedPostState;
+#[cfg(feature = "std")]
 use rust_eth_triedb_state_trie::account::StateAccount;
+
+/// In-memory hashed state that stores account and storage changes with keccak256-hashed keys
+/// in hash maps.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HashedPostState {
@@ -87,7 +91,10 @@ impl HashedPostState {
                     None => HashedStorage::new(false),
                     Some(_) => HashedStorage::from_plain_storage(
                         AccountStatus::Changed,
-                        account.storage.iter().map(|(slot, value)| (slot, &value.previous_or_original_value)),
+                        account
+                            .storage
+                            .iter()
+                            .map(|(slot, value)| (slot, &value.previous_or_original_value)),
                     ),
                 };
                 (hashed_address, (hashed_account, hashed_storage))
@@ -106,16 +113,14 @@ impl HashedPostState {
     }
 
     /// Convert [`HashedPostState`] to [`TrieDBHashedPostState`].
+    #[cfg(feature = "std")]
     pub fn to_triedb_hashed_post_state(&self) -> TrieDBHashedPostState {
         let mut triedb_hashed_post_state = TrieDBHashedPostState::default();
 
-        for (hashed_address, account) in self.accounts.iter() {
+        for (hashed_address, account) in &self.accounts {
             match account {
                 Some(account) => {
-                    let code_hash = match account.bytecode_hash {
-                        Some(code_hash) => code_hash,
-                        None => KECCAK_EMPTY
-                    };
+                    let code_hash = account.bytecode_hash.unwrap_or(KECCAK_EMPTY);
                     let acc = StateAccount::default()
                         .with_nonce(account.nonce)
                         .with_balance(account.balance)
@@ -123,10 +128,10 @@ impl HashedPostState {
                     triedb_hashed_post_state.states.insert(*hashed_address, Some(acc));
 
                     // check if the account is being rebuilt
-                    if let Some(storages) = self.storages.get(hashed_address) {
-                        if storages.wiped {
-                            triedb_hashed_post_state.states_rebuild.insert(*hashed_address);
-                        }
+                    if let Some(storages) = self.storages.get(hashed_address) &&
+                        storages.wiped
+                    {
+                        triedb_hashed_post_state.states_rebuild.insert(*hashed_address);
                     }
                 }
                 None => {
@@ -135,12 +140,12 @@ impl HashedPostState {
             }
         }
 
-        for (hashed_address, storages) in self.storages.iter() {
+        for (hashed_address, storages) in &self.storages {
             if storages.storage.is_empty() {
                 continue;
             }
             let mut kvs = HashMap::new();
-            for (hashed_key, value) in storages.storage.iter() {
+            for (hashed_key, value) in &storages.storage {
                 if value.is_zero() {
                     // if the value is zero, it means the storage is being deleted
                     kvs.insert(*hashed_key, None);

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -24,6 +24,9 @@ use revm_database::{AccountStatus, BundleAccount};
 
 /// In-memory hashed state that stores account and storage changes with keccak256-hashed keys in
 /// hash maps.
+use alloy_consensus::constants::KECCAK_EMPTY;
+use rust_eth_triedb::TrieDBHashedPostState;
+use rust_eth_triedb_state_trie::account::StateAccount;
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HashedPostState {
@@ -46,6 +49,115 @@ impl HashedPostState {
     /// Hashes all changed accounts and storage entries that are currently stored in the bundle
     /// state.
     #[inline]
+    #[cfg(feature = "rayon")]
+    pub fn from_bundle_state<'a, KH: KeyHasher>(
+        state: impl IntoParallelIterator<Item = (&'a Address, &'a BundleAccount)>,
+    ) -> Self {
+        state
+            .into_par_iter()
+            .map(|(address, account)| {
+                let hashed_address = KH::hash_key(address);
+                let hashed_account = account.info.as_ref().map(Into::into);
+                let hashed_storage = HashedStorage::from_plain_storage(
+                    account.status,
+                    account.storage.iter().map(|(slot, value)| (slot, &value.present_value)),
+                );
+
+                (
+                    hashed_address,
+                    hashed_account,
+                    (!hashed_storage.is_empty()).then_some(hashed_storage),
+                )
+            })
+            .collect()
+    }
+
+    /// Initialize [`HashedPostState`] from bundle state.
+    /// Hashes all changed accounts and storage entries that are currently stored in the bundle
+    /// state.
+    pub fn from_bundle_state_to_unwind<'a, KH: KeyHasher>(
+        state: impl IntoIterator<Item = (&'a Address, &'a BundleAccount)>,
+    ) -> Self {
+        let hashed = state
+            .into_iter()
+            .map(|(address, account)| {
+                let hashed_address = KH::hash_key(address);
+                let hashed_account = account.original_info.as_ref().map(Into::into);
+                let hashed_storage = match hashed_account {
+                    None => HashedStorage::new(false),
+                    Some(_) => HashedStorage::from_plain_storage(
+                        AccountStatus::Changed,
+                        account.storage.iter().map(|(slot, value)| (slot, &value.previous_or_original_value)),
+                    ),
+                };
+                (hashed_address, (hashed_account, hashed_storage))
+            })
+            .collect::<Vec<(B256, (Option<Account>, HashedStorage))>>();
+
+        let mut accounts = HashMap::with_capacity_and_hasher(hashed.len(), Default::default());
+        let mut storages = HashMap::with_capacity_and_hasher(hashed.len(), Default::default());
+        for (address, (account, storage)) in hashed {
+            accounts.insert(address, account);
+            if !storage.is_empty() {
+                storages.insert(address, storage);
+            }
+        }
+        Self { accounts, storages }
+    }
+
+    /// Convert [`HashedPostState`] to [`TrieDBHashedPostState`].
+    pub fn to_triedb_hashed_post_state(&self) -> TrieDBHashedPostState {
+        let mut triedb_hashed_post_state = TrieDBHashedPostState::default();
+
+        for (hashed_address, account) in self.accounts.iter() {
+            match account {
+                Some(account) => {
+                    let code_hash = match account.bytecode_hash {
+                        Some(code_hash) => code_hash,
+                        None => KECCAK_EMPTY
+                    };
+                    let acc = StateAccount::default()
+                        .with_nonce(account.nonce)
+                        .with_balance(account.balance)
+                        .with_code_hash(code_hash);
+                    triedb_hashed_post_state.states.insert(*hashed_address, Some(acc));
+
+                    // check if the account is being rebuilt
+                    if let Some(storages) = self.storages.get(hashed_address) {
+                        if storages.wiped {
+                            triedb_hashed_post_state.states_rebuild.insert(*hashed_address);
+                        }
+                    }
+                }
+                None => {
+                    triedb_hashed_post_state.states.insert(*hashed_address, None);
+                }
+            }
+        }
+
+        for (hashed_address, storages) in self.storages.iter() {
+            if storages.storage.is_empty() {
+                continue;
+            }
+            let mut kvs = HashMap::new();
+            for (hashed_key, value) in storages.storage.iter() {
+                if value.is_zero() {
+                    // if the value is zero, it means the storage is being deleted
+                    kvs.insert(*hashed_key, None);
+                } else {
+                    kvs.insert(*hashed_key, Some(*value));
+                }
+            }
+            triedb_hashed_post_state.storage_states.insert(*hashed_address, kvs);
+        }
+
+        triedb_hashed_post_state
+    }
+
+    /// Initialize [`HashedPostState`] from bundle state.
+    /// Hashes all changed accounts and storage entries that are currently stored in the bundle
+    /// state.
+    #[cfg(not(feature = "rayon"))]
     pub fn from_bundle_state<'a, KH: KeyHasher>(
         state: impl IntoIterator<Item = (&'a Address, &'a BundleAccount)>,
     ) -> Self {

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -23,6 +23,9 @@ reth-storage-errors.workspace = true
 reth-stages-types.workspace = true
 reth-metrics = { workspace = true, optional = true }
 
+# triedb
+rust-eth-triedb.workspace = true
+
 # alloy
 alloy-primitives.workspace = true
 
@@ -59,6 +62,7 @@ serde_json.workspace = true
 similar-asserts.workspace = true
 
 [features]
+io-uring = ["rust-eth-triedb/io-uring"]
 metrics = ["reth-trie/metrics", "dep:reth-metrics", "dep:metrics"]
 serde = [
     "similar-asserts/serde",

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -181,13 +181,15 @@ where
         = DatabaseAccountTrieCursor<<TX as DbTx>::Cursor<A::AccountTrieTable>, A>
     where
         Self: 'a;
-
     type StorageTrieCursor<'a>
         = DatabaseStorageTrieCursor<<TX as DbTx>::DupCursor<A::StorageTrieTable>, A>
     where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
+        if rust_eth_triedb::triedb_manager::is_triedb_active() {
+            tracing::warn!("account_trie_cursor should be called under triedb");
+        }
         Ok(DatabaseAccountTrieCursor::new(self.tx.cursor_read::<A::AccountTrieTable>()?))
     }
 
@@ -195,6 +197,9 @@ where
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
+        if rust_eth_triedb::triedb_manager::is_triedb_active() {
+            tracing::warn!("storage_trie_cursor should be called under triedb");
+        }
         Ok(DatabaseStorageTrieCursor::new(
             self.tx.cursor_dup_read::<A::StorageTrieTable>()?,
             hashed_address,

--- a/deny.toml
+++ b/deny.toml
@@ -93,4 +93,5 @@ allow-git = [
     "https://github.com/alloy-rs/hardforks",
     "https://github.com/paradigmxyz/jsonrpsee",
     "https://github.com/DaniPopes/slotmap.git",
+    "https://github.com/bnb-chain/reth-bsc-triedb.git",
 ]

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -1093,6 +1093,10 @@ Static Files:
       --static-files.blocks-per-file.storage-change-sets <BLOCKS_PER_FILE_STORAGE_CHANGE_SETS>
           Number of blocks per file for the storage changesets segment
 
+State Database:
+      --statedb.triedb
+          Use `TrieDB` instead of MDBX for state database
+
 Storage:
       --storage.v2 [<V2>]
           Enable V2 (hot/cold) storage layout for new databases.

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 
 [features]
 ef-tests = []
-asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak"]
+asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak", "reth-provider/asm-keccak"]
 
 [dependencies]
 reth-chainspec.workspace = true


### PR DESCRIPTION
Cherry-pick of `3e7b7666e` from `origin/develop`.

Includes `3e7b7666e` — feat: support triedb as the state storage backend (#53)

Adds `StateDbArgs` and `statedb` field throughout the node config, CLI commands, RPC helpers, stages, and trie storage to support triedb as an alternative state storage backend alongside the existing mdbx backend.

Next commit to port: `8e06e31a6` — fix: get triedb without check active (#55)