### PR TITLE
fix: port triedb fixes from develop (#55, #62)

### DIFF
--- a/bin/reth-bb/Cargo.toml
+++ b/bin/reth-bb/Cargo.toml
@@ -77,6 +77,8 @@ jemalloc = [
     "reth-node-core/jemalloc",
     "reth-ethereum-cli/jemalloc",
     "reth-provider/jemalloc",
+    "reth-engine-tree/jemalloc",
+    "reth-node-builder/jemalloc",
 ]
 
 asm-keccak = [
@@ -88,6 +90,8 @@ asm-keccak = [
     "revm/asm-keccak",
     "revm-primitives/asm-keccak",
     "reth-provider/asm-keccak",
+    "reth-engine-tree/asm-keccak",
+    "reth-node-builder/asm-keccak",
 ]
 
 min-debug-logs = [

--- a/bin/reth/Cargo.toml
+++ b/bin/reth/Cargo.toml
@@ -114,6 +114,8 @@ asm-keccak = [
     "reth-node-ethereum/asm-keccak",
     "alloy-primitives/asm-keccak",
     "reth-provider/asm-keccak",
+    "reth-node-builder/asm-keccak",
+    "reth-rpc/asm-keccak",
 ]
 keccak-cache-global = [
     "reth-node-core/keccak-cache-global",
@@ -134,6 +136,8 @@ jemalloc = [
     "reth-node-metrics/jemalloc",
     "reth-ethereum-cli/jemalloc",
     "reth-provider/jemalloc",
+    "reth-node-builder/jemalloc",
+    "reth-rpc/jemalloc",
 ]
 jemalloc-prof = [
     "jemalloc",

--- a/crates/cli/commands/Cargo.toml
+++ b/crates/cli/commands/Cargo.toml
@@ -116,6 +116,31 @@ tempfile.workspace = true
 [features]
 default = []
 io-uring = ["rust-eth-triedb/io-uring"]
+jemalloc = [
+    "rust-eth-triedb/jemalloc",
+    "reth-cli-util/jemalloc",
+    "reth-db-common/jemalloc",
+    "reth-ethereum-cli/jemalloc",
+    "reth-node-builder/jemalloc",
+    "reth-node-core/jemalloc",
+    "reth-node-metrics/jemalloc",
+    "reth-provider/jemalloc",
+    "reth-stages/jemalloc",
+    "reth-trie-common?/jemalloc",
+    "reth-trie-db/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-db-common/asm-keccak",
+    "reth-ethereum-cli/asm-keccak",
+    "reth-node-builder/asm-keccak",
+    "reth-node-core/asm-keccak",
+    "reth-provider/asm-keccak",
+    "reth-stages/asm-keccak",
+    "reth-trie-common?/asm-keccak",
+    "reth-trie-db/asm-keccak",
+]
 arbitrary = [
     "dep:proptest",
     "dep:arbitrary",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -109,6 +109,27 @@ rand_08.workspace = true
 
 [features]
 io-uring = ["rust-eth-triedb/io-uring"]
+jemalloc = [
+    "rust-eth-triedb/jemalloc",
+    "reth-db-common/jemalloc",
+    "reth-provider/jemalloc",
+    "reth-stages?/jemalloc",
+    "reth-trie-common/jemalloc",
+    "reth-trie-db/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb/asm-keccak",
+    "alloy-evm/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-db-common/asm-keccak",
+    "reth-node-ethereum/asm-keccak",
+    "reth-provider/asm-keccak",
+    "reth-stages?/asm-keccak",
+    "reth-trie-common/asm-keccak",
+    "reth-trie-db/asm-keccak",
+    "revm/asm-keccak",
+    "revm-primitives/asm-keccak",
+]
 test-utils = [
     "reth-chain-state/test-utils",
     "reth-chainspec/test-utils",

--- a/crates/ethereum/cli/Cargo.toml
+++ b/crates/ethereum/cli/Cargo.toml
@@ -44,11 +44,15 @@ dev = ["reth-cli-commands/arbitrary"]
 asm-keccak = [
     "reth-node-core/asm-keccak",
     "reth-node-ethereum/asm-keccak",
+    "reth-cli-commands/asm-keccak",
+    "reth-node-builder/asm-keccak",
 ]
 
 jemalloc = [
     "reth-node-core/jemalloc",
     "reth-node-metrics/jemalloc",
+    "reth-cli-commands/jemalloc",
+    "reth-node-builder/jemalloc",
 ]
 jemalloc-prof = [
     "jemalloc",

--- a/crates/ethereum/node/Cargo.toml
+++ b/crates/ethereum/node/Cargo.toml
@@ -89,6 +89,9 @@ asm-keccak = [
     "reth-node-core/asm-keccak",
     "revm/asm-keccak",
     "reth-provider/asm-keccak",
+    "reth-node-builder/asm-keccak",
+    "reth-rpc/asm-keccak",
+    "reth-rpc-eth-api/asm-keccak",
 ]
 keccak-cache-global = [
     "alloy-primitives/keccak-cache-global",

--- a/crates/ethereum/reth/Cargo.toml
+++ b/crates/ethereum/reth/Cargo.toml
@@ -154,6 +154,9 @@ jemalloc = [
     "reth-ethereum-cli?/jemalloc",
     "reth-node-core?/jemalloc",
     "reth-provider?/jemalloc",
+    "reth-node-builder?/jemalloc",
+    "reth-rpc?/jemalloc",
+    "reth-trie-db?/jemalloc",
 ]
 jemalloc-prof = [
     "jemalloc",

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -99,6 +99,29 @@ reth-evm-ethereum = { workspace = true, features = ["test-utils"] }
 [features]
 default = []
 io-uring = ["rust-eth-triedb/io-uring"]
+jemalloc = [
+    "rust-eth-triedb/jemalloc",
+    "reth-db-common/jemalloc",
+    "reth-engine-tree/jemalloc",
+    "reth-node-core/jemalloc",
+    "reth-node-metrics/jemalloc",
+    "reth-provider/jemalloc",
+    "reth-rpc/jemalloc",
+    "reth-stages/jemalloc",
+    "reth-trie-db/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-db-common/asm-keccak",
+    "reth-engine-tree/asm-keccak",
+    "reth-node-core/asm-keccak",
+    "reth-node-ethereum/asm-keccak",
+    "reth-provider/asm-keccak",
+    "reth-rpc/asm-keccak",
+    "reth-stages/asm-keccak",
+    "reth-trie-db/asm-keccak",
+]
 js-tracer = [
     "reth-rpc/js-tracer",
     "reth-node-ethereum/js-tracer",

--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -64,5 +64,16 @@ tracing.workspace = true
 
 [features]
 io-uring = ["rust-eth-triedb/io-uring"]
+jemalloc = [
+    "rust-eth-triedb/jemalloc",
+    "reth-trie-common/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb/asm-keccak",
+    "alloy-evm/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-trie-common/asm-keccak",
+    "revm/asm-keccak",
+]
 js-tracer = ["revm-inspectors/js-tracer", "reth-rpc-eth-types/js-tracer"]
 client = ["jsonrpsee/client", "jsonrpsee/async-client"]

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -162,7 +162,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         Ok(async move {
             // Check if TrieDB is active, return error if so
             if is_triedb_active() {
-                return Err(EthApiError::MissingTrieNode.into())
+                return Err(EthApiError::MethodNotAvailable("eth_getProof".to_string()).into())
             }
 
             let _permit = self
@@ -195,7 +195,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         self.spawn_blocking_io_fut(move |this| async move {
             // Check if TrieDB is active, return error if so
             if is_triedb_active() {
-                return Err(EthApiError::MissingTrieNode.into())
+                return Err(EthApiError::MethodNotAvailable("eth_getAccount".to_string()).into())
             }
 
             let state = this.state_at_block_id(block_id).await?;

--- a/crates/rpc/rpc-eth-types/src/error/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/error/mod.rs
@@ -147,9 +147,9 @@ pub enum EthApiError {
     /// When the percentile array is invalid
     #[error("invalid reward percentiles")]
     InvalidRewardPercentiles,
-    /// Missing trie node error (used when `TrieDB` is active)
-    #[error("missing trie node")]
-    MissingTrieNode,
+    /// Method not available error (used when `TrieDB` is active)
+    #[error("The method {0} does not exist/is not available")]
+    MethodNotAvailable(String),
     /// Error thrown when a spawned blocking task failed to deliver an anticipated response.
     ///
     /// This only happens if the blocking task panics and is aborted before it can return a
@@ -302,7 +302,10 @@ impl From<EthApiError> for jsonrpsee_types::error::ErrorObject<'static> {
             EthApiError::InvalidBlockData(_) |
             EthApiError::Internal(_) |
             EthApiError::EvmCustom(_) => internal_rpc_err(error.to_string()),
-            EthApiError::MissingTrieNode => rpc_error_with_code(-32000, "missing trie node"),
+            EthApiError::MethodNotAvailable(method) => rpc_error_with_code(
+                -32601,
+                format!("The method {method} does not exist/is not available"),
+            ),
             EthApiError::UnknownBlockOrTxIndex | EthApiError::TransactionNotFound => {
                 rpc_error_with_code(EthRpcErrorCode::ResourceNotFound.code(), error.to_string())
             }

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -106,6 +106,22 @@ jsonrpsee = { workspace = true, features = ["client"] }
 
 [features]
 io-uring = ["rust-eth-triedb/io-uring"]
+jemalloc = [
+    "rust-eth-triedb/jemalloc",
+    "reth-provider/jemalloc",
+    "reth-rpc-eth-api/jemalloc",
+    "reth-trie-common/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb/asm-keccak",
+    "alloy-evm/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-provider/asm-keccak",
+    "reth-rpc-eth-api/asm-keccak",
+    "reth-trie-common/asm-keccak",
+    "revm/asm-keccak",
+    "revm-primitives/asm-keccak",
+]
 js-tracer = [
     "revm-inspectors/js-tracer",
     "reth-rpc-eth-types/js-tracer",

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -32,7 +32,10 @@ use reth_rpc_eth_api::{
     FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
 use reth_rpc_eth_types::{EthApiError, StateCacheDb};
-use reth_rpc_server_types::{result::internal_rpc_err, ToRpcResult};
+use reth_rpc_server_types::{
+    result::{internal_rpc_err, rpc_error_with_code},
+    ToRpcResult,
+};
 use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
     ReceiptProviderIdExt, StateProofProvider, StateProviderFactory, StateRootProvider,
@@ -736,6 +739,13 @@ where
         &self,
         hash: B256,
     ) -> Result<ExecutionWitness, Eth::Error> {
+        if is_triedb_active() {
+            return Err(EthApiError::MethodNotAvailable(
+                "debug_executionWitnessByBlockHash".to_string(),
+            )
+            .into());
+        }
+
         let this = self.clone();
         let block = this
             .eth_api()
@@ -754,6 +764,10 @@ where
         &self,
         block_id: BlockNumberOrTag,
     ) -> Result<ExecutionWitness, Eth::Error> {
+        if is_triedb_active() {
+            return Err(EthApiError::MethodNotAvailable("debug_executionWitness".to_string()).into());
+        }
+
         let this = self.clone();
         let block = this
             .eth_api()
@@ -769,19 +783,21 @@ where
         &self,
         block: Arc<RecoveredBlock<ProviderBlock<Eth::Provider>>>,
     ) -> Result<ExecutionWitness, Eth::Error> {
-        let block_number = block.header().number();
-
-        // TrieDB does not support witness generation.
         if is_triedb_active() {
-            return Err(EthApiError::MissingTrieNode.into())
+            return Err(EthApiError::MethodNotAvailable(
+                "debug_executionWitnessForBlock".to_string(),
+            )
+            .into());
         }
+
+        let block_number = block.header().number();
 
         let (mut exec_witness, lowest_block_number) = self
             .eth_api()
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 let block_executor = eth_api.evm_config().executor(&mut db);
 
-                let mut witness_record = ExecutionWitnessRecord::default();
+                let mut witness_record: ExecutionWitnessRecord = ExecutionWitnessRecord::default();
 
                 let _ = block_executor
                     .execute_with_state_closure(&block, |statedb: &State<_>| {
@@ -1047,9 +1063,10 @@ where
         hashed_state: HashedPostState,
         block_id: Option<BlockId>,
     ) -> Result<(B256, TrieUpdates), Eth::Error> {
-        // Check if TrieDB is active, return error if so
         if is_triedb_active() {
-            return Err(EthApiError::MissingTrieNode.into())
+            return Err(
+                EthApiError::MethodNotAvailable("debug_stateRootWithUpdates".to_string()).into()
+            );
         }
 
         self.inner
@@ -1289,6 +1306,12 @@ where
         &self,
         block: BlockNumberOrTag,
     ) -> RpcResult<ExecutionWitness> {
+        if is_triedb_active() {
+            return Err(rpc_error_with_code(
+                -32601,
+                "The method debug_executionWitness does not exist/is not available",
+            ));
+        }
         let _permit = self.acquire_trace_permit().await;
         Self::debug_execution_witness(self, block).await.map_err(Into::into)
     }
@@ -1298,6 +1321,12 @@ where
         &self,
         hash: B256,
     ) -> RpcResult<ExecutionWitness> {
+        if is_triedb_active() {
+            return Err(rpc_error_with_code(
+                -32601,
+                "The method debug_executionWitnessByBlockHash does not exist/is not available",
+            ));
+        }
         let _permit = self.acquire_trace_permit().await;
         Self::debug_execution_witness_by_block_hash(self, hash).await.map_err(Into::into)
     }
@@ -1518,6 +1547,12 @@ where
         hashed_state: HashedPostState,
         block_id: Option<BlockId>,
     ) -> RpcResult<(B256, TrieUpdates)> {
+        if is_triedb_active() {
+            return Err(rpc_error_with_code(
+                -32601,
+                "The method debug_stateRootWithUpdates does not exist/is not available",
+            ));
+        }
         Self::debug_state_root_with_updates(self, hashed_state, block_id).await.map_err(Into::into)
     }
 

--- a/crates/rpc/rpc/src/validation.rs
+++ b/crates/rpc/rpc/src/validation.rs
@@ -209,9 +209,10 @@ where
 
         self.ensure_payment(&block, &output, &message)?;
 
-        // Check if TrieDB is active, return error if so
         if is_triedb_active() {
-            return Err(ValidationApiError::MissingTrieNode)
+            return Err(ValidationApiError::MethodNotAvailable(
+                "validation_validateMessageAgainstBlock".to_string(),
+            ));
         }
 
         let state_root =
@@ -357,6 +358,12 @@ where
         &self,
         mut blobs_bundle: BlobsBundleV1,
     ) -> Result<Vec<B256>, ValidationApiError> {
+        if is_triedb_active() {
+            return Err(ValidationApiError::MethodNotAvailable(
+                "validation_validateBlobsBundle".to_string(),
+            ));
+        }
+
         if blobs_bundle.commitments.len() != blobs_bundle.proofs.len() ||
             blobs_bundle.commitments.len() != blobs_bundle.blobs.len()
         {
@@ -380,6 +387,11 @@ where
         &self,
         blobs_bundle: BlobsBundleV2,
     ) -> Result<Vec<B256>, ValidationApiError> {
+        if is_triedb_active() {
+            return Err(ValidationApiError::MethodNotAvailable(
+                "validation_validateBlobsBundleV2".to_string(),
+            ));
+        }
         let versioned_hashes = blobs_bundle
             .commitments
             .iter()
@@ -399,6 +411,12 @@ where
         &self,
         request: BuilderBlockValidationRequestV3,
     ) -> Result<(), ValidationApiError> {
+        if is_triedb_active() {
+            return Err(ValidationApiError::MethodNotAvailable(
+                "validation_validateBuilderSubmissionV3".to_string(),
+            ));
+        }
+
         let block = self.payload_validator.ensure_well_formed_payload(ExecutionData {
             payload: ExecutionPayload::V3(request.request.execution_payload),
             sidecar: ExecutionPayloadSidecar::v3(CancunPayloadFields {
@@ -420,6 +438,12 @@ where
         &self,
         request: BuilderBlockValidationRequestV4,
     ) -> Result<(), ValidationApiError> {
+        if is_triedb_active() {
+            return Err(ValidationApiError::MethodNotAvailable(
+                "validation_validateBuilderSubmissionV4".to_string(),
+            ));
+        }
+
         let block = self.payload_validator.ensure_well_formed_payload(ExecutionData {
             payload: ExecutionPayload::V3(request.request.execution_payload),
             sidecar: ExecutionPayloadSidecar::v4(
@@ -448,6 +472,11 @@ where
         &self,
         request: BuilderBlockValidationRequestV5,
     ) -> Result<(), ValidationApiError> {
+        if is_triedb_active() {
+            return Err(ValidationApiError::MethodNotAvailable(
+                "validation_validateBuilderSubmissionV5".to_string(),
+            ));
+        }
         let block = self.payload_validator.ensure_well_formed_payload(ExecutionData {
             payload: ExecutionPayload::V3(request.request.execution_payload),
             sidecar: ExecutionPayloadSidecar::v4(
@@ -499,6 +528,12 @@ where
         &self,
         _request: BuilderBlockValidationRequest,
     ) -> RpcResult<()> {
+        if is_triedb_active() {
+            return Err(rpc_error_with_code(
+                -32601,
+                "The method validation_validateBuilderSubmissionV1 does not exist/is not available",
+            ));
+        }
         warn!(target: "rpc::flashbots", "Method `flashbots_validateBuilderSubmissionV1` is not supported");
         Err(internal_rpc_err("unimplemented"))
     }
@@ -507,6 +542,12 @@ where
         &self,
         _request: BuilderBlockValidationRequestV2,
     ) -> RpcResult<()> {
+        if is_triedb_active() {
+            return Err(rpc_error_with_code(
+                -32601,
+                "The method validation_validateBuilderSubmissionV2 does not exist/is not available",
+            ));
+        }
         warn!(target: "rpc::flashbots", "Method `flashbots_validateBuilderSubmissionV2` is not supported");
         Err(internal_rpc_err("unimplemented"))
     }
@@ -516,6 +557,12 @@ where
         &self,
         request: BuilderBlockValidationRequestV3,
     ) -> RpcResult<()> {
+        if is_triedb_active() {
+            return Err(rpc_error_with_code(
+                -32601,
+                "The method validation_validateBuilderSubmissionV3 does not exist/is not available",
+            ));
+        }
         let this = self.clone();
         let (tx, rx) = oneshot::channel();
 
@@ -534,6 +581,12 @@ where
         &self,
         request: BuilderBlockValidationRequestV4,
     ) -> RpcResult<()> {
+        if is_triedb_active() {
+            return Err(rpc_error_with_code(
+                -32601,
+                "The method validation_validateBuilderSubmissionV4 does not exist/is not available",
+            ));
+        }
         let this = self.clone();
         let (tx, rx) = oneshot::channel();
 
@@ -552,6 +605,12 @@ where
         &self,
         request: BuilderBlockValidationRequestV5,
     ) -> RpcResult<()> {
+        if is_triedb_active() {
+            return Err(rpc_error_with_code(
+                -32601,
+                "The method validation_validateBuilderSubmissionV5 does not exist/is not available",
+            ));
+        }
         let this = self.clone();
         let (tx, rx) = oneshot::channel();
 
@@ -656,8 +715,8 @@ pub enum ValidationApiError {
     InvalidBlobsBundle,
     #[error("block accesses blacklisted address: {_0}")]
     Blacklist(Address),
-    #[error("missing trie node")]
-    MissingTrieNode,
+    #[error("The method {0} does not exist/is not available")]
+    MethodNotAvailable(String),
     #[error(transparent)]
     Blob(#[from] BlobTransactionValidationError),
     #[error(transparent)]
@@ -681,8 +740,10 @@ impl From<ValidationApiError> for ErrorObject<'static> {
             ValidationApiError::ProposerPayment |
             ValidationApiError::InvalidBlobsBundle |
             ValidationApiError::Blob(_) => invalid_params_rpc_err(error.to_string()),
-
-            ValidationApiError::MissingTrieNode => rpc_error_with_code(-32000, "missing trie node"),
+            ValidationApiError::MethodNotAvailable(method) => rpc_error_with_code(
+                -32601,
+                format!("The method {method} does not exist/is not available"),
+            ),
 
             ValidationApiError::MissingLatestBlock |
             ValidationApiError::MissingParentBlock |

--- a/crates/stages/stages/Cargo.toml
+++ b/crates/stages/stages/Cargo.toml
@@ -103,6 +103,21 @@ tempfile.workspace = true
 
 [features]
 io-uring = ["rust-eth-triedb/io-uring"]
+jemalloc = [
+    "rust-eth-triedb/jemalloc",
+    "reth-db-common/jemalloc",
+    "reth-provider/jemalloc",
+    "reth-trie-common/jemalloc",
+    "reth-trie-db/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-db-common/asm-keccak",
+    "reth-provider/asm-keccak",
+    "reth-trie-common/asm-keccak",
+    "reth-trie-db/asm-keccak",
+]
 test-utils = [
     "reth-network-p2p/test-utils",
     "reth-db/test-utils",

--- a/crates/storage/db-common/Cargo.toml
+++ b/crates/storage/db-common/Cargo.toml
@@ -52,6 +52,21 @@ tracing.workspace = true
 [features]
 io-uring = ["rust-eth-triedb/io-uring"]
 edge = ["reth-db-api/edge"]
+jemalloc = [
+    "rust-eth-triedb/jemalloc",
+    "reth-provider/jemalloc",
+    "reth-trie-db/jemalloc",
+    "rust-eth-triedb-common/jemalloc",
+    "rust-eth-triedb-state-trie/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-provider/asm-keccak",
+    "reth-trie-db/asm-keccak",
+    "rust-eth-triedb-common/asm-keccak",
+    "rust-eth-triedb-state-trie/asm-keccak",
+]
 
 [dev-dependencies]
 reth-db = { workspace = true, features = ["mdbx"] }

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -90,8 +90,16 @@ tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }
 
 [features]
 io-uring = ["rust-eth-triedb/io-uring"]
-jemalloc = ["rust-eth-triedb/jemalloc", "rocksdb/jemalloc"]
-asm-keccak = ["rust-eth-triedb/asm-keccak", "alloy-primitives/asm-keccak"]
+jemalloc = [
+    "rust-eth-triedb/jemalloc",
+    "rocksdb/jemalloc",
+    "reth-trie-db/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-trie-db/asm-keccak",
+]
 test-utils = [
     "reth-db/test-utils",
     "reth-nippy-jar/test-utils",

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -1,19 +1,18 @@
 use crate::{
-    providers::{StaticFileProvider, StaticFileWriter as SfWriter},
+    providers::{StaticFileProvider, StaticFileWriter},
     BlockExecutionWriter, BlockWriter, HistoryWriter, StateWriter, StaticFileProviderFactory,
-    StorageLocation, TrieWriter,
+    TrieWriter,
 };
-use alloy_consensus::BlockHeader;
-use reth_chain_state::{ExecutedBlock, ExecutedBlockWithTrieUpdates};
+use reth_chain_state::ExecutedBlock;
 use reth_db_api::transaction::{DbTx, DbTxMut};
 use reth_errors::{ProviderError, ProviderResult};
+use reth_primitives_traits::AlloyBlockHeader;
 use reth_storage_errors::db::DatabaseError;
 use rust_eth_triedb::get_global_triedb;
 use rust_eth_triedb::triedb_manager::is_triedb_active;
 use reth_primitives_traits::{NodePrimitives, SignedTransaction};
 use reth_static_file_types::StaticFileSegment;
 use reth_storage_api::{DBProvider, StageCheckpointWriter, TransactionsProviderExt};
-use reth_storage_errors::writer::UnifiedStorageWriterError;
 use revm_database::OriginalValuesKnown;
 use std::sync::Arc;
 use tracing::debug;
@@ -69,18 +68,6 @@ impl<'a, ProviderDB, ProviderSF> UnifiedStorageWriter<'a, ProviderDB, ProviderSF
         self.static_file.as_ref().expect("should exist")
     }
 
-    /// Ensures that the static file instance is set.
-    ///
-    /// # Returns
-    /// - `Ok(())` if the static file instance is set.
-    /// - `Err(StorageWriterError::MissingStaticFileWriter)` if the static file instance is not set.
-    #[expect(unused)]
-    const fn ensure_static_file(&self) -> Result<(), UnifiedStorageWriterError> {
-        if self.static_file.is_none() {
-            return Err(UnifiedStorageWriterError::MissingStaticFileWriter)
-        }
-        Ok(())
-    }
 }
 
 impl UnifiedStorageWriter<'_, (), ()> {
@@ -135,7 +122,7 @@ where
         + StaticFileProviderFactory,
 {
     /// Writes executed blocks and receipts to storage.
-    pub fn save_blocks<N>(&self, blocks: Vec<ExecutedBlockWithTrieUpdates<N>>) -> ProviderResult<()>
+    pub fn save_blocks<N>(&self, blocks: Vec<ExecutedBlock<N>>) -> ProviderResult<()>
     where
         N: NodePrimitives<SignedTx: SignedTransaction>,
         ProviderDB: BlockWriter<Block = N::Block> + StateWriter<Receipt = N::Receipt>,
@@ -154,7 +141,12 @@ where
 
         debug!(target: "provider::storage_writer", block_count = %blocks.len(), "Writing blocks and execution data to storage");
 
-        let mut triedb = get_global_triedb();
+        // Only get TrieDB instance if TrieDB is active
+        let mut triedb_opt = if is_triedb_active() {
+            Some(get_global_triedb())
+        } else {
+            None
+        };
 
         // TODO: Do performant / batched writes for each type of object
         // instead of a loop over all blocks,
@@ -165,34 +157,36 @@ where
         //  * trie updates (cannot naively extend, need helper)
         //  * indices (already done basically)
         // Insert the blocks
-        for ExecutedBlockWithTrieUpdates {
-            block: ExecutedBlock { recovered_block, execution_output, hashed_state },
-            trie,
-        } in blocks
+        for ExecutedBlock { recovered_block, execution_output, hashed_state, trie_updates } in
+            blocks
         {
             let block_number = recovered_block.number();
             let state_root = recovered_block.state_root();
             let hashed_state_clone = hashed_state.clone();
-            let (latest_block_number, latest_state_root) = triedb.latest_persist_state()
-                .map_err(|e| ProviderError::other(e))?;
 
-            if latest_block_number != block_number - 1 {
-                return Err(ProviderError::Database(DatabaseError::Other(format!("latest_block_number != block_number - 1, latest_block_number={}, block_number={}", latest_block_number, block_number))));
-            }
+            // Only check latest_persist_state if TrieDB is active
+            let latest_state_root_opt = if let Some(ref mut triedb) = triedb_opt {
+                let (latest_block_number, latest_state_root) = triedb.latest_persist_state()
+                    .map_err(|e| ProviderError::other(e))?;
 
-            let block_hash = recovered_block.hash();
-            self.database()
-                .insert_block(Arc::unwrap_or_clone(recovered_block), StorageLocation::Both)?;
+                if latest_block_number != block_number - 1 {
+                    return Err(ProviderError::Database(DatabaseError::Other(format!("latest_block_number != block_number - 1, latest_block_number={}, block_number={}", latest_block_number, block_number))));
+                }
+                Some(latest_state_root)
+            } else {
+                None
+            };
+
+            self.database().insert_block(Arc::unwrap_or_clone(recovered_block))?;
 
             // Write state and changesets to the database.
             // Must be written after blocks because of the receipt lookup.
             self.database().write_state(
                 &execution_output,
                 OriginalValuesKnown::No,
-                StorageLocation::StaticFiles,
             )?;
 
-            if is_triedb_active() {
+            if let (Some(ref mut triedb), Some(latest_state_root)) = (triedb_opt.as_mut(), latest_state_root_opt) {
                 let triedb_hashed_post_state = hashed_state_clone.as_ref().to_triedb_hashed_post_state();
                 let (new_root, difflayer) = triedb.commit_hashed_post_state(latest_state_root, None, &triedb_hashed_post_state)
                     .map_err(|e| ProviderError::other(e))?;
@@ -205,9 +199,9 @@ where
                 // insert hashes and intermediate merkle nodes
                 self.database()
                     .write_hashed_state(&Arc::unwrap_or_clone(hashed_state).into_sorted())?;
-                self.database().write_trie_updates(
-                    trie.as_ref().ok_or(ProviderError::MissingTrieUpdates(block_hash))?,
-                )?;
+                let trie_updates_sorted = (*trie_updates).clone().into_sorted();
+                self.database().write_trie_changesets(block_number, &trie_updates_sorted, None)?;
+                self.database().write_trie_updates_sorted(&trie_updates_sorted)?;
             }
         }
 
@@ -228,7 +222,7 @@ where
     pub fn remove_blocks_above(&self, block_number: u64) -> ProviderResult<()> {
         // IMPORTANT: we use `block_number+1` to make sure we remove only what is ABOVE the block
         debug!(target: "provider::storage_writer", ?block_number, "Removing blocks from database above block_number");
-        self.database().remove_block_and_execution_above(block_number, StorageLocation::Both)?;
+        self.database().remove_block_and_execution_above(block_number)?;
 
         // Get highest static file block for the total block range
         let highest_static_file_block = self

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -506,7 +506,7 @@ where
     where
         <V as TransactionValidator>::Transaction: EthPoolTransaction,
     {
-        let mut elements = Vec::new();
+        let mut elements = Vec::with_capacity(tx_hashes.len());
         self.append_pooled_transaction_elements(&tx_hashes, limit, &mut elements);
         elements.shrink_to_fit();
         elements
@@ -526,13 +526,13 @@ where
     /// Updates the entire pool after a new block was executed.
     pub fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_, V::Block>) {
         trace!(target: "txpool", ?update, "updating pool on canonical state change");
-
         let block_info = update.block_info();
         let CanonicalStateUpdate {
             new_tip, changed_accounts, mined_transactions, update_kind, ..
         } = update;
         self.validator.on_new_head_block(new_tip);
 
+        trace!(target: "txpool", "changed_accounts: {:?} mined_transactions: {:?}", changed_accounts, mined_transactions);
         let changed_senders = self.changed_senders(changed_accounts.into_iter());
 
         // update the pool
@@ -769,6 +769,8 @@ where
     /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
     /// [`TransactionPool::pending_transactions_listener_for`](crate::TransactionPool).
     pub fn on_new_pending_transaction(&self, pending: &AddedPendingTransaction<T::Transaction>) {
+        let start = std::time::Instant::now();
+        let listener_count_before = self.pending_transaction_listener.read().len();
         let mut needs_cleanup = false;
 
         {
@@ -780,12 +782,23 @@ where
             }
         }
 
-        // Clean up dead listeners if we detected any closed channels
         if needs_cleanup {
             self.pending_transaction_listener
                 .write()
                 .retain(|listener| !listener.sender.is_closed());
         }
+
+        let listener_count_after = self.pending_transaction_listener.read().len();
+        let elapsed = start.elapsed();
+        trace!(
+            target: "txpool",
+            tx_hash = %pending.transaction.hash(),
+            listener_count_before,
+            listener_count_after,
+            removed = listener_count_before.saturating_sub(listener_count_after),
+            elapsed_us = elapsed.as_micros(),
+            "on_new_pending_transaction completed"
+        );
     }
 
     /// Notify all listeners about a newly inserted pending transaction.
@@ -797,6 +810,9 @@ where
     /// [`TransactionPool`](crate::TransactionPool) trait for a custom pool implementation
     /// [`TransactionPool::new_transactions_listener_for`](crate::TransactionPool).
     pub fn on_new_transaction(&self, event: NewTransactionEvent<T::Transaction>) {
+        let start = std::time::Instant::now();
+        let tx_hash = *event.transaction.hash();
+        let listener_count_before = self.transaction_listener.read().len();
         let mut needs_cleanup = false;
 
         {
@@ -820,13 +836,25 @@ where
         if needs_cleanup {
             self.transaction_listener.write().retain(|listener| !listener.sender.is_closed());
         }
+
+        let listener_count_after = self.transaction_listener.read().len();
+        let elapsed = start.elapsed();
+        trace!(
+            target: "txpool",
+            tx_hash = %tx_hash,
+            listener_count_before,
+            listener_count_after,
+            removed = listener_count_before.saturating_sub(listener_count_after),
+            elapsed_us = elapsed.as_micros(),
+            "on_new_transaction completed"
+        );
     }
 
     /// Notify all listeners about a blob sidecar for a newly inserted blob (eip4844) transaction.
     fn on_new_blob_sidecar(&self, tx_hash: &TxHash, sidecar: &BlobTransactionSidecarVariant) {
         let mut sidecar_listeners = self.blob_transaction_sidecar_listener.lock();
         if sidecar_listeners.is_empty() {
-            return
+            return;
         }
         let sidecar = Arc::new(sidecar.clone());
         sidecar_listeners.retain_mut(|listener| {
@@ -1056,7 +1084,7 @@ where
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if hashes.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let removed = self.pool.write().remove_transactions(hashes);
 
@@ -1072,7 +1100,7 @@ where
         hashes: Vec<TxHash>,
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if hashes.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let removed = self.pool.write().remove_transactions_and_descendants(hashes);
 
@@ -1119,7 +1147,7 @@ where
         A: HandleMempoolData,
     {
         if announcement.is_empty() {
-            return
+            return;
         }
         let pool = self.get_pool_data();
         announcement.retain_by_hash(|tx| !pool.contains(tx))
@@ -1230,7 +1258,7 @@ where
     /// If no transaction exists, it is skipped.
     pub fn get_all(&self, txs: Vec<TxHash>) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if txs.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         self.get_pool_data().get_all(txs).collect()
     }
@@ -1243,7 +1271,7 @@ where
         txs: &[TxHash],
     ) -> Vec<Arc<ValidPoolTransaction<T::Transaction>>> {
         if txs.is_empty() {
-            return Vec::new()
+            return Vec::new();
         }
         let pool = self.get_pool_data();
         txs.iter().filter_map(|tx| pool.get(tx).filter(|tx| tx.propagate)).collect()
@@ -1384,9 +1412,9 @@ where
         loop {
             let next = self.iter.next()?;
             if self.kind.is_propagate_only() && !next.propagate {
-                continue
+                continue;
             }
-            return Some(*next.hash())
+            return Some(*next.hash());
         }
     }
 }
@@ -1408,12 +1436,12 @@ where
         loop {
             let next = self.iter.next()?;
             if self.kind.is_propagate_only() && !next.propagate {
-                continue
+                continue;
             }
             return Some(NewTransactionEvent {
                 subpool: SubPool::Pending,
                 transaction: next.clone(),
-            })
+            });
         }
     }
 }

--- a/crates/transaction-pool/src/pool/pending.rs
+++ b/crates/transaction-pool/src/pool/pending.rs
@@ -191,7 +191,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 // Remove all dependent transactions.
                 'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
                     if next_id.sender != id.sender {
-                        break 'this
+                        break 'this;
                     }
                     removed.push(Arc::clone(&next_tx.transaction));
                     transactions_iter.next();
@@ -233,7 +233,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                 // Remove all dependent transactions.
                 'this: while let Some((next_id, next_tx)) = transactions_iter.peek() {
                     if next_id.sender != id.sender {
-                        break 'this
+                        break 'this;
                     }
                     removed.push(Arc::clone(&next_tx.transaction));
                     transactions_iter.next();
@@ -444,7 +444,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                         }
                     }
 
-                    return
+                    return;
                 }
 
                 if !remove_locals && tx.transaction.is_local() {
@@ -452,7 +452,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
                     if local_senders.insert(sender_id) {
                         non_local_senders -= 1;
                     }
-                    continue
+                    continue;
                 }
 
                 total_size += tx.transaction.size();
@@ -470,7 +470,7 @@ impl<T: TransactionOrdering> PendingPool<T> {
             // return if either the pool is under limits or there are no more _eligible_
             // transactions to remove
             if !self.exceeds(limit) || non_local_senders == 0 {
-                return
+                return;
             }
         }
     }
@@ -492,13 +492,13 @@ impl<T: TransactionOrdering> PendingPool<T> {
         let mut removed = Vec::new();
         // return early if the pool is already under the limits
         if !self.exceeds(&limit) {
-            return removed
+            return removed;
         }
 
         // first truncate only non-local transactions, returning if the pool end up under the limit
         self.remove_to_limit(&limit, false, &mut removed);
         if !self.exceeds(&limit) {
-            return removed
+            return removed;
         }
 
         // now repeat for local transactions, since local transactions must be removed now for the

--- a/crates/transaction-pool/src/pool/txpool.rs
+++ b/crates/transaction-pool/src/pool/txpool.rs
@@ -33,6 +33,7 @@ use alloy_eips::{
 #[cfg(test)]
 use alloy_primitives::Address;
 use alloy_primitives::{map::AddressSet, TxHash, B256};
+use reth_primitives_traits::transaction::error::InvalidTransactionError;
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use std::{
@@ -42,7 +43,7 @@ use std::{
     ops::Bound::{Excluded, Unbounded},
     sync::Arc,
 };
-use tracing::{trace, warn};
+use tracing::{debug, trace, warn};
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
 // TODO: Inlined diagram due to a bug in aquamarine library, should become an include when it's
@@ -756,6 +757,25 @@ impl<T: TransactionOrdering> TxPool<T> {
             return Err(PoolError::new(*tx.hash(), PoolErrorKind::AlreadyImported))
         }
 
+        let sender_id = tx.sender_id();
+        let current_nonce =
+            self.all_transactions.sender_info.get(&sender_id).map(|i| i.state_nonce).unwrap_or(0);
+        trace!(target: "txpool", "add transaction: txhash: {}, sender: {}, on_chain_nonce: {}, current_nonce: {}, tx_nonce: {}", tx.hash(), tx.sender(), on_chain_nonce, current_nonce, tx.nonce());
+        // TODO: temporarily add a nonce double check to prevent the transaction from being added to
+        // the pool if the nonce is lower than the current nonce
+        if tx.nonce() < current_nonce {
+            debug!(target: "txpool", "double check nonce failed when adding transaction: txhash: {}, sender: {}, nonce: {}, current_nonce: {}, tx_nonce: {}", 
+                tx.hash(), tx.sender(), tx.nonce(), current_nonce, tx.nonce());
+            return Err(PoolError::new(
+                *tx.hash(),
+                PoolErrorKind::InvalidTransaction(InvalidPoolTransactionError::Consensus(
+                    InvalidTransactionError::NonceNotConsistent {
+                        tx: tx.nonce(),
+                        state: current_nonce,
+                    },
+                )),
+            ))
+        }
         self.validate_auth(&tx, on_chain_nonce, on_chain_code_hash)?;
 
         // Update sender info with balance and nonce
@@ -1162,7 +1182,14 @@ impl<T: TransactionOrdering> TxPool<T> {
             // We trace here instead of in subpool structs directly, because the `ParkedPool` type
             // is generic and it would not be possible to distinguish whether a transaction is
             // being removed from the `BaseFee` pool, or the `Queued` pool.
-            trace!(target: "txpool", hash=%tx.transaction.hash(), ?pool, "Removed transaction from a subpool");
+            let sender_id = tx.sender_id();
+            let current_nonce = self
+                .all_transactions
+                .sender_info
+                .get(&sender_id)
+                .map(|i| i.state_nonce)
+                .unwrap_or(0);
+            trace!(target: "txpool", hash=%tx.transaction.hash(), ?pool, "Removed transaction from a subpool, sender: {}, current_nonce: {}, tx_nonce: {}", tx.sender(), current_nonce, tx.nonce());
         }
 
         tx

--- a/crates/trie/common/Cargo.toml
+++ b/crates/trie/common/Cargo.toml
@@ -72,6 +72,15 @@ revm-state.workspace = true
 [features]
 default = ["std"]
 io-uring = ["rust-eth-triedb?/io-uring"]
+jemalloc = [
+    "rust-eth-triedb?/jemalloc",
+    "rust-eth-triedb-state-trie?/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb?/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "rust-eth-triedb-state-trie?/asm-keccak",
+]
 std = [
     "alloy-consensus/std",
     "alloy-genesis/std",

--- a/crates/trie/db/Cargo.toml
+++ b/crates/trie/db/Cargo.toml
@@ -64,6 +64,18 @@ similar-asserts.workspace = true
 [features]
 io-uring = ["rust-eth-triedb/io-uring"]
 metrics = ["reth-trie/metrics", "dep:reth-metrics", "dep:metrics"]
+jemalloc = [
+    "rust-eth-triedb/jemalloc",
+    "reth-provider/jemalloc",
+    "reth-trie-common/jemalloc",
+]
+asm-keccak = [
+    "rust-eth-triedb/asm-keccak",
+    "alloy-primitives/asm-keccak",
+    "reth-provider/asm-keccak",
+    "reth-trie-common/asm-keccak",
+    "revm/asm-keccak",
+]
 serde = [
     "similar-asserts/serde",
     "alloy-consensus/serde",

--- a/testing/ef-tests/Cargo.toml
+++ b/testing/ef-tests/Cargo.toml
@@ -13,7 +13,13 @@ workspace = true
 
 [features]
 ef-tests = []
-asm-keccak = ["alloy-primitives/asm-keccak", "revm/asm-keccak", "reth-provider/asm-keccak"]
+asm-keccak = [
+    "alloy-primitives/asm-keccak",
+    "revm/asm-keccak",
+    "reth-provider/asm-keccak",
+    "reth-db-common/asm-keccak",
+    "reth-trie-db/asm-keccak",
+]
 
 [dependencies]
 reth-chainspec.workspace = true


### PR DESCRIPTION
## Summary

Cherry-picks 3 commits from `develop` onto `develop-v2`:

- `8e06e31a6` — fix: get triedb without check active (#55)
- `3a0306bfb` — fix: forbid rpc err msg
- `91919b570` — fix: to avoid stale p2p tx corrupt the tx-pool meta/data (#62)

Includes conflict resolution for develop-v2 compatibility:
- Remove invalid `reth-provider/rocksdb` feature from `edge` feature (rocksdb is a direct dep on develop-v2, not optional)
- Fix `sender_info` access through `all_transactions` in txpool (field was restructured in upstream)
- Keep `expire_pre_merge_transactions` as stub (required methods not available in this fork)
- Replace `MissingTrieNode` error variant with `MethodNotAvailable` per #55

Next commit to port: `e0628ad91` — feat: define proxyed peer (#56)

🤖 Generated with [Claude Code](https://claude.com/claude-code)