### PR TITLE
feat: define proxyed peer (#56)

### DIFF
--- a/crates/net/eth-wire-types/src/broadcast.rs
+++ b/crates/net/eth-wire-types/src/broadcast.rs
@@ -4,7 +4,7 @@ use crate::{EthMessage, EthVersion, NetworkPrimitives};
 use alloc::{sync::Arc, vec::Vec};
 use alloy_primitives::{
     map::{HashMap, HashSet},
-    Bytes, TxHash, B256, U128,
+    Bytes, TxHash, B256, U128, U256,
 };
 use alloy_rlp::{
     Decodable, Encodable, RlpDecodable, RlpDecodableWrapper, RlpEncodable, RlpEncodableWrapper,
@@ -79,6 +79,9 @@ pub trait NewBlockPayload:
 
     /// Returns a reference to the block.
     fn block(&self) -> &Self::Block;
+
+    /// Returns the total difficulty if available
+    fn td(&self) -> Option<U256>;
 }
 
 /// A new block with the current total difficulty, which includes the difficulty of the returned
@@ -98,6 +101,10 @@ impl<B: Block + 'static> NewBlockPayload for NewBlock<B> {
 
     fn block(&self) -> &Self::Block {
         &self.block
+    }
+
+    fn td(&self) -> Option<U256> {
+        Some(U256::from(self.td))
     }
 }
 

--- a/crates/net/network-api/src/lib.rs
+++ b/crates/net/network-api/src/lib.rs
@@ -23,6 +23,7 @@ pub mod noop;
 pub mod test_utils;
 use test_utils::PeersHandleProvider;
 
+use alloy_primitives::{B256, U256};
 pub use alloy_rpc_types_admin::EthProtocolInfo;
 pub use reth_network_p2p::{BlockClient, HeadersClient};
 pub use reth_network_types::{PeerKind, Reputation, ReputationChangeKind};
@@ -244,12 +245,18 @@ pub struct PeerInfo {
     pub direction: Direction,
     /// The negotiated eth version.
     pub eth_version: EthVersion,
-    /// The Status message the peer sent for the `eth` handshake
+    /// The Status message the peer sent for the `eth` handshake (snapshot at connection time)
     pub status: Arc<UnifiedStatus>,
     /// The timestamp when the session to that peer has been established.
     pub session_established: Instant,
     /// The peer's connection kind
     pub kind: PeerKind,
+    /// Real-time tracked best block hash of the peer
+    pub best_hash: B256,
+    /// Real-time tracked best block number of the peer
+    pub best_number: Option<u64>,
+    /// Real-time tracked total difficulty of the peer (None in `PoS`)
+    pub best_td: Option<U256>,
 }
 
 /// The direction of the connection.

--- a/crates/net/network-types/src/peers/config.rs
+++ b/crates/net/network-types/src/peers/config.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashSet, time::Duration};
 
 use reth_net_banlist::{BanList, IpFilter};
-use reth_network_peers::{NodeRecord, TrustedPeer};
+use reth_network_peers::{NodeRecord, PeerId, TrustedPeer};
 
 use crate::{peers::PersistedPeerInfo, BackoffKind, ReputationChangeWeights};
 
@@ -174,6 +174,8 @@ pub struct PeersConfig {
     ///
     /// This filters out peers from other networks that pollute the discovery table.
     pub enforce_enr_fork_id: bool,
+    /// The node ids of the proxied nodes.
+    pub proxied_node_ids: Vec<PeerId>,
 }
 
 impl Default for PeersConfig {
@@ -195,6 +197,7 @@ impl Default for PeersConfig {
             incoming_ip_throttle_duration: INBOUND_IP_THROTTLE_DURATION,
             ip_filter: IpFilter::default(),
             enforce_enr_fork_id: false,
+            proxied_node_ids: Vec::new(),
         }
     }
 }

--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -220,6 +220,8 @@ pub struct NetworkConfigBuilder<N: NetworkPrimitives = EthNetworkPrimitives> {
     required_block_hashes: Vec<BlockNumHash>,
     /// Optional network id
     network_id: Option<u64>,
+    /// The node ids of the proxied nodes.
+    proxied_node_ids: Vec<PeerId>,
 }
 
 impl NetworkConfigBuilder<EthNetworkPrimitives> {
@@ -262,6 +264,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
             handshake: Arc::new(EthHandshake::default()),
             required_block_hashes: Vec::new(),
             network_id: None,
+            proxied_node_ids: Vec::new(),
         }
     }
 
@@ -467,6 +470,14 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
         self.boot_nodes.iter()
     }
 
+    /// Sets the proxied peer IDs.
+    ///
+    /// These peer IDs will be treated specially in the network layer.
+    pub fn proxied_peers(mut self, peer_ids: Vec<PeerId>) -> Self {
+        self.proxied_node_ids = peer_ids;
+        self
+    }
+
     /// Disable the DNS discovery.
     pub fn disable_dns_discovery(mut self) -> Self {
         self.dns_discovery_config = None;
@@ -620,6 +631,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
             handshake,
             required_block_hashes,
             network_id,
+            proxied_node_ids,
         } = self;
 
         let head = head.unwrap_or_else(|| Head {
@@ -667,6 +679,10 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
             dns_networks.insert(link.parse().expect("is valid DNS link entry"));
         }
 
+        // Set proxied_node_ids in peers_config
+        let mut peers_config = peers_config.unwrap_or_default();
+        peers_config.proxied_node_ids = proxied_node_ids;
+
         NetworkConfig {
             client,
             secret_key,
@@ -676,7 +692,7 @@ impl<N: NetworkPrimitives> NetworkConfigBuilder<N> {
             discovery_v5_config: discovery_v5_builder.map(|builder| builder.build()),
             discovery_v4_addr: discovery_addr.unwrap_or(DEFAULT_DISCOVERY_ADDRESS),
             listener_addr,
-            peers_config: peers_config.unwrap_or_default(),
+            peers_config,
             sessions_config: sessions_config.unwrap_or_default(),
             chain_id,
             block_import: block_import.unwrap_or_else(|| Box::<ProofOfStakeBlockImport>::default()),

--- a/crates/net/network/src/fetch/mod.rs
+++ b/crates/net/network/src/fetch/mod.rs
@@ -139,6 +139,11 @@ impl<N: NetworkPrimitives> StateFetcher<N> {
         false
     }
 
+    /// Gets the peer's best block number
+    pub(crate) fn get_peer_best_number(&self, peer_id: &PeerId) -> Option<u64> {
+        self.peers.get(peer_id).map(|peer| peer.best_number)
+    }
+
     /// Invoked when an active session is about to be disconnected.
     pub(crate) fn on_pending_disconnect(&mut self, peer_id: &PeerId) {
         if let Some(peer) = self.peers.get_mut(peer_id) {

--- a/crates/net/network/src/manager.rs
+++ b/crates/net/network/src/manager.rs
@@ -644,7 +644,17 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             }
             PeerMessage::NewBlock(block) => {
                 self.within_pow_or_disconnect(peer_id, move |this| {
-                    this.swarm.state_mut().on_new_block(peer_id, block.hash);
+                    // Extract TD from the NewBlock message
+                    let td = block.td();
+
+                    // Update the session's current TD (important for BSC and other chains)
+                    if let Some(session) = this.swarm.sessions().active_sessions().get(&peer_id) {
+                        session.update_td(td);
+                    }
+
+                    // Update NetworkState's ActivePeer TD
+                    this.swarm.state_mut().on_new_block_with_td(peer_id, block.hash, td);
+
                     // start block import process
                     this.block_import.on_new_block(peer_id, NewBlockEvent::Block(block));
                 });
@@ -680,13 +690,15 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             NetworkHandleMessage::DiscoveryListener(tx) => {
                 self.swarm.state_mut().discovery_mut().add_listener(tx);
             }
-            NetworkHandleMessage::AnnounceBlock(block, hash) => {
+            NetworkHandleMessage::AnnounceBlock(block, hash, total_difficulty) => {
                 if self.handle.mode().is_stake() {
                     // See [EIP-3675](https://eips.ethereum.org/EIPS/eip-3675#devp2p)
                     warn!(target: "net", "Peer performed block propagation, but it is not supported in proof of stake (EIP-3675)");
-                    return
+                    return;
                 }
-                let msg = NewBlockMessage { hash, block: Arc::new(block) };
+                // Include the total_difficulty when announcing our own block
+                // This is essential for BSC and other chains that rely on TD
+                let msg = NewBlockMessage { hash, block: Arc::new(block), td: total_difficulty };
                 self.swarm.state_mut().announce_new_block(msg);
             }
             NetworkHandleMessage::EthRequest { peer_id, request } => {
@@ -1010,11 +1022,20 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
             .active_sessions()
             .iter()
             .filter_map(|(&peer_id, session)| {
-                self.swarm
-                    .state()
-                    .peers()
-                    .peer_by_id(peer_id)
-                    .map(|(record, kind)| session.peer_info(&record, kind))
+                let (record, kind) = self.swarm.state().peers().peer_by_id(peer_id)?;
+
+                // Get real-time block info from NetworkState
+                let (best_hash, best_number, best_td) =
+                    self.swarm.state().get_peer_best_block(&peer_id).unwrap_or_else(|| {
+                        // Fallback to status from handshake if no real-time data
+                        (
+                            session.status.blockhash,
+                            session.status.latest_block,
+                            session.status.total_difficulty,
+                        )
+                    });
+
+                Some(session.peer_info(&record, kind, best_hash, best_number, best_td))
             })
             .collect()
     }
@@ -1023,13 +1044,21 @@ impl<N: NetworkPrimitives> NetworkManager<N> {
     ///
     /// Returns `None` if there's no active session to the peer.
     fn get_peer_info_by_id(&self, peer_id: PeerId) -> Option<PeerInfo> {
-        self.swarm.sessions().active_sessions().get(&peer_id).and_then(|session| {
-            self.swarm
-                .state()
-                .peers()
-                .peer_by_id(peer_id)
-                .map(|(record, kind)| session.peer_info(&record, kind))
-        })
+        let session = self.swarm.sessions().active_sessions().get(&peer_id)?;
+        let (record, kind) = self.swarm.state().peers().peer_by_id(peer_id)?;
+
+        // Get real-time block info from NetworkState
+        let (best_hash, best_number, best_td) =
+            self.swarm.state().get_peer_best_block(&peer_id).unwrap_or_else(|| {
+                // Fallback to status from handshake if no real-time data
+                (
+                    session.status.blockhash,
+                    session.status.latest_block,
+                    session.status.total_difficulty,
+                )
+            });
+
+        Some(session.peer_info(&record, kind, best_hash, best_number, best_td))
     }
 
     /// Returns [`PeerInfo`] for a given peers.
@@ -1159,7 +1188,7 @@ impl<N: NetworkPrimitives> Future for NetworkManager<N> {
         if maybe_more_handle_messages || maybe_more_swarm_events {
             // make sure we're woken up again
             cx.waker().wake_by_ref();
-            return Poll::Pending
+            return Poll::Pending;
         }
 
         this.update_poll_metrics(start, poll_durations);

--- a/crates/net/network/src/message.rs
+++ b/crates/net/network/src/message.rs
@@ -30,6 +30,8 @@ pub struct NewBlockMessage<P = NewBlock<reth_ethereum_primitives::Block>> {
     pub hash: B256,
     /// Raw received message
     pub block: Arc<P>,
+    /// Total difficulty (extracted from the `NewBlock` message for BSC and other chains)
+    pub td: Option<alloy_primitives::U256>,
 }
 
 // === impl NewBlockMessage ===
@@ -38,6 +40,11 @@ impl<P: NewBlockPayload> NewBlockMessage<P> {
     /// Returns the block number of the block
     pub fn number(&self) -> u64 {
         self.block.block().header().number()
+    }
+
+    /// Returns the total difficulty if available
+    pub const fn td(&self) -> Option<alloy_primitives::U256> {
+        self.td
     }
 }
 

--- a/crates/net/network/src/network.rs
+++ b/crates/net/network/src/network.rs
@@ -116,8 +116,15 @@ impl<N: NetworkPrimitives> NetworkHandle<N> {
     /// Caution: in `PoS` this is a noop because new blocks are no longer announced over devp2p.
     /// Instead they are sent to the node by CL and can be requested over devp2p.
     /// Broadcasting new blocks is considered a protocol violation.
-    pub fn announce_block(&self, block: N::NewBlockPayload, hash: B256) {
-        self.send_message(NetworkHandleMessage::AnnounceBlock(block, hash))
+    ///
+    /// For BSC and other `PoW`-based chains, the `total_difficulty` parameter is essential.
+    pub fn announce_block(
+        &self,
+        block: N::NewBlockPayload,
+        hash: B256,
+        total_difficulty: Option<alloy_primitives::U256>,
+    ) {
+        self.send_message(NetworkHandleMessage::AnnounceBlock(block, hash, total_difficulty))
     }
 
     /// Sends a [`PeerRequest`] to the given peer's session.
@@ -433,7 +440,7 @@ impl<N: NetworkPrimitives> SyncStateProvider for NetworkHandle<N> {
     // used to guard the txpool
     fn is_initially_syncing(&self) -> bool {
         if self.inner.initial_sync_done.load(Ordering::Relaxed) {
-            return false
+            return false;
         }
         self.inner.is_syncing.load(Ordering::Relaxed)
     }
@@ -522,7 +529,7 @@ pub(crate) enum NetworkHandleMessage<N: NetworkPrimitives = EthNetworkPrimitives
     /// Disconnects a connection to a peer if it exists, optionally providing a disconnect reason.
     DisconnectPeer(PeerId, Option<DisconnectReason>),
     /// Broadcasts an event to announce a new block to all nodes.
-    AnnounceBlock(N::NewBlockPayload, B256),
+    AnnounceBlock(N::NewBlockPayload, B256, Option<alloy_primitives::U256>),
     /// Sends a list of transactions to the given peer.
     SendTransaction {
         /// The ID of the peer to which the transactions are sent.

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -38,6 +38,7 @@ use tokio::{
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{trace, warn};
 
+use std::sync::{Arc, RwLock};
 /// Maintains the state of _all_ the peers known to the network.
 ///
 /// This is supposed to be owned by the network itself, but can be reached via the [`PeersHandle`].
@@ -95,6 +96,8 @@ pub struct PeersManager {
     /// If true, discovered peers without a confirmed ENR fork ID will not be added until their
     /// fork ID is verified via EIP-868.
     enforce_enr_fork_id: bool,
+    /// The map of proxied node ids.
+    proxied_node_ids_map: Arc<RwLock<HashSet<PeerId>>>,
 }
 
 impl PeersManager {
@@ -116,6 +119,7 @@ impl PeersManager {
             incoming_ip_throttle_duration,
             ip_filter,
             enforce_enr_fork_id,
+            proxied_node_ids,
         } = config;
         let (manager_tx, handle_rx) = mpsc::unbounded_channel();
         let now = Instant::now();
@@ -166,6 +170,15 @@ impl PeersManager {
             });
         }
 
+        let proxied_node_ids_map =
+            Arc::new(RwLock::new(HashSet::with_capacity(proxied_node_ids.len())));
+        {
+            let mut proxied_node_ids_map_guard = proxied_node_ids_map.write().unwrap();
+            for proxied_node_id in proxied_node_ids {
+                proxied_node_ids_map_guard.insert(proxied_node_id);
+            }
+        }
+
         trace!(target: "net::peers", trusted_peers=?trusted_peer_ids, "Initialized peers manager");
 
         Self {
@@ -193,6 +206,7 @@ impl PeersManager {
             incoming_ip_throttle_duration,
             ip_filter,
             enforce_enr_fork_id,
+            proxied_node_ids_map,
         }
     }
 
@@ -314,7 +328,7 @@ impl PeersManager {
         }
 
         if self.ban_list.is_banned_ip(&addr) {
-            return Err(InboundConnectionError::IpBanned)
+            return Err(InboundConnectionError::IpBanned);
         }
 
         // check if we even have slots for a new incoming connection
@@ -322,7 +336,7 @@ impl PeersManager {
             if self.trusted_peer_ids.is_empty() {
                 // if we don't have any incoming slots and no trusted peers, we don't accept any new
                 // connections
-                return Err(InboundConnectionError::ExceedsCapacity)
+                return Err(InboundConnectionError::ExceedsCapacity);
             }
 
             // there's an edge case here where no incoming connections besides from trusted peers
@@ -335,17 +349,17 @@ impl PeersManager {
                     self.trusted_peer_ids.len().max(self.connection_info.config.max_inbound);
                 if self.connection_info.num_pending_in < max_inbound {
                     self.connection_info.inc_pending_in();
-                    return Ok(())
+                    return Ok(());
                 }
             }
 
             // all trusted peers are either connected or connecting
-            return Err(InboundConnectionError::ExceedsCapacity)
+            return Err(InboundConnectionError::ExceedsCapacity);
         }
 
         // also cap the incoming connections we can process at once
         if !self.connection_info.has_in_pending_capacity() {
-            return Err(InboundConnectionError::ExceedsCapacity)
+            return Err(InboundConnectionError::ExceedsCapacity);
         }
 
         // apply the rate limit
@@ -397,14 +411,14 @@ impl PeersManager {
         // on_incoming_pending_session. We also check if the peer is in the backoff list here.
         if self.ban_list.is_banned_peer(&peer_id) {
             self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-            return
+            return;
         }
 
         // check if the peer is trustable or not
         let mut is_trusted = self.trusted_peer_ids.contains(&peer_id);
         if self.trusted_nodes_only && !is_trusted {
             self.queued_actions.push_back(PeerAction::DisconnectUntrustedIncoming { peer_id });
-            return
+            return;
         }
 
         // start a new tick, so the peer is not immediately rewarded for the time since last tick
@@ -415,7 +429,7 @@ impl PeersManager {
                 let peer = entry.get_mut();
                 if peer.is_banned() {
                     self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
-                    return
+                    return;
                 }
                 // it might be the case that we're also trying to connect to this peer at the same
                 // time, so we need to adjust the state here
@@ -544,7 +558,7 @@ impl PeersManager {
                             ReputationChangeKind::Timeout |
                             ReputationChangeKind::AlreadySeenTransaction
                     ) {
-                        return
+                        return;
                     }
 
                     // also be less strict with the reputation slashing for trusted peers
@@ -556,7 +570,7 @@ impl PeersManager {
                 peer.apply_reputation(reputation_change, rep)
             }
         } else {
-            return
+            return;
         };
 
         match outcome {
@@ -668,7 +682,7 @@ impl PeersManager {
         if let Some(peer) = self.peers.get(peer_id) {
             if peer.state.is_incoming() {
                 // we already have an active connection to the peer, so we can ignore this error
-                return
+                return;
             }
 
             if peer.is_trusted() && is_connection_failed_reputation(peer.reputation) {
@@ -878,7 +892,7 @@ impl PeersManager {
     pub(crate) fn remove_peer(&mut self, peer_id: PeerId) {
         let Entry::Occupied(entry) = self.peers.entry(peer_id) else { return };
         if entry.get().is_trusted() {
-            return
+            return;
         }
         let mut peer = entry.remove();
 
@@ -971,7 +985,7 @@ impl PeersManager {
     pub(crate) fn remove_peer_from_trusted_set(&mut self, peer_id: PeerId) {
         let Entry::Occupied(mut entry) = self.peers.entry(peer_id) else { return };
         if !entry.get().is_trusted() {
-            return
+            return;
         }
 
         let peer = entry.get_mut();
@@ -1004,13 +1018,13 @@ impl PeersManager {
         let mut best_peer = unconnected.next()?;
 
         if best_peer.1.is_trusted() || best_peer.1.is_static() {
-            return Some((*best_peer.0, best_peer.1))
+            return Some((*best_peer.0, best_peer.1));
         }
 
         for maybe_better in unconnected {
             // if the peer is trusted or static, return it immediately
             if maybe_better.1.is_trusted() || maybe_better.1.is_static() {
-                return Some((*maybe_better.0, maybe_better.1))
+                return Some((*maybe_better.0, maybe_better.1));
             }
 
             // prefer higher reputation, break ties by fork_id presence
@@ -1037,7 +1051,7 @@ impl PeersManager {
 
         if !self.net_connection_state.is_active() {
             // nothing to fill
-            return
+            return;
         }
 
         // as long as there are slots available fill them with the best peers
@@ -1098,7 +1112,7 @@ impl PeersManager {
         loop {
             // drain buffered actions
             if let Some(action) = self.queued_actions.pop_front() {
-                return Poll::Ready(action)
+                return Poll::Ready(action);
             }
 
             while let Poll::Ready(Some(cmd)) = self.handle_rx.poll_next_unpin(cx) {
@@ -1137,7 +1151,7 @@ impl PeersManager {
                         if let Some(peer) = self.peers.get_mut(peer_id) {
                             peer.backed_off = false;
                         }
-                        return false
+                        return false;
                     }
                     true
                 })
@@ -1152,9 +1166,14 @@ impl PeersManager {
             }
 
             if self.queued_actions.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
+    }
+
+    /// Checks if the given peer ID belongs to a proxied node.
+    pub fn is_proxied_peer(&self, peer_id: &PeerId) -> bool {
+        self.proxied_node_ids_map.read().unwrap().contains(peer_id)
     }
 }
 
@@ -2190,7 +2209,7 @@ mod tests {
 
             let p = peers.peers.get(&peer).unwrap();
             if p.is_banned() {
-                break
+                break;
             }
         }
 

--- a/crates/net/network/src/session/active.rs
+++ b/crates/net/network/src/session/active.rs
@@ -275,9 +275,13 @@ impl<N: NetworkPrimitives> ActiveSession<N> {
                 self.try_emit_broadcast(PeerMessage::NewBlockHashes(msg)).into()
             }
             EthMessage::NewBlock(msg) => {
+                // Extract TD from NewBlock message (BSC and other chains need this)
+                let td = msg.td();
+
                 let block = NewBlockMessage {
                     hash: msg.block().header().hash_slow(),
                     block: Arc::new(*msg),
+                    td,
                 };
                 self.try_emit_broadcast(PeerMessage::NewBlock(block)).into()
             }

--- a/crates/net/network/src/session/handle.rs
+++ b/crates/net/network/src/session/handle.rs
@@ -76,6 +76,9 @@ pub struct ActiveSessionHandle<N: NetworkPrimitives> {
     pub(crate) local_addr: Option<SocketAddr>,
     /// The Status message the peer sent for the `eth` handshake
     pub(crate) status: Arc<UnifiedStatus>,
+    /// Current total difficulty, updated when receiving `NewBlock` messages
+    /// This is essential for BSC and other chains that rely on TD
+    pub(crate) current_td: Arc<parking_lot::Mutex<Option<alloy_primitives::U256>>>,
 }
 
 // === impl ActiveSessionHandle ===
@@ -139,8 +142,28 @@ impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
         self.commands.queued_broadcast_items()
     }
 
+    /// Returns the current total difficulty
+    pub fn current_td(&self) -> Option<alloy_primitives::U256> {
+        *self.current_td.lock()
+    }
+
+    /// Updates the current total difficulty
+    pub fn update_td(&self, td: Option<alloy_primitives::U256>) {
+        *self.current_td.lock() = td;
+    }
+
     /// Extracts the [`PeerInfo`] from the session handle.
-    pub(crate) fn peer_info(&self, record: &NodeRecord, kind: PeerKind) -> PeerInfo {
+    pub(crate) fn peer_info(
+        &self,
+        record: &NodeRecord,
+        kind: PeerKind,
+        best_hash: alloy_primitives::B256,
+        best_number: Option<u64>,
+        best_td: Option<alloy_primitives::U256>,
+    ) -> PeerInfo {
+        // Use session's current_td if available, otherwise fallback to provided best_td
+        let td = self.current_td().or(best_td);
+
         PeerInfo {
             remote_id: self.remote_id,
             direction: self.direction,
@@ -154,6 +177,9 @@ impl<N: NetworkPrimitives> ActiveSessionHandle<N> {
             status: self.status.clone(),
             session_established: self.established,
             kind,
+            best_hash,
+            best_number,
+            best_td: td,
         }
     }
 }

--- a/crates/net/network/src/session/mod.rs
+++ b/crates/net/network/src/session/mod.rs
@@ -411,7 +411,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
     ) {
         if !self.disconnections_counter.has_capacity() {
             // drop the connection if we don't have capacity for gracefully disconnecting
-            return
+            return;
         }
 
         let guard = self.disconnections_counter.clone();
@@ -519,7 +519,7 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                         peer_id,
                         remote_addr,
                         direction,
-                    })
+                    });
                 }
 
                 let (commands_tx, commands_rx) = mpsc::channel(self.session_command_buffer);
@@ -600,6 +600,8 @@ impl<N: NetworkPrimitives> SessionManager<N> {
                     client_version: Arc::clone(&client_version),
                     remote_addr,
                     local_addr,
+                    // Initialize current_td from status
+                    current_td: Arc::new(parking_lot::Mutex::new(status.total_difficulty)),
                 };
 
                 self.active_sessions.insert(peer_id, handle);
@@ -947,7 +949,7 @@ async fn start_pending_outbound_session<N: NetworkPrimitives>(
                     error,
                 })
                 .await;
-            return
+            return;
         }
     };
     authenticate(
@@ -995,7 +997,7 @@ async fn authenticate<N: NetworkPrimitives>(
                     direction,
                 })
                 .await;
-            return
+            return;
         }
     };
 

--- a/crates/net/network/src/state.rs
+++ b/crates/net/network/src/state.rs
@@ -9,7 +9,7 @@ use crate::{
     session::BlockRangeInfo,
     FetchClient,
 };
-use alloy_consensus::BlockHeader;
+use alloy_consensus::{BlockHeader, Sealable};
 use alloy_primitives::B256;
 use rand::seq::SliceRandom;
 use reth_eth_wire::{
@@ -173,6 +173,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
             peer,
             ActivePeer {
                 best_hash: status.blockhash,
+                best_td: status.total_difficulty,
                 capabilities,
                 request_tx,
                 pending_response: None,
@@ -202,8 +203,10 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         // number of peers)
         let num_propagate = (self.active_peers.len() as f64).sqrt() as u64 + 1;
 
+        let hash = msg.block.block().header().hash_slow();
         let number = msg.block.block().header().number();
         let mut count = 0;
+        let mut proxied_peer_count = 0;
 
         // Shuffle to propagate to a random sample of peers on every block announcement
         let mut peers: Vec<_> = self.active_peers.iter_mut().collect();
@@ -212,7 +215,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         for (peer_id, peer) in peers {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue
+                continue;
             }
 
             // Queue a `NewBlock` message for the peer
@@ -231,10 +234,27 @@ impl<N: NetworkPrimitives> NetworkState<N> {
                 count += 1;
             }
 
-            if count >= num_propagate {
-                break
+            if count > num_propagate && self.peers_manager.is_proxied_peer(peer_id) {
+                debug!("peer:{} is proxied, sending new block:{}", peer_id, number);
+                self.queued_messages
+                    .push_back(StateAction::NewBlock { peer_id: *peer_id, block: msg.clone() });
+
+                // update peer block info
+                if self.state_fetcher.update_peer_block(peer_id, msg.hash, number) {
+                    peer.best_hash = msg.hash;
+                }
+
+                // mark the block as seen by the peer
+                peer.blocks.insert(msg.hash);
+                proxied_peer_count += 1;
             }
+            // todo: evn
         }
+
+        debug!(
+            "Propagated block hash:{}, count:{}, proxied_peer_count:{}",
+            hash, count, proxied_peer_count,
+        );
     }
 
     /// Completes the block propagation process started in [`NetworkState::announce_new_block()`]
@@ -245,7 +265,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         for (peer_id, peer) in &mut self.active_peers {
             if peer.blocks.contains(&msg.hash) {
                 // skip peers which already reported the block
-                continue
+                continue;
             }
 
             if self.state_fetcher.update_peer_block(peer_id, msg.hash, number) {
@@ -267,18 +287,37 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         self.state_fetcher.update_peer_block(peer_id, hash, number);
     }
 
+    /// Gets the peer's real-time best block information
+    /// Returns (`best_hash`, `best_number`, `best_td`)
+    pub(crate) fn get_peer_best_block(
+        &self,
+        peer_id: &PeerId,
+    ) -> Option<(B256, Option<u64>, Option<alloy_primitives::U256>)> {
+        let active_peer = self.active_peers.get(peer_id)?;
+        let best_number = self.state_fetcher.get_peer_best_number(peer_id);
+        Some((active_peer.best_hash, best_number, active_peer.best_td))
+    }
+
     /// Invoked when a new [`ForkId`] is activated.
     pub(crate) fn update_fork_id(&self, fork_id: ForkId) {
         self.discovery.update_fork_id(fork_id)
     }
 
-    /// Invoked after a `NewBlock` message was received by the peer.
+    /// Invoked after a `NewBlock` message was received by the peer with TD info.
     ///
-    /// This will keep track of blocks we know a peer has
-    pub(crate) fn on_new_block(&mut self, peer_id: PeerId, hash: B256) {
-        // Mark the blocks as seen
+    /// This will keep track of blocks we know a peer has and update the TD
+    pub(crate) fn on_new_block_with_td(
+        &mut self,
+        peer_id: PeerId,
+        hash: B256,
+        td: Option<alloy_primitives::U256>,
+    ) {
+        // Mark the blocks as seen and update TD
         if let Some(peer) = self.active_peers.get_mut(&peer_id) {
             peer.blocks.insert(hash);
+            if td.is_some() {
+                peer.best_td = td;
+            }
         }
     }
 
@@ -489,7 +528,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
         loop {
             // drain buffered messages
             if let Some(message) = self.queued_messages.pop_front() {
-                return Poll::Ready(message)
+                return Poll::Ready(message);
             }
 
             while let Poll::Ready(discovery) = self.discovery.poll(cx) {
@@ -559,7 +598,7 @@ impl<N: NetworkPrimitives> NetworkState<N> {
             // We need to poll again in case we have received any responses because they may have
             // triggered follow-up requests.
             if self.queued_messages.is_empty() {
-                return Poll::Pending
+                return Poll::Pending;
             }
         }
     }
@@ -572,6 +611,8 @@ impl<N: NetworkPrimitives> NetworkState<N> {
 pub(crate) struct ActivePeer<N: NetworkPrimitives> {
     /// Best block of the peer.
     pub(crate) best_hash: B256,
+    /// Total difficulty of the peer (None in `PoS`)
+    pub(crate) best_td: Option<alloy_primitives::U256>,
     /// The capabilities of the remote peer.
     pub(crate) capabilities: Arc<Capabilities>,
     /// A communication channel directly to the session task.

--- a/examples/bsc-p2p/src/block_import/service.rs
+++ b/examples/bsc-p2p/src/block_import/service.rs
@@ -402,7 +402,7 @@ mod tests {
     fn create_test_block() -> NewBlockMessage<NewBlock<Block>> {
         let block: reth_ethereum_primitives::Block = Block::default();
         let new_block = NewBlock { block: block.clone(), td: U128::ZERO };
-        NewBlockMessage { hash: block.header.hash_slow(), block: Arc::new(new_block) }
+        NewBlockMessage { hash: block.header.hash_slow(), block: Arc::new(new_block), td: None }
     }
 
     /// Helper function to handle engine messages with specified payload statuses

--- a/typos.toml
+++ b/typos.toml
@@ -42,3 +42,4 @@ BA = "BA" # Part of BAL - Block Access List (EIP-7928)
 consts = "consts" # std::env::consts is a valid Rust module
 Consts = "Consts" # Valid identifier suffix (e.g., RethCliVersionConsts)
 writeable = "writeable"
+evn = "evn" # Abbreviation used in TODO comments


### PR DESCRIPTION
## Summary

Cherry-pick of `e0628ad91` from `develop`:
- feat: define proxyed peer (#56)
- adds TD (total difficulty) tracking for block messages and peer info

Includes conflict resolution for develop-v2:
- Keep upstream's `enforce_enr_fork_id` field alongside new `proxyed_node_ids`
- Keep upstream's `queued_broadcast_items` method alongside new `current_td`/`update_td` methods
- Remove unused `tracing::info` import (code uses fully qualified `tracing::info!`)

Next commit to port: `c7be16ab3` — feat: add set header (#61)

🤖 Generated with [Claude Code](https://claude.com/claude-code)