### PR TITLE
feat: add some metrics (#72)

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -187,6 +187,9 @@ pub struct EngineMetrics {
     pub(crate) block_insert_total_duration: Histogram,
     /// Block insert throughput in mgas/s
     pub(crate) block_insert_mgasps: Gauge,
+    /// Block insertion delay: the difference between current timestamp and block header timestamp
+    /// (in nanoseconds)
+    pub(crate) block_insert_timestamp_delay: Histogram,
 }
 
 /// Metrics for engine forkchoiceUpdated responses.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2947,6 +2947,11 @@ where
 
         let ctx = TreeCtx::new(&mut self.state, &self.canonical_in_memory_state);
 
+        let current_timestamp_nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
         let start = Instant::now();
 
         let (executed, timing_stats) = execute(&mut self.payload_validator, input, ctx)?;
@@ -2968,6 +2973,10 @@ where
         }
 
         let gas_used = executed.sealed_block().header().gas_used();
+        let block_timestamp = executed.sealed_block().header().timestamp();
+        let block_timestamp_nanos = block_timestamp as u128 * 1_000_000_000;
+        let timestamp_delay_nanos =
+            current_timestamp_nanos.saturating_sub(block_timestamp_nanos) as f64;
 
         // if the parent is the canonical head, we can insert the block as the pending block
         if self.state.tree_state.canonical_block_hash() == executed.recovered_block().parent_hash()
@@ -2993,6 +3002,7 @@ where
             .block_insert_total_duration
             .record(block_insert_start.elapsed().as_secs_f64());
         self.metrics.engine.block_insert_mgasps.set(gas_used as f64 / elapsed.as_secs_f64());
+        self.metrics.engine.block_insert_timestamp_delay.record(timestamp_delay_nanos);
         debug!(target: "engine::tree", block=?block_num_hash, "Finished inserting block");
         Ok(InsertPayloadOk::Inserted(BlockStatus::Valid))
     }


### PR DESCRIPTION
## Summary

Cherry-pick of `581a4f37f` from `develop`:
- feat: add some metrics (#72)
- adds `block_insert_timestamp_delay` metric to record the delay between the block timestamp and the local system time when the block is inserted

Conflict resolution:
- Kept HEAD's single-line metric chain style (`self.metrics.engine.foo.set(...)`) while adding the new `block_insert_timestamp_delay` metric

Next commit to port: `62206ddf9` — fix(triedb): disable merkle changesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)