### PR TITLE
fix(triedb): disable merkle changesets

### DIFF
--- a/crates/node/builder/src/setup.rs
+++ b/crates/node/builder/src/setup.rs
@@ -138,7 +138,10 @@ where
             )
             .build(provider_factory, static_file_producer);
 
-        info!(target: "reth::builder", "Pipeline built with TrieDB, without merkle execute and merkle unwind");
+        info!(
+            target: "reth::builder",
+            "Pipeline built with TrieDB, without merkle execute/unwind/changesets"
+        );
         pipeline
     } else {
         builder

--- a/crates/storage/provider/src/writer/mod.rs
+++ b/crates/storage/provider/src/writer/mod.rs
@@ -164,6 +164,11 @@ where
             let state_root = recovered_block.state_root();
             let hashed_state_clone = hashed_state.clone();
 
+            if triedb_opt.is_none() && is_triedb_active() {
+                // TrieDB became active mid-call; switch to TrieDB path for remaining blocks.
+                triedb_opt = Some(get_global_triedb());
+            }
+
             // Only check latest_persist_state if TrieDB is active
             let latest_state_root_opt = if let Some(ref mut triedb) = triedb_opt {
                 let (latest_block_number, latest_state_root) = triedb.latest_persist_state()

--- a/crates/trie/db/src/trie_cursor.rs
+++ b/crates/trie/db/src/trie_cursor.rs
@@ -12,7 +12,11 @@ use reth_trie::{
     BranchNodeCompact, Nibbles, PackedStorageTrieEntry, PackedStoredNibbles,
     PackedStoredNibblesSubKey, StorageTrieEntry, StoredNibbles, StoredNibblesSubKey,
 };
-use std::marker::PhantomData;
+use std::{
+    backtrace::Backtrace,
+    marker::PhantomData,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 /// Trait abstracting nibble encoding for trie keys.
 ///
@@ -187,8 +191,15 @@ where
         Self: 'a;
 
     fn account_trie_cursor(&self) -> Result<Self::AccountTrieCursor<'_>, DatabaseError> {
-        if rust_eth_triedb::triedb_manager::is_triedb_active() {
-            tracing::warn!("account_trie_cursor should be called under triedb");
+        static WARNED_ACCOUNT_CURSOR: AtomicBool = AtomicBool::new(false);
+        if rust_eth_triedb::triedb_manager::is_triedb_active() &&
+            !WARNED_ACCOUNT_CURSOR.swap(true, Ordering::Relaxed)
+        {
+            tracing::warn!(
+                target: "reth_trie_db::trie_cursor",
+                backtrace = ?Backtrace::force_capture(),
+                "account_trie_cursor called while triedb is active"
+            );
         }
         Ok(DatabaseAccountTrieCursor::new(self.tx.cursor_read::<A::AccountTrieTable>()?))
     }
@@ -197,8 +208,16 @@ where
         &self,
         hashed_address: B256,
     ) -> Result<Self::StorageTrieCursor<'_>, DatabaseError> {
-        if rust_eth_triedb::triedb_manager::is_triedb_active() {
-            tracing::warn!("storage_trie_cursor should be called under triedb");
+        static WARNED_STORAGE_CURSOR: AtomicBool = AtomicBool::new(false);
+        if rust_eth_triedb::triedb_manager::is_triedb_active() &&
+            !WARNED_STORAGE_CURSOR.swap(true, Ordering::Relaxed)
+        {
+            tracing::warn!(
+                target: "reth_trie_db::trie_cursor",
+                backtrace = ?Backtrace::force_capture(),
+                hashed_address = ?hashed_address,
+                "storage_trie_cursor called while triedb is active"
+            );
         }
         Ok(DatabaseStorageTrieCursor::new(
             self.tx.cursor_dup_read::<A::StorageTrieTable>()?,


### PR DESCRIPTION
## Summary

Cherry-pick of `62206ddf9` from `develop`:
- fix(triedb): disable merkle changesets
- Adds a fallback in `writer/mod.rs` to pick up `TrieDB` mid-call if it becomes active during block processing
- Deduplicates the `account_trie_cursor`/`storage_trie_cursor` warnings (only log once with a backtrace) when called while triedb is active

Conflict resolution:
- Skipped `.disable(StageId::MerkleChangeSets)` in `setup.rs` — the `MerkleChangeSets` stage has been removed upstream in develop-v2, so it's no longer in the pipeline and can't (or need not) be disabled

Next commit to port: `de3650d09` — feat: rebase to 1.10.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)