### PR TITLE
chore: make tracing-samply optional

### DIFF
--- a/crates/tracing/Cargo.toml
+++ b/crates/tracing/Cargo.toml
@@ -21,7 +21,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "ansi"
 tracing-appender.workspace = true
 tracing-journald.workspace = true
 tracing-logfmt.workspace = true
-tracing-samply.workspace = true
+tracing-samply = { workspace = true, optional = true }
 tracing-tracy = { workspace = true, optional = true }
 tracy-client = { workspace = true, optional = true }
 
@@ -34,4 +34,5 @@ rolling-file.workspace = true
 default = ["otlp"]
 otlp = ["reth-tracing-otlp"]
 otlp-logs = ["reth-tracing-otlp/otlp-logs"]
+samply = ["tracing-samply"]
 tracy = ["tracing-tracy", "tracy-client"]

--- a/crates/tracing/src/layers.rs
+++ b/crates/tracing/src/layers.rs
@@ -159,6 +159,7 @@ impl Layers {
         }
     }
 
+    #[cfg(feature = "samply")]
     pub(crate) fn samply(&mut self, config: LayerInfo) -> eyre::Result<()> {
         self.add_layer(
             tracing_samply::SamplyLayer::new()
@@ -169,6 +170,11 @@ impl Layers {
                 )?),
         );
         Ok(())
+    }
+
+    #[cfg(not(feature = "samply"))]
+    pub(crate) fn samply(&self, _config: LayerInfo) -> eyre::Result<()> {
+        Err(eyre::eyre!("samply feature is disabled"))
     }
 
     #[cfg(feature = "tracy")]


### PR DESCRIPTION
## Summary

Cherry-pick of `84c5b1c85` from `develop`:
- make tracing-samply optional
- Wraps the `tracing-samply` dep behind a feature flag so the node can be built without it

Small fix on top: changed the `samply` stub fn from `&mut self` to `&self` — it doesn't mutate anything, and clippy (used-mutably) was rejecting the needless `mut`.

## Skipped

`de3650d09` (feat: rebase to 1.10.2) was skipped — it's BSC develop's internal version bump from reth 1.9.x → 1.10.2, but `develop-v2` is already on a newer upstream. The content was either:
- Fixing BSC's own duplicate-field bugs from prior cherry-picks (duplicates don't exist on develop-v2)
- Removing `.disable(StageId::MerkleChangeSets)` — already handled in #154 (we never added it since the stage doesn't exist on develop-v2)
- Modifying `examples/custom-node/*` — deleted on develop-v2
- Adapting to 1.10.2 APIs that develop-v2 is already past

Next commit to port: `db3e2483b` — fix(triedb): detect and handle gap between triedb and execution checkpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)