### PR TITLE
fix(triedb): detect and handle gap between triedb and execution checkpoint

### DIFF
--- a/bin/reth-bench/src/bench/replay_payloads.rs
+++ b/bin/reth-bench/src/bench/replay_payloads.rs
@@ -391,12 +391,11 @@ impl Command {
                 let name_str = name.to_string_lossy();
                 let index = if let Some(rest) = name_str.strip_prefix("payload_block_") {
                     rest.strip_suffix(".json")?.parse::<u64>().ok()?
-                } else if let Some(rest) = name_str.strip_prefix("big_block_") {
+                } else {
                     // "big_block_FROM_to_TO.json" — use FROM as the index
+                    let rest = name_str.strip_prefix("big_block_")?;
                     let rest = rest.strip_suffix(".json")?;
                     rest.split("_to_").next()?.parse::<u64>().ok()?
-                } else {
-                    return None;
                 };
                 Some((index, e.path()))
             })

--- a/crates/net/discv5/src/lib.rs
+++ b/crates/net/discv5/src/lib.rs
@@ -248,7 +248,7 @@ impl Discv5 {
             discv5::Event::SocketUpdated(_) | discv5::Event::TalkRequest(_) |
             // `Discovered` not unique discovered peers
             discv5::Event::Discovered(_) => None,
-            discv5::Event::NodeInserted { replaced: _, .. } => {
+            discv5::Event::NodeInserted { .. } => {
 
                 // node has been inserted into kbuckets
 

--- a/crates/rpc/rpc-convert/src/transaction.rs
+++ b/crates/rpc/rpc-convert/src/transaction.rs
@@ -491,7 +491,6 @@ impl<Network, Evm, Receipt, Header, Map, SimTx, RpcTx, TxEnv>
             evm,
             sim_tx_converter,
             rpc_tx_converter,
-            tx_env_converter: _,
             ..
         } = self;
         RpcConverter {

--- a/crates/stages/api/src/error.rs
+++ b/crates/stages/api/src/error.rs
@@ -103,6 +103,15 @@ pub enum StageError {
     /// Post Execute Commit error
     #[error("post execute commit error occurred: {_0}")]
     PostExecuteCommit(&'static str),
+    /// `TrieDB` is behind the execution stage checkpoint.
+    /// This indicates a gap between triedb state and execution state that requires an unwind.
+    #[error("TrieDB is behind execution stage: triedb_block={triedb_block}, execution_start_block={execution_start_block}. Unwinding to triedb checkpoint.")]
+    TrieDBBehind {
+        /// The block number at which triedb checkpoint is.
+        triedb_block: u64,
+        /// The block number at which execution stage wants to start.
+        execution_start_block: u64,
+    },
     /// Internal error
     #[error(transparent)]
     Internal(#[from] RethError),

--- a/crates/stages/api/src/pipeline/mod.rs
+++ b/crates/stages/api/src/pipeline/mod.rs
@@ -2,13 +2,17 @@ mod ctrl;
 mod event;
 pub use crate::pipeline::ctrl::ControlFlow;
 use crate::{PipelineTarget, StageCheckpoint, StageId};
-use alloy_primitives::{BlockNumber, B256};
+use alloy_eips::eip1898::BlockWithParent;
+use alloy_primitives::{BlockNumber, Sealable, B256};
 pub use event::*;
 use futures_util::Future;
-use reth_primitives_traits::constants::BEACON_CONSENSUS_REORG_UNWIND_DEPTH;
+use reth_errors::ProviderError;
+use reth_primitives_traits::{
+    constants::BEACON_CONSENSUS_REORG_UNWIND_DEPTH, AlloyBlockHeader as _,
+};
 use reth_provider::{
     providers::ProviderNodeTypes, BlockHashReader, BlockNumReader, ChainStateBlockReader,
-    ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, ProviderFactory,
+    ChainStateBlockWriter, DBProvider, DatabaseProviderFactory, HeaderProvider, ProviderFactory,
     PruneCheckpointReader, StageCheckpointReader, StageCheckpointWriter,
 };
 use reth_prune::PrunerBuilder;
@@ -637,6 +641,31 @@ impl<N: ProviderNodeTypes> Pipeline<N> {
                 target: block.block.number.saturating_sub(1),
                 bad_block: block,
             }))
+        } else if let StageError::TrieDBBehind { triedb_block, execution_start_block } = err {
+            error!(
+                target: "sync::pipeline",
+                stage = %stage_id,
+                triedb_block = %triedb_block,
+                execution_start_block = %execution_start_block,
+                "TrieDB is behind execution stage. Unwinding to triedb checkpoint."
+            );
+
+            // Construct a BlockWithParent for the execution_start_block
+            // to identify the block that triggered the unwind
+            let header = self
+                .provider_factory
+                .header_by_number(execution_start_block)?
+                .ok_or(ProviderError::HeaderNotFound(execution_start_block.into()))?;
+            let bad_block = Box::new(BlockWithParent {
+                block: alloy_eips::eip1898::BlockNumHash {
+                    number: execution_start_block,
+                    hash: header.hash_slow(),
+                },
+                parent: header.parent_hash(),
+            });
+
+            // Unwind to the triedb checkpoint so execution can resume from there
+            Ok(Some(ControlFlow::Unwind { target: triedb_block, bad_block }))
         } else if err.is_fatal() {
             error!(target: "sync::pipeline", stage = %stage_id, "Stage encountered a fatal error: {err}");
             Err(err.into())

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -516,12 +516,26 @@ where
             let (latest_block_number, latest_state_root) =
                 triedb.latest_persist_state().map_err(|e| StageError::Fatal(Box::new(e)))?;
 
+            // Check for gap between triedb checkpoint and execution start block.
+            // If triedb is behind where we're starting execution, we can't compute
+            // correct state roots. Trigger an unwind to the triedb checkpoint.
+            if start_block > 0 && latest_block_number < start_block - 1 {
+                warn!(target: "sync::stages::execution",
+                    "TrieDB is behind execution stage: triedb_block={}, execution_start_block={}. \
+                    This indicates a gap that requires unwinding to triedb checkpoint.",
+                    latest_block_number, start_block);
+                return Err(StageError::TrieDBBehind {
+                    triedb_block: latest_block_number,
+                    execution_start_block: start_block,
+                });
+            }
+
             if latest_block_number < stage_progress {
                 let root_hash = if start_block == 0 {
                     alloy_trie::EMPTY_ROOT_HASH
                 } else {
-                    // latest_block_number < start_block
-                    // use the latest state root, maybe empty block
+                    // latest_block_number == start_block - 1 (guaranteed by check above)
+                    // use the latest state root as parent for computing new states
                     latest_state_root
                 };
 

--- a/crates/transaction-pool/src/traits.rs
+++ b/crates/transaction-pool/src/traits.rs
@@ -1808,13 +1808,9 @@ impl<Tx: PoolTransaction> NewSubpoolTransactionStream<Tx> {
         &mut self,
     ) -> Result<NewTransactionEvent<Tx>, tokio::sync::mpsc::error::TryRecvError> {
         loop {
-            match self.st.try_recv() {
-                Ok(event) => {
-                    if event.subpool == self.subpool {
-                        return Ok(event)
-                    }
-                }
-                Err(e) => return Err(e),
+            let event = self.st.try_recv()?;
+            if event.subpool == self.subpool {
+                return Ok(event)
             }
         }
     }


### PR DESCRIPTION
## Summary

Cherry-pick of `db3e2483b` from `develop`:
- Adds a new `PipelineError` variant and detection/recovery logic in the pipeline and execution stage to handle cases where the triedb checkpoint is ahead of (or behind) the execution stage checkpoint

Clean cherry-pick (no conflicts).

Next commit to port: `458f3a2b0` — fix(headers): persist total difficulty in header static files

🤖 Generated with [Claude Code](https://claude.com/claude-code)