### PR TITLE
fix(headers): persist total difficulty in header static files

### DIFF
--- a/crates/stages/stages/src/stages/headers.rs
+++ b/crates/stages/stages/src/stages/headers.rs
@@ -1,5 +1,5 @@
 use alloy_consensus::BlockHeader;
-use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256};
+use alloy_primitives::{BlockHash, BlockNumber, Bytes, B256, U256};
 use alloy_rlp::Decodable;
 use futures_util::StreamExt;
 use reth_config::config::EtlConfig;
@@ -17,8 +17,8 @@ use reth_network_p2p::headers::{
 };
 use reth_primitives_traits::{FullBlockHeader, HeaderTy, NodePrimitives, SealedHeader};
 use reth_provider::{
-    providers::StaticFileWriter, BlockHashReader, DBProvider, HeaderSyncGapProvider,
-    StaticFileProviderFactory,
+    providers::StaticFileWriter, BlockHashReader, DBProvider, HeaderProvider,
+    HeaderSyncGapProvider, StaticFileProviderFactory,
 };
 use reth_stages_api::{
     CheckpointBlockRange, EntitiesCheckpoint, ExecInput, ExecOutput, HeadersCheckpoint, Stage,
@@ -115,6 +115,10 @@ where
             .get_highest_static_file_block(StaticFileSegment::Headers)
             .unwrap_or_default();
 
+        // Get the total difficulty of the last header to continue accumulating TD
+        let mut current_td =
+            static_file_provider.header_td_by_number(last_header_number)?.unwrap_or(U256::ZERO);
+
         // Although headers were downloaded in reverse order, the collector iterates it in ascending
         // order
         let mut writer = static_file_provider.latest_writer(StaticFileSegment::Headers)?;
@@ -137,8 +141,11 @@ where
             }
             last_header_number = header.number();
 
-            // Append to Headers segment
-            writer.append_header(header, header_hash)?;
+            // Calculate the new total difficulty: parent_td + block_difficulty
+            current_td = current_td.saturating_add(header.difficulty());
+
+            // Append to Headers segment with total difficulty
+            writer.append_header_with_td(header, current_td, header_hash)?;
         }
 
         info!(target: "sync::stages::headers", total = total_headers, "Writing headers hash index");

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -580,16 +580,19 @@ where
             let mut writer = static_file_provider
                 .get_writer(genesis_block_number, StaticFileSegment::Headers)?;
 
+            // For genesis blocks, total_difficulty equals the block's difficulty
+            let total_difficulty = difficulty;
+
             // For non-zero genesis blocks, we need to set block range to genesis_block_number and
             // append header without increment block
             if genesis_block_number > 0 {
                 writer
                     .user_header_mut()
                     .set_block_range(genesis_block_number, genesis_block_number);
-                writer.append_header_direct(header, difficulty, &block_hash)?;
+                writer.append_header_direct(header, total_difficulty, &block_hash)?;
             } else {
-                // For zero genesis blocks, use normal append_header
-                writer.append_header(header, &block_hash)?;
+                // For zero genesis blocks, use append_header_with_td with genesis difficulty as TD
+                writer.append_header_with_td(header, total_difficulty, &block_hash)?;
             }
         }
         Ok(Some(_)) => {}

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -439,14 +439,20 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
     }
 
     /// Writes headers for all blocks to the static file segment.
+    ///
+    /// `starting_td` is the total difficulty of the parent block (block before the first block).
     #[instrument(level = "debug", target = "providers::static_file", skip_all)]
     fn write_headers(
         w: &mut StaticFileProviderRWRefMut<'_, N>,
         blocks: &[ExecutedBlock<N>],
+        starting_td: U256,
     ) -> ProviderResult<()> {
+        let mut current_td = starting_td;
         for block in blocks {
             let b = block.recovered_block();
-            w.append_header(b.header(), &b.hash())?;
+            // Calculate new TD: parent_td + block_difficulty
+            current_td = current_td.saturating_add(b.header().difficulty());
+            w.append_header_with_td(b.header(), current_td, &b.hash())?;
         }
         Ok(())
     }
@@ -592,12 +598,22 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         tx_nums: &[TxNumber],
         ctx: StaticFileWriteCtx,
         runtime: &reth_tasks::Runtime,
-    ) -> ProviderResult<()> {
+    ) -> ProviderResult<()>
+    where
+        N::BlockHeader: Value,
+    {
         if blocks.is_empty() {
             return Ok(());
         }
 
         let first_block_number = blocks[0].recovered_block().number();
+
+        // Get the TD of the parent block (block before first_block_number) to continue accumulating
+        let starting_td = if first_block_number > 0 {
+            self.header_td_by_number(first_block_number - 1)?.unwrap_or(U256::ZERO)
+        } else {
+            U256::ZERO
+        };
 
         let mut r_headers = None;
         let mut r_txs = None;
@@ -614,7 +630,7 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
                 let _guard = span.enter();
                 r_headers =
                     Some(self.write_segment(StaticFileSegment::Headers, first_block_number, |w| {
-                        Self::write_headers(w, blocks)
+                        Self::write_headers(w, blocks, starting_td)
                     }));
             });
 


### PR DESCRIPTION
## Summary

Cherry-pick of `458f3a2b0` from `develop`:
- Persists the accumulated total difficulty of each header in static files so that it can be recovered during sync restarts, by piping a `starting_td` value through `write_blocks_data` → `write_headers`
- Headers stage now reads `current_td` from the static file writer instead of reinitializing to zero

## Conflict resolution

- `launch/common.rs`: merged new `BlockReaderIdExt, DatabaseProviderFactory` imports with HEAD's existing `StorageSettings` import (both sides needed)
- `headers.rs`: took incoming `use alloy_primitives::U256` (needed by new TD logic); dropped `serde_bincode_compat` import (unused)
- `manager.rs`: kept HEAD's rayon/runtime-based `write_blocks_data` structure, added the new `starting_td` computation and passed it into `write_headers`; added `where N::BlockHeader: Value` trait bound (required by `header_td_by_number`)

Next commit to port: `fa578ae0b` — fix: save block for triedb

🤖 Generated with [Claude Code](https://claude.com/claude-code)