### PR TITLE
fix: save block for triedb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ __pycache__/
 # direnv
 .envrc
 .direnv/
+
+# Claude Code session files
+.claude/

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2127,17 +2127,27 @@ where
             .ok_or_else(|| ProviderError::StateForNumberNotFound(block.header().number()))?;
         let hashed_state = self.provider.hashed_post_state(execution_output.state());
 
-        debug!(
-            target: "engine::tree",
-            number = ?block.number(),
-            "computing block trie updates",
-        );
-        let db_provider = self.provider.database_provider_ro()?;
-        let trie_updates = reth_trie_db::compute_block_trie_updates(
-            &self.changeset_cache,
-            &db_provider,
-            block.number(),
-        )?;
+        // In TrieDB mode, skip computing trie updates from MDBX - TrieDB manages its own trie data
+        let trie_updates = if rust_eth_triedb::triedb_manager::is_triedb_active() {
+            debug!(
+                target: "engine::tree",
+                number = ?block.number(),
+                "skipping block trie updates computation in TrieDB mode",
+            );
+            reth_trie::updates::TrieUpdatesSorted::default()
+        } else {
+            debug!(
+                target: "engine::tree",
+                number = ?block.number(),
+                "computing block trie updates",
+            );
+            let db_provider = self.provider.database_provider_ro()?;
+            reth_trie_db::compute_block_trie_updates(
+                &self.changeset_cache,
+                &db_provider,
+                block.number(),
+            )?
+        };
 
         let sorted_hashed_state = Arc::new(hashed_state.into_sorted());
         let sorted_trie_updates = Arc::new(trie_updates);

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1834,31 +1834,34 @@ where
                 }
 
                 // Compute and cache changesets using the computed trie_updates.
+                // Skip in TrieDB mode — TrieDB manages its own trie data.
                 // Use the pre-created provider to avoid races with changeset cache
                 // eviction that can happen between task spawn and execution.
-                let changeset_start = Instant::now();
+                if !rust_eth_triedb::triedb_manager::is_triedb_active() {
+                    let changeset_start = Instant::now();
 
-                match reth_trie::changesets::compute_trie_changesets(
-                    &changeset_provider,
-                    &computed.trie_updates,
-                ) {
-                    Ok(changesets) => {
-                        debug!(
-                            target: "engine::tree::changeset",
-                            ?block_number,
-                            elapsed = ?changeset_start.elapsed(),
-                            "Computed and caching changesets"
-                        );
+                    match reth_trie::changesets::compute_trie_changesets(
+                        &changeset_provider,
+                        &computed.trie_updates,
+                    ) {
+                        Ok(changesets) => {
+                            debug!(
+                                target: "engine::tree::changeset",
+                                ?block_number,
+                                elapsed = ?changeset_start.elapsed(),
+                                "Computed and caching changesets"
+                            );
 
-                        pending_changeset_guard.resolve(block_number, Arc::new(changesets));
-                    }
-                    Err(e) => {
-                        warn!(
-                            target: "engine::tree::changeset",
-                            ?block_number,
-                            ?e,
-                            "Failed to compute changesets in deferred trie task"
-                        );
+                            pending_changeset_guard.resolve(block_number, Arc::new(changesets));
+                        }
+                        Err(e) => {
+                            warn!(
+                                target: "engine::tree::changeset",
+                                ?block_number,
+                                ?e,
+                                "Failed to compute changesets in deferred trie task"
+                            );
+                        }
                     }
                 }
             }));

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -73,6 +73,7 @@ use reth_trie_db::{ChangesetCache, DatabaseStorageTrieCursor, TrieTableAdapter};
 use revm_database::states::{
     PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset,
 };
+use rust_eth_triedb::{get_global_triedb, triedb_manager::is_triedb_active};
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
@@ -677,8 +678,14 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                 );
             }
 
+            // Get TrieDB instance if active
+            let triedb_active = is_triedb_active();
+            let mut triedb_opt = triedb_active.then(get_global_triedb);
+
             for (i, block) in blocks.iter().enumerate() {
                 let recovered_block = block.recovered_block();
+                let block_number = recovered_block.number();
+                let state_root = recovered_block.state_root();
 
                 let start = Instant::now();
                 self.insert_block_mdbx_only(recovered_block, tx_nums[i])?;
@@ -704,12 +711,75 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                         },
                     )?;
                     timings.write_state += start.elapsed();
+
+                    if let Some(ref mut triedb) = triedb_opt {
+                        // TrieDB mode: update TrieDB instead of writing hashed state to MDBX
+                        let start = Instant::now();
+
+                        let trie_data = block.trie_data();
+
+                        let (latest_block_number, latest_state_root) =
+                            triedb.latest_persist_state().map_err(ProviderError::other)?;
+
+                        // Validate that triedb state is consistent
+                        if block_number > 0 && latest_block_number != block_number - 1 {
+                            return Err(ProviderError::Database(reth_db_api::DatabaseError::Other(format!(
+                                "triedb state gap in save_blocks: latest_block_number={}, expected={}, block_number={}",
+                                latest_block_number,
+                                block_number - 1,
+                                block_number
+                            ))));
+                        }
+
+                        let triedb_hashed_post_state =
+                            trie_data.hashed_state.to_triedb_hashed_post_state();
+
+                        debug!(
+                            target: "providers::db",
+                            "Begin update triedb in save_blocks, block_number={}, latest_triedb_block={}, parent_root={:?}, expected_root={:?}",
+                            block_number,
+                            latest_block_number,
+                            latest_state_root,
+                            state_root,
+                        );
+
+                        let (new_root, difflayer) = triedb
+                            .commit_hashed_post_state(
+                                latest_state_root,
+                                None,
+                                &triedb_hashed_post_state,
+                            )
+                            .map_err(ProviderError::other)?;
+
+                        if new_root != state_root {
+                            return Err(ProviderError::Database(reth_db_api::DatabaseError::Other(format!(
+                                "triedb update failed in save_blocks: new_root({:?}) != expected_root({:?}), block_number={}",
+                                new_root,
+                                state_root,
+                                block_number
+                            ))));
+                        }
+
+                        triedb
+                            .flush(block_number, new_root, &difflayer)
+                            .map_err(ProviderError::other)?;
+
+                        debug!(
+                            target: "providers::db",
+                            "End update triedb in save_blocks, block_number={}, new_root={:?}",
+                            block_number,
+                            new_root
+                        );
+
+                        timings.write_hashed_state += start.elapsed();
+                    }
                 }
             }
 
             // Write all hashed state and trie updates in single batches.
             // This reduces cursor open/close overhead from N calls to 1.
-            if save_mode.with_state() {
+            // Skip in TrieDB mode — TrieDB manages its own trie data.
+            if save_mode.with_state() && !triedb_active {
                 // Blocks are oldest-to-newest, merge_batch expects newest-to-oldest.
                 let start = Instant::now();
                 let merged_hashed_state = HashedPostStateSorted::merge_batch(
@@ -852,18 +922,22 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         self.unwind_storage_history_indices(changed_storages.iter().copied())?;
 
         // Unwind accounts/storages trie tables using the revert.
-        // Get the database tip block number
-        let db_tip_block = self
-            .get_stage_checkpoint(reth_stages_types::StageId::Finish)?
-            .as_ref()
-            .map(|chk| chk.block_number)
-            .ok_or_else(|| ProviderError::InsufficientChangesets {
-                requested: from,
-                available: 0..=0,
-            })?;
+        // Skip in TrieDB mode - TrieDB manages its own trie data.
+        if !is_triedb_active() {
+            // Get the database tip block number
+            let db_tip_block = self
+                .get_stage_checkpoint(reth_stages_types::StageId::Finish)?
+                .as_ref()
+                .map(|chk| chk.block_number)
+                .ok_or_else(|| ProviderError::InsufficientChangesets {
+                    requested: from,
+                    available: 0..=0,
+                })?;
 
-        let trie_revert = self.changeset_cache.get_or_compute_range(self, from..=db_tip_block)?;
-        self.write_trie_updates_sorted(&trie_revert)?;
+            let trie_revert =
+                self.changeset_cache.get_or_compute_range(self, from..=db_tip_block)?;
+            self.write_trie_updates_sorted(&trie_revert)?;
+        }
 
         Ok(())
     }

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -800,6 +800,53 @@ impl HashedPostStateSorted {
         self.accounts.clear();
         self.storages.clear();
     }
+
+    /// Convert [`HashedPostStateSorted`] to [`TrieDBHashedPostState`].
+    #[cfg(feature = "std")]
+    pub fn to_triedb_hashed_post_state(&self) -> TrieDBHashedPostState {
+        let mut triedb_hashed_post_state = TrieDBHashedPostState::default();
+
+        for (hashed_address, account) in &self.accounts {
+            match account {
+                Some(account) => {
+                    let code_hash = account.bytecode_hash.unwrap_or(KECCAK_EMPTY);
+                    let acc = StateAccount::default()
+                        .with_nonce(account.nonce)
+                        .with_balance(account.balance)
+                        .with_code_hash(code_hash);
+                    triedb_hashed_post_state.states.insert(*hashed_address, Some(acc));
+
+                    // check if the account is being rebuilt
+                    if let Some(storages) = self.storages.get(hashed_address) &&
+                        storages.wiped
+                    {
+                        triedb_hashed_post_state.states_rebuild.insert(*hashed_address);
+                    }
+                }
+                None => {
+                    triedb_hashed_post_state.states.insert(*hashed_address, None);
+                }
+            }
+        }
+
+        for (hashed_address, storages) in &self.storages {
+            if storages.storage_slots.is_empty() {
+                continue;
+            }
+            let mut kvs = HashMap::new();
+            for (hashed_key, value) in &storages.storage_slots {
+                if value.is_zero() {
+                    // if the value is zero, it means the storage is being deleted
+                    kvs.insert(*hashed_key, None);
+                } else {
+                    kvs.insert(*hashed_key, Some(*value));
+                }
+            }
+            triedb_hashed_post_state.storage_states.insert(*hashed_address, kvs);
+        }
+
+        triedb_hashed_post_state
+    }
 }
 
 impl AsRef<Self> for HashedPostStateSorted {


### PR DESCRIPTION
## Summary

Cherry-pick of `fa578ae0b` from `develop`:
- When saving blocks, if TrieDB is active, update TrieDB (commit hashed post state, validate root, flush) instead of writing hashed state to MDBX
- Skip changeset computation and batched hashed state / trie update writes in TrieDB mode — TrieDB manages its own trie data
- Adds `HashedPostStateSorted::to_triedb_hashed_post_state` conversion

## Conflict resolution

- `payload_validator.rs`: kept HEAD's newer API (`changeset_provider`, `pending_changeset_guard.resolve`) and wrapped the existing changeset computation in `if !is_triedb_active()` per the incoming intent
- `provider.rs` (per-block): added incoming's TrieDB update branch after `write_state`; dropped the incoming's non-TrieDB `else` branch because HEAD already writes hashed state in batch later
- `provider.rs` (batched write): kept HEAD's merged-batch structure for hashed_state + trie_updates but gated it on `!triedb_active`
- `provider.rs` (unwind): dropped the incoming's `clear_trie_changesets_from(from)?` call — the method doesn't exist on develop-v2

Clippy fixes applied on top (in `hashed_state.rs`): collapsed `match Option<T> { Some => x, None => default }` into `unwrap_or`, collapsed nested `if let Some` + `if storages.wiped`, and used `&container` instead of `.iter()` in three loops.

Next commit to port: `2cede4935` — fix(network): allow proxied peers to receive NewBlock after fanout

🤖 Generated with [Claude Code](https://claude.com/claude-code)