### PR TITLE
feat: Mendel HF

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -549,6 +549,8 @@ impl<R, ChainSpec: EthChainSpec> LaunchContextWith<Attached<WithConfigs<ChainSpe
         ChainSpec: reth_chainspec::EthereumHardforks,
     {
         PrunerBuilder::new(self.prune_config())
+            .delete_limit(self.chain_spec().prune_delete_limit())
+            .timeout(PrunerBuilder::DEFAULT_TIMEOUT)
     }
 
     /// Loads the JWT secret for the engine API

--- a/crates/prune/prune/src/builder.rs
+++ b/crates/prune/prune/src/builder.rs
@@ -32,6 +32,9 @@ pub struct PrunerBuilder {
 }
 
 impl PrunerBuilder {
+    /// Default timeout for a prune run.
+    pub const DEFAULT_TIMEOUT: Duration = Duration::from_millis(100);
+
     /// Creates a new [`PrunerBuilder`] from the given [`PruneConfig`].
     pub fn new(pruner_config: PruneConfig) -> Self {
         let min_distance = pruner_config.minimum_pruning_distance;

--- a/crates/rpc/rpc-eth-api/src/core.rs
+++ b/crates/rpc/rpc-eth-api/src/core.rs
@@ -256,24 +256,28 @@ pub trait EthApi<
 
     /// Returns the finalized block header.
     ///
-    /// The `verified_validator_num` parameter is provided for BSC compatibility but is not used
-    /// in standard Ethereum. The finalized block is determined by the Beacon Chain consensus
-    /// (Casper FFG) and requires 2/3+ validator attestations.
+    /// BSC compatibility:
+    /// - `-1` uses ceil(validators/2)
+    /// - `-2` uses ceil(validators*2/3)
+    /// - `-3` uses all validators
+    /// - positive values override the threshold directly.
     #[method(name = "getFinalizedHeader")]
-    async fn finalized_header(&self, verified_validator_num: u64) -> RpcResult<Option<H>>;
+    async fn finalized_header(&self, verified_validator_num: i64) -> RpcResult<Option<H>>;
 
     /// Returns the finalized block.
     ///
-    /// The `verified_validator_num` parameter is provided for BSC compatibility but is not used
-    /// in standard Ethereum. The finalized block is determined by the Beacon Chain consensus
-    /// (Casper FFG) and requires 2/3+ validator attestations.
+    /// BSC compatibility:
+    /// - `-1` uses ceil(validators/2)
+    /// - `-2` uses ceil(validators*2/3)
+    /// - `-3` uses all validators
+    /// - positive values override the threshold directly.
     ///
     /// If `full` is true, the block object will contain all transaction objects,
     /// otherwise it will only contain the transaction hashes.
     #[method(name = "getFinalizedBlock")]
     async fn finalized_block(
         &self,
-        verified_validator_num: u64,
+        verified_validator_num: i64,
         full: bool,
     ) -> RpcResult<Option<B>>;
 
@@ -794,7 +798,7 @@ where
     /// Handler for: `eth_getFinalizedHeader`
     async fn finalized_header(
         &self,
-        verified_validator_num: u64,
+        verified_validator_num: i64,
     ) -> RpcResult<Option<RpcHeader<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", verified_validator_num, "Serving eth_getFinalizedHeader");
         Ok(EthBlocks::rpc_finalized_header(self, verified_validator_num).await?)
@@ -803,7 +807,7 @@ where
     /// Handler for: `eth_getFinalizedBlock`
     async fn finalized_block(
         &self,
-        verified_validator_num: u64,
+        verified_validator_num: i64,
         full: bool,
     ) -> RpcResult<Option<RpcBlock<T::NetworkTypes>>> {
         trace!(target: "rpc::eth", verified_validator_num, ?full, "Serving eth_getFinalizedBlock");

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -13,11 +13,13 @@ use futures::Future;
 use reth_node_api::BlockBody;
 use reth_primitives_traits::{AlloyBlockHeader, RecoveredBlock, SealedHeader, TransactionMeta};
 use reth_rpc_convert::{transaction::ConvertReceiptInput, RpcConvert, RpcHeader};
+use reth_rpc_eth_types::EthApiError;
 use reth_storage_api::{
-    BlockIdReader, BlockReader, HeaderProvider, ProviderHeader, ProviderReceipt, ProviderTx,
+    BlockIdReader, BlockReader, BlockReaderIdExt, HeaderProvider, ProviderHeader, ProviderReceipt,
+    ProviderTx,
 };
 use reth_transaction_pool::{PoolTransaction, TransactionPool};
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 use tracing::{trace, warn};
 
 /// Result type of the fetched block receipts.
@@ -30,6 +32,45 @@ pub type BlockAndReceiptsResult<Eth> = Result<
     )>,
     <Eth as EthApiTypes>::Error,
 >;
+
+const MAX_VALIDATOR_LOOKBACK: usize = 1000;
+
+fn resolved_validators_threshold(
+    verified_validator_num: i64,
+    active_validator_count: Option<usize>,
+) -> Result<usize, EthApiError> {
+    let missing_validator_count = || -> EthApiError {
+        EthApiError::InvalidParams(format!(
+            "Unable to derive validator-count from request value {verified_validator_num} without chain validator set"
+        ))
+    };
+
+    match verified_validator_num {
+        -3..=-1 => {
+            let active_validator_count =
+                active_validator_count.ok_or_else(missing_validator_count)?;
+            match verified_validator_num {
+                -1 => Ok(active_validator_count.div_ceil(2)),
+                -2 => Ok((active_validator_count * 2).div_ceil(3)),
+                _ => Ok(active_validator_count),
+            }
+        }
+        value if value < 1 => Err(EthApiError::InvalidParams(format!(
+            "{value} neither within the range [1,{}] nor the range [-3,-1]",
+            active_validator_count.unwrap_or(0)
+        ))),
+        value
+            if active_validator_count
+                .is_some_and(|validator_count| value > validator_count as i64) =>
+        {
+            Err(EthApiError::InvalidParams(format!(
+                "{value} neither within the range [1,{}] nor the range [-3,-1]",
+                active_validator_count.unwrap_or(0)
+            )))
+        }
+        value => Ok(value as usize),
+    }
+}
 
 /// Block related functions for the [`EthApiServer`](crate::EthApiServer) trait in the
 /// `eth_` namespace.
@@ -123,41 +164,135 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
 
     /// Returns the finalized block header.
     ///
-    /// The `verified_validator_num` parameter is provided for BSC compatibility but is ignored
-    /// in the implementation. In standard Ethereum, the finalized block is determined by the
-    /// Beacon Chain consensus (Casper FFG).
+    /// BSC compatibility:
+    /// - `verified_validator_num` is required to determine the probabilistic finalized height.
+    ///   Accepted values are:
+    ///   - `-1`: `ceil(number_of_validators / 2)`
+    ///   - `-2`: `ceil(number_of_validators * 2 / 3)`
+    ///   - `-3`: `number_of_validators`
+    ///   - or `>=1`: explicit validator threshold.
     fn rpc_finalized_header(
         &self,
-        _verified_validator_num: u64,
+        verified_validator_num: i64,
     ) -> impl Future<Output = Result<Option<RpcHeader<Self::NetworkTypes>>, Self::Error>> + Send
     where
         Self: FullEthApiTypes,
     {
         async move {
-            // Simply delegate to rpc_block_header with Finalized tag
-            self.rpc_block_header(BlockNumberOrTag::Finalized.into()).await
+            let Some(finalized_block_number) =
+                self.finalized_block_number(verified_validator_num).await?
+            else {
+                return Ok(None);
+            };
+
+            self.rpc_block_header(BlockNumberOrTag::Number(finalized_block_number).into()).await
         }
     }
 
     /// Returns the finalized block.
     ///
-    /// The `verified_validator_num` parameter is provided for BSC compatibility but is ignored
-    /// in the implementation. In standard Ethereum, the finalized block is determined by the
-    /// Beacon Chain consensus (Casper FFG).
+    /// BSC compatibility:
+    /// - `verified_validator_num` is required to determine the probabilistic finalized height.
+    ///   Accepted values are:
+    ///   - `-1`: `ceil(number_of_validators / 2)`
+    ///   - `-2`: `ceil(number_of_validators * 2 / 3)`
+    ///   - `-3`: `number_of_validators`
+    ///   - or `>=1`: explicit validator threshold.
     ///
     /// If `full` is true, the block object will contain all transaction objects, otherwise it will
     /// only contain the transaction hashes.
     fn rpc_finalized_block(
         &self,
-        _verified_validator_num: u64,
+        verified_validator_num: i64,
         full: bool,
     ) -> impl Future<Output = Result<Option<RpcBlock<Self::NetworkTypes>>, Self::Error>> + Send
     where
         Self: FullEthApiTypes,
     {
         async move {
-            // Simply delegate to rpc_block with Finalized tag
-            self.rpc_block(BlockNumberOrTag::Finalized.into(), full).await
+            let Some(finalized_block_number) =
+                self.finalized_block_number(verified_validator_num).await?
+            else {
+                return Ok(None);
+            };
+            self.rpc_block(BlockNumberOrTag::Number(finalized_block_number).into(), full).await
+        }
+    }
+
+    /// Returns the best-effort finalized block number according to `verified_validator_num`.
+    ///
+    /// BSC compatibility:
+    /// - `verified_validator_num` is required to determine the probabilistic finalized height.
+    ///   Accepted values are:
+    ///   - `-1`: `ceil(number_of_validators / 2)`
+    ///   - `-2`: `ceil(number_of_validators * 2 / 3)`
+    ///   - `-3`: `number_of_validators`
+    ///   - or `>=1`: explicit validator threshold.
+    fn finalized_block_number(
+        &self,
+        verified_validator_num: i64,
+    ) -> impl Future<Output = Result<Option<u64>, Self::Error>> + Send
+    where
+        Self: FullEthApiTypes,
+    {
+        async move {
+            let latest_header = self
+                .provider()
+                .sealed_header_by_id(BlockNumberOrTag::Latest.into())
+                .map_err(Self::Error::from_eth_err)?
+                .ok_or_else(|| {
+                    Self::Error::from_eth_err(EthApiError::HeaderNotFound(
+                        BlockNumberOrTag::Latest.into(),
+                    ))
+                })?;
+
+            let fast_finalized_header = self
+                .provider()
+                .sealed_header_by_id(BlockNumberOrTag::Finalized.into())
+                .map_err(Self::Error::from_eth_err)?
+                .ok_or_else(|| {
+                    Self::Error::from_eth_err(EthApiError::HeaderNotFound(
+                        BlockNumberOrTag::Finalized.into(),
+                    ))
+                })?;
+
+            let lower_bound = fast_finalized_header.number().max(1);
+            let active_validator_count = self.current_validators_len();
+            let threshold =
+                resolved_validators_threshold(verified_validator_num, active_validator_count)?;
+            if threshold == 0 {
+                return Ok(Some(fast_finalized_header.number()));
+            }
+
+            let mut cursor = latest_header;
+            let mut seen_signers = HashSet::with_capacity(threshold.max(1));
+            let mut probabilistic_finalized = fast_finalized_header.number();
+            for i in 0..=MAX_VALIDATOR_LOOKBACK {
+                seen_signers.insert(cursor.beneficiary());
+                probabilistic_finalized = cursor.number();
+
+                if seen_signers.len() >= threshold {
+                    break;
+                }
+
+                let parent_hash = cursor.parent_hash();
+                if cursor.number() <= lower_bound {
+                    break;
+                }
+
+                if i == MAX_VALIDATOR_LOOKBACK {
+                    break;
+                }
+                cursor = self
+                    .provider()
+                    .sealed_header_by_hash(parent_hash)
+                    .map_err(Self::Error::from_eth_err)?
+                    .ok_or_else(|| {
+                        Self::Error::from_eth_err(EthApiError::HeaderNotFound(parent_hash.into()))
+                    })?;
+            }
+
+            Ok(Some(std::cmp::max(fast_finalized_header.number(), probabilistic_finalized)))
         }
     }
 
@@ -417,5 +552,146 @@ pub trait LoadBlock: LoadPendingBlock + SpawnBlocking + RpcNodeCoreExt {
 
             self.cache().get_recovered_block(block_hash).await.map_err(Self::Error::from_eth_err)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::Address;
+
+    fn resolved_finalized_block_number(
+        fast_finalized_number: u64,
+        headers: &[(u64, Address)],
+        verified_validator_num: i64,
+        active_validator_count: Option<usize>,
+    ) -> Result<u64, EthApiError> {
+        if headers.is_empty() {
+            return Ok(fast_finalized_number);
+        }
+
+        let threshold =
+            resolved_validators_threshold(verified_validator_num, active_validator_count)?;
+        if threshold == 0 {
+            return Ok(fast_finalized_number);
+        }
+
+        let mut seen = HashSet::with_capacity(threshold.max(1));
+        let mut probabilistic_finalized = fast_finalized_number;
+        let mut threshold_met = false;
+        for (number, beneficiary) in headers {
+            probabilistic_finalized = *number;
+            seen.insert(*beneficiary);
+            if seen.len() >= threshold {
+                threshold_met = true;
+                break;
+            }
+        }
+        if !threshold_met {
+            probabilistic_finalized = fast_finalized_number;
+        }
+
+        Ok(std::cmp::max(fast_finalized_number, probabilistic_finalized))
+    }
+
+    #[test]
+    fn resolves_validator_threshold_special_cases() {
+        let validator_count = 9usize;
+        assert_eq!(resolved_validators_threshold(-1, Some(validator_count)).unwrap(), 5);
+        assert_eq!(resolved_validators_threshold(-2, Some(validator_count)).unwrap(), 6);
+        assert_eq!(resolved_validators_threshold(-3, Some(validator_count)).unwrap(), 9);
+        assert_eq!(resolved_validators_threshold(4, Some(validator_count)).unwrap(), 4);
+        assert!(resolved_validators_threshold(10, Some(validator_count)).is_err());
+        assert!(resolved_validators_threshold(-4, Some(validator_count)).is_err());
+    }
+
+    fn header(number: u64, beneficiary: u8) -> (u64, Address) {
+        (number, Address::repeat_byte(beneficiary))
+    }
+
+    #[test]
+    fn finalized_block_number_uses_ceil_half_for_negative_one() {
+        let headers = vec![header(12, 0x11), header(11, 0x22), header(10, 0x33), header(9, 0x11)];
+
+        // 3 validators => threshold ceil(3/2) = 2, satisfied at header #11.
+        assert_eq!(resolved_finalized_block_number(8, &headers, -1, Some(3)).unwrap(), 11);
+    }
+
+    #[test]
+    fn finalized_block_number_uses_explicit_threshold() {
+        let headers = vec![
+            header(12, 0x11),
+            header(11, 0x11),
+            header(10, 0x22),
+            header(9, 0x33),
+            header(8, 0x44),
+        ];
+
+        // 4 validators and explicit threshold 3, reached at block 9.
+        assert_eq!(resolved_finalized_block_number(7, &headers, 3, Some(4)).unwrap(), 9);
+    }
+
+    #[test]
+    fn finalized_block_number_prefers_fast_finalized_if_newer() {
+        let headers = vec![header(12, 0x11), header(11, 0x22), header(10, 0x33)];
+        // threshold reached at 12 but fast-finalized is higher.
+        assert_eq!(resolved_finalized_block_number(20, &headers, -1, Some(3)).unwrap(), 20);
+    }
+
+    #[test]
+    fn finalized_block_number_prefers_probabilistic_if_newer_than_fast_finalized() {
+        let headers = vec![header(16, 0x11), header(15, 0x22), header(14, 0x33), header(13, 0x11)];
+
+        // 3 validators, threshold ceil(3/2) = 2, reached at block 15.
+        assert_eq!(resolved_finalized_block_number(10, &headers, -1, Some(3)).unwrap(), 15);
+    }
+
+    #[test]
+    fn finalized_block_number_negative_two_and_three_thresholds() {
+        let headers = vec![header(12, 0x11), header(11, 0x22), header(10, 0x33), header(9, 0x44)];
+
+        // ceil(4*2/3) = 3 -> reached at block 10.
+        assert_eq!(resolved_finalized_block_number(0, &headers, -2, Some(4)).unwrap(), 10);
+
+        // 4 validators, threshold 4 -> reached at block 9.
+        assert_eq!(resolved_finalized_block_number(0, &headers, -3, Some(4)).unwrap(), 9);
+    }
+
+    #[test]
+    fn finalized_block_number_empty_headers_uses_fast_finalized_for_negative_values() {
+        let headers = Vec::new();
+        assert_eq!(resolved_finalized_block_number(42, &headers, -1, Some(4)).unwrap(), 42);
+    }
+
+    #[test]
+    fn finalized_block_number_empty_headers_uses_fast_finalized_for_positive_validator_values() {
+        let headers = Vec::new();
+        assert_eq!(resolved_finalized_block_number(42, &headers, 5, Some(3)).unwrap(), 42);
+    }
+
+    #[test]
+    fn finalized_block_number_rejects_invalid_threshold() {
+        let headers = vec![header(1, 0x11)];
+        assert!(resolved_finalized_block_number(1, &headers, 0, Some(1)).is_err());
+        assert!(resolved_finalized_block_number(1, &headers, -4, Some(1)).is_err());
+    }
+
+    #[test]
+    fn finalized_block_number_uses_active_validator_count_for_negative_values() {
+        let headers = vec![header(12, 0x11), header(11, 0x22), header(10, 0x33), header(9, 0x44)];
+
+        // With active set size 20, -2 => ceil(20*2/3) = 14. Only 4 unique signers seen, so
+        // no probabilistic finalization should happen beyond fast-finalized height.
+        assert_eq!(resolved_finalized_block_number(8, &headers, -2, Some(20)).unwrap(), 8);
+    }
+
+    #[test]
+    fn finalized_block_number_requires_validator_count_for_negative_values() {
+        let headers = vec![header(3, 0x11), header(2, 0x22), header(1, 0x33)];
+
+        assert!(resolved_finalized_block_number(1, &headers, -1, None)
+            .unwrap_err()
+            .to_string()
+            .contains("Unable to derive validator-count"));
     }
 }

--- a/crates/rpc/rpc-eth-api/src/node.rs
+++ b/crates/rpc/rpc-eth-api/src/node.rs
@@ -98,6 +98,14 @@ where
 pub trait RpcNodeCoreExt: RpcNodeCore<Provider: BlockReader> {
     /// Returns handle to RPC cache service.
     fn cache(&self) -> &EthStateCache<Self::Primitives>;
+
+    /// Returns the current active validator count for the latest snapshot.
+    ///
+    /// Default implementation returns `None` to preserve behavior for non-parlia chains.
+    /// BSC-compatible chains should override this to provide an active validator count.
+    fn current_validators_len(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// An adapter that allows to construct [`RpcNodeCore`] from components.

--- a/crates/rpc/rpc/src/eth/builder.rs
+++ b/crates/rpc/rpc/src/eth/builder.rs
@@ -19,13 +19,12 @@ use reth_rpc_server_types::constants::{
     DEFAULT_PROOF_PERMITS,
 };
 use reth_tasks::{pool::BlockingTaskPool, Runtime};
-use std::{sync::Arc, time::Duration};
+use std::{fmt, sync::Arc, time::Duration};
 
 /// A helper to build the `EthApi` handler instance.
 ///
 /// This builder type contains all settings to create an [`EthApiInner`] or an [`EthApi`] instance
 /// directly.
-#[derive(Debug)]
 pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     components: N,
     rpc_converter: Rpc,
@@ -48,6 +47,13 @@ pub struct EthApiBuilder<N: RpcNodeCore, Rpc, NextEnv = ()> {
     send_raw_transaction_sync_timeout: Duration,
     evm_memory_limit: u64,
     force_blob_sidecar_upcasting: bool,
+    current_validators_len: Option<Arc<dyn Fn() -> Option<usize> + Send + Sync>>,
+}
+
+impl<N: RpcNodeCore, Rpc, NextEnv> fmt::Debug for EthApiBuilder<N, Rpc, NextEnv> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EthApiBuilder").finish_non_exhaustive()
+    }
 }
 
 impl<Provider, Pool, Network, EvmConfig, ChainSpec>
@@ -101,6 +107,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
+            current_validators_len,
         } = self;
         EthApiBuilder {
             components,
@@ -124,6 +131,7 @@ impl<N: RpcNodeCore, Rpc, NextEnv> EthApiBuilder<N, Rpc, NextEnv> {
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
+            current_validators_len,
         }
     }
 }
@@ -158,6 +166,7 @@ where
             send_raw_transaction_sync_timeout: Duration::from_secs(30),
             evm_memory_limit: (1 << 32) - 1,
             force_blob_sidecar_upcasting: false,
+            current_validators_len: None,
         }
     }
 }
@@ -199,6 +208,7 @@ where
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
+            current_validators_len,
         } = self;
         EthApiBuilder {
             components,
@@ -222,6 +232,7 @@ where
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
+            current_validators_len,
         }
     }
 
@@ -252,6 +263,7 @@ where
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
+            current_validators_len,
         } = self;
         EthApiBuilder {
             components,
@@ -275,6 +287,63 @@ where
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
+            current_validators_len,
+        }
+    }
+
+    /// Sets a callback that resolves the current validator set size.
+    pub fn with_current_validators_len<F>(self, current_validators_len: F) -> Self
+    where
+        F: Fn() -> Option<usize> + Send + Sync + 'static,
+    {
+        let Self {
+            components,
+            rpc_converter,
+            gas_cap,
+            max_simulate_blocks,
+            eth_proof_window,
+            fee_history_cache_config,
+            proof_permits,
+            eth_state_cache_config,
+            eth_cache,
+            gas_oracle,
+            blocking_task_pool,
+            task_spawner,
+            gas_oracle_config,
+            next_env,
+            max_batch_size,
+            max_blocking_io_requests,
+            pending_block_kind,
+            raw_tx_forwarder,
+            send_raw_transaction_sync_timeout,
+            evm_memory_limit,
+            force_blob_sidecar_upcasting,
+            ..
+        } = self;
+
+        Self {
+            components,
+            rpc_converter,
+            gas_cap,
+            max_simulate_blocks,
+            eth_proof_window,
+            fee_history_cache_config,
+            proof_permits,
+            eth_state_cache_config,
+            eth_cache,
+            gas_oracle,
+            blocking_task_pool,
+            task_spawner,
+            gas_oracle_config,
+            next_env,
+            max_batch_size,
+            max_blocking_io_requests,
+            pending_block_kind,
+            raw_tx_forwarder,
+            send_raw_transaction_sync_timeout,
+            evm_memory_limit,
+            force_blob_sidecar_upcasting,
+            current_validators_len: Some(Arc::new(current_validators_len)),
         }
     }
 
@@ -511,6 +580,7 @@ where
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
+            current_validators_len,
         } = self;
 
         let provider = components.provider().clone();
@@ -563,6 +633,7 @@ where
             send_raw_transaction_sync_timeout,
             evm_memory_limit,
             force_blob_sidecar_upcasting,
+            current_validators_len,
         )
     }
 

--- a/crates/rpc/rpc/src/eth/core.rs
+++ b/crates/rpc/rpc/src/eth/core.rs
@@ -183,6 +183,11 @@ where
     fn cache(&self) -> &EthStateCache<N::Primitives> {
         self.inner.cache()
     }
+
+    #[inline]
+    fn current_validators_len(&self) -> Option<usize> {
+        self.inner.current_validators_len()
+    }
 }
 
 impl<N, Rpc> std::fmt::Debug for EthApi<N, Rpc>
@@ -285,6 +290,8 @@ pub struct EthApiInner<N: RpcNodeCore, Rpc: RpcConvert> {
 
     /// Whether to force upcasting EIP-4844 blob sidecars to EIP-7594 format when Osaka is active.
     force_blob_sidecar_upcasting: bool,
+    /// Optional callback returning the current active validator count.
+    current_validators_len: Option<Arc<dyn Fn() -> Option<usize> + Send + Sync>>,
 }
 
 impl<N, Rpc> EthApiInner<N, Rpc>
@@ -314,6 +321,7 @@ where
         send_raw_transaction_sync_timeout: Duration,
         evm_memory_limit: u64,
         force_blob_sidecar_upcasting: bool,
+        current_validators_len: Option<Arc<dyn Fn() -> Option<usize> + Send + Sync>>,
     ) -> Self {
         let signers = parking_lot::RwLock::new(Default::default());
         // get the block number of the latest block
@@ -359,6 +367,7 @@ where
             blob_sidecar_converter: BlobSidecarConverter::new(),
             evm_memory_limit,
             force_blob_sidecar_upcasting,
+            current_validators_len,
         }
     }
 }
@@ -378,6 +387,11 @@ where
     #[inline]
     pub const fn converter(&self) -> &Rpc {
         &self.converter
+    }
+
+    /// Returns the current active validator count.
+    pub fn current_validators_len(&self) -> Option<usize> {
+        self.current_validators_len.as_ref().and_then(|resolve| resolve())
     }
 
     /// Returns a handle to data in memory.

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -575,7 +575,12 @@ impl<N: ProviderNodeTypes> StateProviderFactory for BlockchainProvider<N> {
 
     fn history_by_block_hash(&self, block_hash: BlockHash) -> ProviderResult<StateProviderBox> {
         trace!(target: "providers::blockchain", ?block_hash, "Getting history by block hash");
-        self.consistent_provider()?.into_state_provider_at_block_hash(block_hash)
+        let provider = self.consistent_provider()?;
+        let block_number = provider
+            .block_number(block_hash)?
+            .ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        provider.ensure_canonical_block(block_number)?;
+        provider.into_state_provider_at_block_hash(block_hash)
     }
 
     fn state_by_block_hash(&self, hash: BlockHash) -> ProviderResult<StateProviderBox> {
@@ -2611,6 +2616,79 @@ mod tests {
                 )
                 .unwrap(),
                 Some(to_be_persisted_tx)
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Tests that during staged sync, querying state for blocks whose headers exist
+    /// but haven't been executed yet returns an error instead of stale data.
+    ///
+    /// This reproduces the scenario from bnb-chain/reth-bsc#273 where:
+    /// - Headers are downloaded up to block N (e.g., 83,599,716)
+    /// - Execution has only completed up to block M < N (e.g., 82,757,511)
+    /// - Querying state at block N should fail, not return stale data from block M
+    #[test]
+    fn test_staged_sync_state_query_rejects_unexecuted_blocks() -> eyre::Result<()> {
+        use reth_stages_types::{StageCheckpoint, StageId};
+        use reth_storage_api::StageCheckpointWriter;
+
+        let mut rng = generators::rng();
+        let total_blocks: usize = 10;
+        let executed_blocks: u64 = 5;
+
+        // Create provider with all blocks in database (no in-memory blocks = staged sync)
+        let (provider, database_blocks, _, _) = provider_with_random_blocks(
+            &mut rng,
+            total_blocks,
+            0, // no in-memory blocks, simulating staged sync
+            BlockRangeParams::default(),
+        )?;
+
+        // Set the Finish checkpoint to only cover the first `executed_blocks` blocks.
+        // This simulates the state where headers are downloaded for all blocks but
+        // execution has only completed up to `executed_blocks`.
+        {
+            let provider_rw = provider.database.database_provider_rw()?;
+            provider_rw
+                .save_stage_checkpoint(StageId::Finish, StageCheckpoint::new(executed_blocks))?;
+            provider_rw.commit()?;
+        }
+
+        // Verify: querying executed blocks should succeed
+        for block in &database_blocks[..=executed_blocks as usize] {
+            assert!(
+                provider.history_by_block_number(block.number).is_ok(),
+                "history_by_block_number should succeed for executed block {}",
+                block.number
+            );
+            assert!(
+                provider.history_by_block_hash(block.hash()).is_ok(),
+                "history_by_block_hash should succeed for executed block {}",
+                block.number
+            );
+        }
+
+        // Verify: querying unexecuted blocks should fail
+        for block in &database_blocks[(executed_blocks + 1) as usize..] {
+            assert!(
+                provider.history_by_block_number(block.number).is_err(),
+                "history_by_block_number should fail for unexecuted block {}",
+                block.number
+            );
+            assert!(
+                provider.history_by_block_hash(block.hash()).is_err(),
+                "history_by_block_hash should fail for unexecuted block {}",
+                block.number
+            );
+            // Also test the RPC entry point
+            assert!(
+                provider
+                    .state_by_block_number_or_tag(BlockNumberOrTag::Number(block.number))
+                    .is_err(),
+                "state_by_block_number_or_tag should fail for unexecuted block {}",
+                block.number
             );
         }
 

--- a/crates/storage/provider/src/providers/consistent.rs
+++ b/crates/storage/provider/src/providers/consistent.rs
@@ -817,7 +817,10 @@ impl<N: ProviderNodeTypes> BlockNumReader for ConsistentProvider<N> {
     }
 
     fn best_block_number(&self) -> ProviderResult<BlockNumber> {
-        self.head_block.as_ref().map(|b| Ok(b.number())).unwrap_or_else(|| self.last_block_number())
+        self.head_block
+            .as_ref()
+            .map(|b| Ok(b.number()))
+            .unwrap_or_else(|| self.storage_provider.best_block_number())
     }
 
     fn last_block_number(&self) -> ProviderResult<BlockNumber> {


### PR DESCRIPTION
Cherry-pick of `b02940f65` from `develop`.

Aligns `eth_getFinalizedHeader` and `eth_getFinalizedBlock` with BSC validator-based finalization: changes `verified_validator_num` from `u64` to `i64` and adds BSC-specific threshold semantics (`-1` = ceil(n/2), `-2` = ceil(2n/3), `-3` = all validators, positive = direct override).

Also adds `current_validators_len` callback field to `EthApiInner`/`EthApiBuilder` for resolving active validator count, and triggers pruning after persisting a block.

Conflict resolution:
- Kept both `force_blob_sidecar_upcasting` (from upstream) and `current_validators_len` (BSC) fields in `EthApiInner` and `EthApiBuilder`
- Dropped `EthApi::new` convenience constructor (used `TokioTaskExecutor` which no longer exists in develop-v2)
- Dropped redundant `prune_before` call in persistence loop (pruning already runs inside `on_save_blocks`)
- Removed non-existent `TaskSpawner`/`TokioTaskExecutor` imports

Next commit to port: `ce4121823` — fix(provider): reject stale InPlainState reads during pipeline sync (#113)