### PR TITLE
fix(provider): reject stale InPlainState reads during pipeline sync (#113)

### DIFF
--- a/crates/storage/errors/src/provider.rs
+++ b/crates/storage/errors/src/provider.rs
@@ -123,6 +123,18 @@ pub enum ProviderError {
         /// The earliest available block number.
         earliest_available: BlockNumber,
     },
+    /// Historical state at the requested block may be inconsistent because pipeline sync is in
+    /// progress. The Execution stage has advanced `PlainState` beyond the history index coverage,
+    /// so the `InPlainState` fallback would return data from a future block.
+    #[error("historical state at block #{block} is inconsistent during pipeline sync: execution tip is #{execution_tip} but history index only covers up to #{history_tip}")]
+    HistoryStateInconsistent {
+        /// The block number being queried.
+        block: BlockNumber,
+        /// Block number up to which the Execution stage has committed `PlainState`.
+        execution_tip: BlockNumber,
+        /// Block number up to which the history index has been built.
+        history_tip: BlockNumber,
+    },
     /// Provider does not support this particular request.
     #[error("this provider does not support this request")]
     UnsupportedProvider,

--- a/crates/storage/provider/src/lib.rs
+++ b/crates/storage/provider/src/lib.rs
@@ -23,9 +23,9 @@ pub use traits::*;
 pub mod providers;
 pub use providers::{
     DatabaseProvider, DatabaseProviderRO, DatabaseProviderRW, HistoricalStateProvider,
-    HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, ProviderFactory,
-    PruneShardOutcome, PrunedIndices, SaveBlocksMode, StaticFileAccess, StaticFileProviderBuilder,
-    StaticFileWriteCtx, StaticFileWriter,
+    HistoricalStateProviderRef, LatestStateProvider, LatestStateProviderRef, PipelineConsistency,
+    ProviderFactory, PruneShardOutcome, PrunedIndices, SaveBlocksMode, StaticFileAccess,
+    StaticFileProviderBuilder, StaticFileWriteCtx, StaticFileWriter,
 };
 
 pub mod changeset_walker;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -14,9 +14,9 @@ use crate::{
     BlockReader, BlockWriter, BundleStateInit, ChainStateBlockReader, ChainStateBlockWriter,
     DBProvider, EitherReader, EitherWriter, EitherWriterDestination, HashingWriter, HeaderProvider,
     HeaderSyncGapProvider, HistoricalStateProvider, HistoricalStateProviderRef, HistoryWriter,
-    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, ProviderError,
-    PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit, RocksBatchArg,
-    RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
+    LatestStateProvider, LatestStateProviderRef, OriginalValuesKnown, PipelineConsistency,
+    ProviderError, PruneCheckpointReader, PruneCheckpointWriter, RawRocksDBBatch, RevertsInit,
+    RocksBatchArg, RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StateWriter,
     StaticFileProviderFactory, StatsReader, StorageReader, StorageTrieWriter, TransactionVariant,
     TransactionsProvider, TransactionsProviderExt, TrieWriter,
 };
@@ -290,10 +290,29 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         Ok(())
     }
 
-    /// State provider for latest state
+    /// State provider for latest state.
+    ///
+    /// No [`PipelineConsistency`] guard is needed here: `LatestStateProviderRef` reads
+    /// `PlainState` directly and always returns the Execution-stage tip. The guard only
+    /// protects historical providers whose `InPlainState` fallback would silently serve
+    /// future-block data when the history index lags behind.
     pub fn latest<'a>(&'a self) -> Box<dyn StateProvider + 'a> {
         trace!(target: "providers::db", "Returning latest state provider");
         Box::new(LatestStateProviderRef::new(self))
+    }
+
+    /// Reads pipeline stage checkpoints and builds [`PipelineConsistency`] info.
+    ///
+    /// During pipeline sync the Execution stage commits `PlainState` before the history index
+    /// stages run. This helper detects that gap so [`HistoricalStateProviderRef`] can reject
+    /// `InPlainState` reads that would return data from a future block.
+    fn build_pipeline_consistency(&self) -> ProviderResult<PipelineConsistency> {
+        let execution_tip = self.get_stage_checkpoint(StageId::Execution)?.map(|c| c.block_number);
+        let account_history_tip =
+            self.get_stage_checkpoint(StageId::IndexAccountHistory)?.map(|c| c.block_number);
+        let storage_history_tip =
+            self.get_stage_checkpoint(StageId::IndexStorageHistory)?.map(|c| c.block_number);
+        Ok(PipelineConsistency { execution_tip, account_history_tip, storage_history_tip })
     }
 
     /// Storage provider for state at that given block hash
@@ -303,8 +322,11 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     ) -> ProviderResult<Box<dyn StateProvider + 'a>> {
         let mut block_number =
             self.block_number(block_hash)?.ok_or(ProviderError::BlockHashNotFound(block_hash))?;
+        let pipeline_consistency = self.build_pipeline_consistency()?;
         if block_number == self.best_block_number().unwrap_or_default() &&
-            block_number == self.last_block_number().unwrap_or_default()
+            block_number == self.last_block_number().unwrap_or_default() &&
+            pipeline_consistency.account_inconsistency().is_none() &&
+            pipeline_consistency.storage_inconsistency().is_none()
         {
             return Ok(Box::new(LatestStateProviderRef::new(self)))
         }
@@ -317,7 +339,8 @@ impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
         let storage_history_prune_checkpoint =
             self.get_prune_checkpoint(PruneSegment::StorageHistory)?;
 
-        let mut state_provider = HistoricalStateProviderRef::new(self, block_number);
+        let mut state_provider = HistoricalStateProviderRef::new(self, block_number)
+            .with_pipeline_consistency(pipeline_consistency);
 
         // If we pruned account or storage history, we can't return state on every historical block.
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune segment.
@@ -995,9 +1018,15 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
             });
         }
 
-        // If requesting state at the best block, use the latest state provider
-        if block_number == best_block {
-            return Ok(Box::new(LatestStateProvider::new(self)));
+        // Only use the LatestStateProvider fast path when there is no pipeline gap.
+        // During pipeline sync the Execution stage may have advanced PlainState beyond the
+        // Finish checkpoint, so LatestStateProvider would return data from a future block.
+        let pipeline_consistency = self.build_pipeline_consistency()?;
+        if block_number == best_block &&
+            pipeline_consistency.account_inconsistency().is_none() &&
+            pipeline_consistency.storage_inconsistency().is_none()
+        {
+            return Ok(Box::new(LatestStateProvider::new(self)))
         }
 
         // +1 as the changeset that we want is the one that was applied after this block.
@@ -1008,7 +1037,8 @@ impl<TX: DbTx + 'static, N: NodeTypes> TryIntoHistoricalStateProvider for Databa
         let storage_history_prune_checkpoint =
             self.get_prune_checkpoint(PruneSegment::StorageHistory)?;
 
-        let mut state_provider = HistoricalStateProvider::new(self, block_number);
+        let mut state_provider = HistoricalStateProvider::new(self, block_number)
+            .with_pipeline_consistency(pipeline_consistency);
 
         // If we pruned account or storage history, we can't return state on every historical block.
         // Instead, we should cap it at the latest prune checkpoint for corresponding prune segment.

--- a/crates/storage/provider/src/providers/mod.rs
+++ b/crates/storage/provider/src/providers/mod.rs
@@ -17,7 +17,7 @@ mod state;
 pub use state::{
     historical::{
         compute_history_rank, history_info, needs_prev_shard_check, HistoricalStateProvider,
-        HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks,
+        HistoricalStateProviderRef, HistoryInfo, LowestAvailableBlocks, PipelineConsistency,
     },
     latest::{LatestStateProvider, LatestStateProviderRef},
     overlay::{OverlayStateProvider, OverlayStateProviderFactory},

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -127,6 +127,10 @@ pub struct HistoricalStateProviderRef<'b, Provider> {
     block_number: BlockNumber,
     /// Lowest blocks at which different parts of the state are available.
     lowest_available_blocks: LowestAvailableBlocks,
+    /// Cached pipeline consistency info. When the Execution stage checkpoint is ahead of the
+    /// history index checkpoint, `PlainState` has been advanced beyond history coverage and the
+    /// `InPlainState` fallback would return data from a future block.
+    pipeline_consistency: PipelineConsistency,
 }
 
 impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + BlockNumReader>
@@ -134,7 +138,12 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
 {
     /// Create new `StateProvider` for historical block number
     pub fn new(provider: &'b Provider, block_number: BlockNumber) -> Self {
-        Self { provider, block_number, lowest_available_blocks: Default::default() }
+        Self {
+            provider,
+            block_number,
+            lowest_available_blocks: Default::default(),
+            pipeline_consistency: Default::default(),
+        }
     }
 
     /// Create new `StateProvider` for historical block number and lowest block numbers at which
@@ -144,7 +153,26 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
         block_number: BlockNumber,
         lowest_available_blocks: LowestAvailableBlocks,
     ) -> Self {
-        Self { provider, block_number, lowest_available_blocks }
+        Self {
+            provider,
+            block_number,
+            lowest_available_blocks,
+            pipeline_consistency: PipelineConsistency {
+                execution_tip: None,
+                account_history_tip: None,
+                storage_history_tip: None,
+            },
+        }
+    }
+
+    /// Set the pipeline consistency info for detecting stale `InPlainState` reads during
+    /// pipeline sync.
+    pub const fn with_pipeline_consistency(
+        mut self,
+        pipeline_consistency: PipelineConsistency,
+    ) -> Self {
+        self.pipeline_consistency = pipeline_consistency;
+        self
     }
 
     /// Lookup an account in the `AccountsHistory` table using `EitherReader`.
@@ -223,6 +251,15 @@ impl<'b, Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + Block
                 .map(|entry| entry.value)
                 .map(Some),
             HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
+                if let Some((exec_tip, hist_tip)) =
+                    self.pipeline_consistency.storage_inconsistency()
+                {
+                    return Err(ProviderError::HistoryStateInconsistent {
+                        block: self.block_number,
+                        execution_tip: exec_tip,
+                        history_tip: hist_tip,
+                    })
+                }
                 if self.provider.cached_storage_settings().use_hashed_state() {
                     let hashed_address = alloy_primitives::keccak256(address);
                     let hashed_slot = alloy_primitives::keccak256(lookup_key);
@@ -345,6 +382,15 @@ impl<
                     .map(|account_before| account_before.info)
             }
             HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
+                if let Some((exec_tip, hist_tip)) =
+                    self.pipeline_consistency.account_inconsistency()
+                {
+                    return Err(ProviderError::HistoryStateInconsistent {
+                        block: self.block_number,
+                        execution_tip: exec_tip,
+                        history_tip: hist_tip,
+                    })
+                }
                 if self.provider.cached_storage_settings().use_hashed_state() {
                     let hashed_address = alloy_primitives::keccak256(address);
                     Ok(self.tx().get_by_encoded_key::<tables::HashedAccounts>(&hashed_address)?)
@@ -595,6 +641,8 @@ pub struct HistoricalStateProvider<Provider> {
     block_number: BlockNumber,
     /// Lowest blocks at which different parts of the state are available.
     lowest_available_blocks: LowestAvailableBlocks,
+    /// Cached pipeline consistency info.
+    pipeline_consistency: PipelineConsistency,
 }
 
 impl<Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + BlockNumReader>
@@ -602,7 +650,12 @@ impl<Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + BlockNumR
 {
     /// Create new `StateProvider` for historical block number
     pub fn new(provider: Provider, block_number: BlockNumber) -> Self {
-        Self { provider, block_number, lowest_available_blocks: Default::default() }
+        Self {
+            provider,
+            block_number,
+            lowest_available_blocks: Default::default(),
+            pipeline_consistency: Default::default(),
+        }
     }
 
     /// Set the lowest block number at which the account history is available.
@@ -623,6 +676,16 @@ impl<Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + BlockNumR
         self
     }
 
+    /// Set the pipeline consistency info for detecting stale `InPlainState` reads during
+    /// pipeline sync.
+    pub const fn with_pipeline_consistency(
+        mut self,
+        pipeline_consistency: PipelineConsistency,
+    ) -> Self {
+        self.pipeline_consistency = pipeline_consistency;
+        self
+    }
+
     /// Returns a new provider that takes the `TX` as reference
     #[inline(always)]
     const fn as_ref(&self) -> HistoricalStateProviderRef<'_, Provider> {
@@ -631,11 +694,57 @@ impl<Provider: DBProvider + ChangeSetReader + StorageChangeSetReader + BlockNumR
             self.block_number,
             self.lowest_available_blocks,
         )
+        .with_pipeline_consistency(self.pipeline_consistency)
     }
 }
 
 // Delegates all provider impls to [HistoricalStateProviderRef]
 reth_storage_api::macros::delegate_provider_impls!(HistoricalStateProvider<Provider> where [Provider: DBProvider + BlockNumReader + BlockHashReader + ChangeSetReader + StorageChangeSetReader + StorageSettingsCache + RocksDBProviderFactory + NodePrimitivesProvider]);
+
+/// Cached pipeline stage checkpoint info used to detect inconsistent `InPlainState` reads.
+///
+/// During pipeline sync, the `ExecutionStage` commits `PlainAccountState` / `PlainStorageState`
+/// in its own MDBX write transaction **before** the `IndexAccountHistoryStage` and
+/// `IndexStorageHistoryStage` commit the corresponding history indices. This creates a window
+/// where `HistoricalStateProvider` would incorrectly fall back to `InPlainState` and return
+/// data from a future block.
+///
+/// When the Execution checkpoint is ahead of the history index checkpoint, we know `PlainState`
+/// has been silently advanced and the `InPlainState` path must not be used.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PipelineConsistency {
+    /// Block number up to which the Execution stage has committed `PlainState`.
+    pub execution_tip: Option<BlockNumber>,
+    /// Block number up to which the account history index has been built.
+    pub account_history_tip: Option<BlockNumber>,
+    /// Block number up to which the storage history index has been built.
+    pub storage_history_tip: Option<BlockNumber>,
+}
+
+impl PipelineConsistency {
+    /// Returns `Some((exec_tip, hist_tip))` if account history is inconsistent with `PlainState`,
+    /// meaning the `InPlainState` fallback would return wrong data.
+    ///
+    /// A `None` history tip means the index stage has never run, which is equivalent to block 0.
+    pub const fn account_inconsistency(&self) -> Option<(BlockNumber, BlockNumber)> {
+        match (self.execution_tip, self.account_history_tip) {
+            (Some(exec), Some(hist)) if exec > hist => Some((exec, hist)),
+            (Some(exec), None) => Some((exec, 0)),
+            _ => None,
+        }
+    }
+
+    /// Returns `Some((exec_tip, hist_tip))` if storage history is inconsistent with `PlainState`.
+    ///
+    /// A `None` history tip means the index stage has never run, which is equivalent to block 0.
+    pub const fn storage_inconsistency(&self) -> Option<(BlockNumber, BlockNumber)> {
+        match (self.execution_tip, self.storage_history_tip) {
+            (Some(exec), Some(hist)) if exec > hist => Some((exec, hist)),
+            (Some(exec), None) => Some((exec, 0)),
+            _ => None,
+        }
+    }
+}
 
 /// Lowest blocks at which different parts of the state are available.
 /// They may be [Some] if pruning is enabled.


### PR DESCRIPTION
Cherry-pick of bnb-chain/reth@ce41218 onto develop-v2.

During pipeline sync, the Execution stage commits `PlainState` before `IndexAccountHistory`/`IndexStorageHistory` run. This adds a `PipelineConsistency` guard that detects the inconsistent window and returns `HistoryStateInconsistent` error when the `InPlainState` fallback would serve data from a future block.

Conflict resolution: kept HEAD's `BlockNotExecuted`/`BlockExpired` error variants alongside the new `HistoryStateInconsistent`, preserved BSC's hashed-state path and `storage_by_lookup_key` helper, and kept `commit_unwind()` from develop-v2.