### PR TITLE
feat: cherry-pick fastnode support (#12) onto develop-v2

### DIFF
--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -546,6 +546,10 @@ pub struct BlockValidationMetrics {
     pub anchored_overlay_trie_updates_size: Histogram,
     /// Size of `AnchoredTrieInput` overlay `HashedPostStateSorted` (`total_len`)
     pub anchored_overlay_hashed_state_size: Histogram,
+    /// Total number of times the triedb validation path was entered.
+    pub triedb_validate_entry_total: Counter,
+    /// Histogram of triedb validation duration.
+    pub triedb_validate_entry_duration: Histogram,
 }
 
 impl BlockValidationMetrics {

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -796,127 +796,131 @@ where
             block
         );
 
-        let root_time = Instant::now();
-        let mut maybe_state_root = None;
-        let mut state_root_task_failed = false;
         #[cfg(feature = "trie-debug")]
         let mut trie_debug_recorders = Vec::new();
 
-        match strategy {
-            StateRootStrategy::StateRootTask => {
-                debug!(target: "engine::tree::payload_validator", "Using sparse trie state root algorithm");
+        let (state_root, trie_output, root_elapsed) = if self.config.skip_state_root_validation() {
+            debug!(target: "engine::tree::payload_validator", "Skipping state root calculation in fastnode mode");
+            (block.header().state_root(), Arc::new(TrieUpdates::default()), std::time::Duration::ZERO)
+        } else {
+            let root_time = Instant::now();
+            let mut maybe_state_root = None;
+            let mut state_root_task_failed = false;
 
-                let task_result = ensure_ok_post_block!(
-                    self.await_state_root_with_timeout(
-                        &mut handle,
-                        overlay_factory.clone(),
-                        &hashed_state,
-                    ),
-                    block
-                );
+            match strategy {
+                StateRootStrategy::StateRootTask => {
+                    debug!(target: "engine::tree::payload_validator", "Using sparse trie state root algorithm");
 
-                match task_result {
-                    Ok(StateRootComputeOutcome {
-                        state_root,
-                        trie_updates,
-                        #[cfg(feature = "trie-debug")]
-                        debug_recorders,
-                    }) => {
-                        let elapsed = root_time.elapsed();
-                        info!(target: "engine::tree::payload_validator", ?state_root, ?elapsed, "State root task finished");
+                    let task_result = ensure_ok_post_block!(
+                        self.await_state_root_with_timeout(
+                            &mut handle,
+                            overlay_factory.clone(),
+                            &hashed_state,
+                        ),
+                        block
+                    );
 
-                        #[cfg(feature = "trie-debug")]
-                        {
-                            trie_debug_recorders = debug_recorders;
-                        }
-
-                        // Compare trie updates with serial computation if configured
-                        if self.config.always_compare_trie_updates() {
-                            let _has_diff = self.compare_trie_updates_with_serial(
-                                overlay_factory.clone(),
-                                &hashed_state,
-                                trie_updates.as_ref().clone(),
-                            );
+                    match task_result {
+                        Ok(StateRootComputeOutcome {
+                            state_root,
+                            trie_updates,
                             #[cfg(feature = "trie-debug")]
-                            if _has_diff {
+                            debug_recorders,
+                        }) => {
+                            let elapsed = root_time.elapsed();
+                            info!(target: "engine::tree::payload_validator", ?state_root, ?elapsed, "State root task finished");
+
+                            #[cfg(feature = "trie-debug")]
+                            {
+                                trie_debug_recorders = debug_recorders;
+                            }
+
+                            // Compare trie updates with serial computation if configured
+                            if self.config.always_compare_trie_updates() {
+                                let _has_diff = self.compare_trie_updates_with_serial(
+                                    overlay_factory.clone(),
+                                    &hashed_state,
+                                    trie_updates.as_ref().clone(),
+                                );
+                                #[cfg(feature = "trie-debug")]
+                                if _has_diff {
+                                    Self::write_trie_debug_recorders(
+                                        block.header().number(),
+                                        &trie_debug_recorders,
+                                    );
+                                }
+                            }
+
+                            // we double check the state root here for good measure
+                            if state_root == block.header().state_root() {
+                                maybe_state_root = Some((state_root, trie_updates, elapsed))
+                            } else {
+                                warn!(
+                                    target: "engine::tree::payload_validator",
+                                    ?state_root,
+                                    block_state_root = ?block.header().state_root(),
+                                    "State root task returned incorrect state root"
+                                );
+                                #[cfg(feature = "trie-debug")]
                                 Self::write_trie_debug_recorders(
                                     block.header().number(),
                                     &trie_debug_recorders,
                                 );
+                                state_root_task_failed = true;
                             }
                         }
-
-                        // we double check the state root here for good measure
-                        if state_root == block.header().state_root() {
-                            maybe_state_root = Some((state_root, trie_updates, elapsed))
-                        } else {
-                            warn!(
-                                target: "engine::tree::payload_validator",
-                                ?state_root,
-                                block_state_root = ?block.header().state_root(),
-                                "State root task returned incorrect state root"
-                            );
-                            #[cfg(feature = "trie-debug")]
-                            Self::write_trie_debug_recorders(
-                                block.header().number(),
-                                &trie_debug_recorders,
-                            );
+                        Err(error) => {
+                            debug!(target: "engine::tree::payload_validator", %error, "State root task failed");
                             state_root_task_failed = true;
                         }
                     }
-                    Err(error) => {
-                        debug!(target: "engine::tree::payload_validator", %error, "State root task failed");
-                        state_root_task_failed = true;
+                }
+                StateRootStrategy::Parallel => {
+                    debug!(target: "engine::tree::payload_validator", "Using parallel state root algorithm");
+                    match self.compute_state_root_parallel(overlay_factory.clone(), &hashed_state) {
+                        Ok(result) => {
+                            let elapsed = root_time.elapsed();
+                            info!(
+                                target: "engine::tree::payload_validator",
+                                regular_state_root = ?result.0,
+                                ?elapsed,
+                                "Regular root task finished"
+                            );
+                            maybe_state_root = Some((result.0, Arc::new(result.1), elapsed));
+                        }
+                        Err(error) => {
+                            debug!(target: "engine::tree::payload_validator", %error, "Parallel state root computation failed");
+                        }
                     }
                 }
+                StateRootStrategy::Synchronous => {}
             }
-            StateRootStrategy::Parallel => {
-                debug!(target: "engine::tree::payload_validator", "Using parallel state root algorithm");
-                match self.compute_state_root_parallel(overlay_factory.clone(), &hashed_state) {
-                    Ok(result) => {
-                        let elapsed = root_time.elapsed();
-                        info!(
-                            target: "engine::tree::payload_validator",
-                            regular_state_root = ?result.0,
-                            ?elapsed,
-                            "Regular root task finished"
-                        );
-                        maybe_state_root = Some((result.0, Arc::new(result.1), elapsed));
-                    }
-                    Err(error) => {
-                        debug!(target: "engine::tree::payload_validator", %error, "Parallel state root computation failed");
-                    }
-                }
-            }
-            StateRootStrategy::Synchronous => {}
-        }
 
-        // Determine the state root.
-        // If the state root was computed in parallel, we use it.
-        // Otherwise, we fall back to computing it synchronously.
-        let (state_root, trie_output, root_elapsed) = if let Some(maybe_state_root) =
-            maybe_state_root
-        {
-            maybe_state_root
-        } else {
-            // fallback is to compute the state root regularly in sync
-            if self.config.state_root_fallback() {
-                debug!(target: "engine::tree::payload_validator", "Using state root fallback for testing");
+            // Determine the state root.
+            // If the state root was computed in parallel, we use it.
+            // Otherwise, we fall back to computing it synchronously.
+            if let Some(maybe_state_root) = maybe_state_root {
+                maybe_state_root
             } else {
-                warn!(target: "engine::tree::payload_validator", "Failed to compute state root in parallel");
-                self.metrics.block_validation.state_root_parallel_fallback_total.increment(1);
+                // fallback is to compute the state root regularly in sync
+                if self.config.state_root_fallback() {
+                    debug!(target: "engine::tree::payload_validator", "Using state root fallback for testing");
+                } else {
+                    warn!(target: "engine::tree::payload_validator", "Failed to compute state root in parallel");
+                    self.metrics.block_validation.state_root_parallel_fallback_total.increment(1);
+                }
+
+                let (root, updates) = ensure_ok_post_block!(
+                    Self::compute_state_root_serial(overlay_factory.clone(), &hashed_state),
+                    block
+                );
+
+                if state_root_task_failed {
+                    self.metrics.block_validation.state_root_task_fallback_success_total.increment(1);
+                }
+
+                (root, Arc::new(updates), root_time.elapsed())
             }
-
-            let (root, updates) = ensure_ok_post_block!(
-                Self::compute_state_root_serial(overlay_factory.clone(), &hashed_state),
-                block
-            );
-
-            if state_root_task_failed {
-                self.metrics.block_validation.state_root_task_fallback_success_total.increment(1);
-            }
-
-            (root, Arc::new(updates), root_time.elapsed())
         };
 
         self.metrics.block_validation.record_state_root(&trie_output, root_elapsed.as_secs_f64());
@@ -925,7 +929,7 @@ where
         debug!(target: "engine::tree::payload_validator", ?root_elapsed, "Calculated state root");
 
         // ensure state root matches
-        if state_root != block.header().state_root() {
+        if !self.config.skip_state_root_validation() && state_root != block.header().state_root() {
             #[cfg(feature = "trie-debug")]
             Self::write_trie_debug_recorders(block.header().number(), &trie_debug_recorders);
 
@@ -1671,7 +1675,7 @@ where
     /// Note: Use state root task only if prefix sets are empty, otherwise proof generation is
     /// too expensive because it requires walking all paths in every proof.
     const fn plan_state_root_computation(&self) -> StateRootStrategy {
-        if self.config.state_root_fallback() {
+        if self.config.skip_state_root_validation() || self.config.state_root_fallback() {
             StateRootStrategy::Synchronous
         } else if self.config.use_state_root_task() {
             StateRootStrategy::StateRootTask

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -533,7 +533,23 @@ where
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
         if rust_eth_triedb::triedb_manager::is_triedb_active() {
-            return self.validate_block_with_state_with_triedb(input, ctx);
+            let block_num_hash = input.num_hash();
+            let start = Instant::now();
+            self.metrics.block_validation.triedb_validate_entry_total.increment(1);
+
+            let res = self.validate_block_with_state_with_triedb(input, ctx);
+
+            let elapsed = start.elapsed().as_secs_f64();
+            self.metrics.block_validation.triedb_validate_entry_duration.record(elapsed);
+
+            tracing::debug!(
+                target: "engine::tree",
+                block = ?block_num_hash,
+                elapsed_ms = (elapsed * 1000.0),
+                "Triedb validate_block_with_state completed"
+            );
+
+            return res;
         }
 
         // Spawn payload conversion on a background thread so it runs concurrently with the
@@ -801,7 +817,11 @@ where
 
         let (state_root, trie_output, root_elapsed) = if self.config.skip_state_root_validation() {
             debug!(target: "engine::tree::payload_validator", "Skipping state root calculation in fastnode mode");
-            (block.header().state_root(), Arc::new(TrieUpdates::default()), std::time::Duration::ZERO)
+            (
+                block.header().state_root(),
+                Arc::new(TrieUpdates::default()),
+                std::time::Duration::ZERO,
+            )
         } else {
             let root_time = Instant::now();
             let mut maybe_state_root = None;
@@ -916,7 +936,10 @@ where
                 );
 
                 if state_root_task_failed {
-                    self.metrics.block_validation.state_root_task_fallback_success_total.increment(1);
+                    self.metrics
+                        .block_validation
+                        .state_root_task_fallback_success_total
+                        .increment(1);
                 }
 
                 (root, Arc::new(updates), root_time.elapsed())
@@ -928,7 +951,7 @@ where
             .record_state_root_gas_bucket(block.header().gas_used(), root_elapsed.as_secs_f64());
         debug!(target: "engine::tree::payload_validator", ?root_elapsed, "Calculated state root");
 
-        // ensure state root matches
+        // ensure state root matches (validation already skipped in fastnode mode)
         if !self.config.skip_state_root_validation() && state_root != block.header().state_root() {
             #[cfg(feature = "trie-debug")]
             Self::write_trie_debug_recorders(block.header().number(), &trie_debug_recorders);

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -389,6 +389,11 @@ pub struct EngineArgs {
     /// If not specified, defaults to the same count as storage workers.
     #[arg(long = "engine.account-worker-count", default_value = Resettable::from(DefaultEngineValues::get_global().account_worker_count.map(|v| v.to_string().into())))]
     pub account_worker_count: Option<usize>,
+    /// Skip state root validation for fastnode mode.
+    /// This disables validation of state root hashes during live sync and also automatically
+    /// disables hashing stages for maximum sync speed at the cost of reduced validation.
+    #[arg(long = "engine.skip-state-root-validation", default_value = "false")]
+    pub skip_state_root_validation: bool,
 
     /// Configure the number of prewarming threads.
     /// If not specified, defaults to available parallelism.
@@ -620,6 +625,7 @@ impl EngineArgs {
             .with_skip_state_root_validation(self.skip_state_root_validation)
             .with_min_blocks_for_pipeline_run(self.min_blocks_for_pipeline_run)
             .with_enable_proof_v2(self.enable_proof_v2);
+
         if let Some(count) = self.storage_worker_count {
             config = config.with_storage_worker_count(count);
         }

--- a/crates/node/core/src/args/engine.rs
+++ b/crates/node/core/src/args/engine.rs
@@ -487,10 +487,6 @@ pub struct EngineArgs {
     )]
     pub proof_jitter: Option<Duration>,
 
-    /// Skip state root validation for fastnode mode.
-    #[arg(long = "engine.skip-state-root-validation", default_value_t = false)]
-    pub skip_state_root_validation: bool,
-
     /// Configure the minimum number of blocks required to trigger a pipeline run for backfilling.
     /// When the local head is behind the forkchoice head by more than this threshold,
     /// the pipeline will be used to backfill blocks instead of downloading them individually.

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -995,6 +995,9 @@ Engine:
       --engine.account-worker-count <ACCOUNT_WORKER_COUNT>
           Configure the number of account proof workers in the Tokio blocking pool. If not specified, defaults to the same count as storage workers
 
+      --engine.skip-state-root-validation
+          Skip state root validation for fastnode mode. This disables validation of state root hashes during live sync and also automatically disables hashing stages for maximum sync speed at the cost of reduced validation
+
       --engine.prewarming-threads <PREWARMING_THREADS>
           Configure the number of prewarming threads. If not specified, defaults to available parallelism
 
@@ -1047,9 +1050,6 @@ Engine:
           The engine and payload builder contend for the same trie — if a builder task is still running when `newPayload` arrives, the engine will block until the trie is stored back.
 
           The builder also anchors the trie at the built block's state root, so if the next `newPayload` is not on top of that block, the trie cache is invalidated and cleared.
-
-      --engine.skip-state-root-validation
-          Skip state root validation for fastnode mode
 
       --engine.min-blocks-for-pipeline-run <MIN_BLOCKS_FOR_PIPELINE_RUN>
           Configure the minimum number of blocks required to trigger a pipeline run for backfilling. When the local head is behind the forkchoice head by more than this threshold, the pipeline will be used to backfill blocks instead of downloading them individually


### PR DESCRIPTION
## Summary

Cherry-picks commit `9b36daefc` ("impl fastnode (#12)") from `main` onto `develop-v2`.

- Adds `--engine.skip-state-root-validation` CLI flag to skip state root validation during live sync (fastnode mode)
- When enabled, hashing stages are disabled for maximum sync speed
- Activates global `FASTNODE_ACTIVE` flag for runtime queries
- Wraps state root computation in `payload_validator.rs` with a fastnode shortcut that uses the block header's state root directly

## Conflict resolution

`develop-v2` had diverged from `main` with additional features not in the original fastnode commit:
- `min_blocks_for_pipeline_run` field in `TreeConfig` — kept from `develop-v2`
- Extra engine args (`prewarming_threads`, `cache_metrics_disabled`, sparse trie params, etc.) — kept from `develop-v2`
- Richer `StateRootTask` handling (`await_state_root_with_timeout`, `trie-debug` recorders, `state_root_task_failed` fallback tracking) — kept from `develop-v2`, wrapped with the fastnode early-return

## Test plan

- [ ] Build compiles cleanly (`cargo check` passes on all modified crates)
- [ ] Node starts with `--engine.skip-state-root-validation` flag
- [ ] Fastnode mode disables hashing stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)