### PR TITLE
feat: cherry-pick enable miner triedb (#111) onto develop-v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,7 +496,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "auto_impl",
- "dashmap",
+ "dashmap 6.1.0",
  "either",
  "futures",
  "futures-utils-wasm",
@@ -1785,7 +1785,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cow-utils",
- "dashmap",
+ "dashmap 6.1.0",
  "dynify",
  "fast-float2",
  "float16",
@@ -1981,6 +1981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2073,19 @@ checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
 dependencies = [
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
+dependencies = [
+ "camino",
+ "cargo-platform 0.1.9",
+ "semver 1.0.28",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2908,6 +2927,19 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -3435,6 +3467,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -5951,6 +5992,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mini-moka"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c325dfab65f261f386debee8b0969da215b3fa0037e74c8a1234db7ba986d803"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "dashmap 5.5.3",
+ "skeptic",
+ "smallvec",
+ "tagptr",
+ "triomphe",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6939,6 +6995,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
+dependencies = [
+ "bitflags 2.11.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7646,6 +7713,7 @@ dependencies = [
  "reth-trie",
  "revm-database",
  "revm-state",
+ "rust-eth-triedb-common",
  "serde",
  "tokio",
  "tokio-stream",
@@ -8079,7 +8147,7 @@ dependencies = [
  "alloy-chains",
  "alloy-primitives",
  "alloy-rlp",
- "dashmap",
+ "dashmap 6.1.0",
  "data-encoding",
  "enr",
  "hickory-resolver",
@@ -8332,6 +8400,9 @@ dependencies = [
  "revm-primitives",
  "revm-state",
  "rust-eth-triedb",
+ "rust-eth-triedb-common",
+ "rust-eth-triedb-pathdb",
+ "rust-eth-triedb-state-trie",
  "schnellru",
  "serde_json",
  "thiserror 2.0.18",
@@ -8695,6 +8766,7 @@ dependencies = [
  "reth-storage-errors",
  "reth-trie-common",
  "revm",
+ "rust-eth-triedb-common",
 ]
 
 [[package]]
@@ -8934,7 +9006,7 @@ dependencies = [
  "bitflags 2.11.0",
  "byteorder",
  "crossbeam-queue",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_more",
  "parking_lot",
  "reth-mdbx-sys",
@@ -9530,7 +9602,7 @@ dependencies = [
  "arbitrary",
  "byteorder",
  "bytes",
- "dashmap",
+ "dashmap 6.1.0",
  "derive_more",
  "modular-bitfield",
  "once_cell",
@@ -10287,7 +10359,7 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-rpc-types-engine",
- "dashmap",
+ "dashmap 6.1.0",
  "reth-chainspec",
  "reth-db-api",
  "reth-errors",
@@ -10310,7 +10382,7 @@ name = "reth-tasks"
 version = "2.0.0"
 dependencies = [
  "crossbeam-utils",
- "dashmap",
+ "dashmap 6.1.0",
  "futures-util",
  "libc",
  "metrics",
@@ -10970,7 +11042,7 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 [[package]]
 name = "rust-eth-triedb"
 version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#7c3966b60f9ebc124b4139a24b96fe42eebe63f3"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -10991,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "rust-eth-triedb-common"
 version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#7c3966b60f9ebc124b4139a24b96fe42eebe63f3"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -11002,11 +11074,12 @@ dependencies = [
 [[package]]
 name = "rust-eth-triedb-pathdb"
 version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#7c3966b60f9ebc124b4139a24b96fe42eebe63f3"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
  "metrics",
+ "mini-moka",
  "reth-metrics",
  "rocksdb",
  "rust-eth-triedb-common",
@@ -11020,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "rust-eth-triedb-state-trie"
 version = "0.1.0"
-source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?tag=v0.0.1#2dc40833ebb7fe554a4bf9969abcdd41d2a47ca3"
+source = "git+https://github.com/bnb-chain/reth-bsc-triedb.git?branch=develop#7c3966b60f9ebc124b4139a24b96fe42eebe63f3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11695,6 +11768,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "skeptic"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
+dependencies = [
+ "bytecount",
+ "cargo_metadata 0.14.2",
+ "error-chain",
+ "glob",
+ "pulldown-cmark",
+ "tempfile",
+ "walkdir",
+]
+
+[[package]]
 name = "sketches-ddsketch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12056,9 +12144,9 @@ dependencies = [
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "259cdf8ed4e4aca6f1e9d011e10bd53f524a2d0637d7b28450f6c64ac298c4c6"
 
 [[package]]
 name = "thiserror"
@@ -12712,6 +12800,12 @@ dependencies = [
  "hash-db",
  "rlp",
 ]
+
+[[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 
 [[package]]
 name = "try-lock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -435,9 +435,10 @@ reth-zstd-compressors = { version = "0.1.1", default-features = false }
 # triedb
 # Note: To enable io-uring support, add `io-uring = ["rust-eth-triedb/io-uring"]` to the [features] section
 # of any crate that depends on rust-eth-triedb. Then enable the io-uring feature at the root (bin/reth).
-rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.1" }
-rust-eth-triedb-common = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.1", package = "rust-eth-triedb-common" }
-rust-eth-triedb-state-trie = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", tag = "v0.0.1", package = "rust-eth-triedb-state-trie" }
+rust-eth-triedb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop" }
+rust-eth-triedb-common = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-common" }
+rust-eth-triedb-pathdb = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-pathdb" }
+rust-eth-triedb-state-trie = { git = "https://github.com/bnb-chain/reth-bsc-triedb.git", branch = "develop", package = "rust-eth-triedb-state-trie" }
 
 # revm
 revm = { version = "36.0.0", default-features = false }
@@ -708,12 +709,9 @@ vergen-git2 = "9.1.0"
 # networking
 ipnet = "2.11"
 
-# Patch rust-eth-triedb's dependencies to use local reth crates
 [patch."https://github.com/bnb-chain/reth-bsc-triedb.git"]
 reth-metrics = { path = "crates/metrics" }
 
-# Patch bnb-chain/reth.git dependencies to use local reth crates
-# This is needed because rust-eth-triedb depends on bnb-chain/reth.git
 [patch."https://github.com/bnb-chain/reth.git"]
 reth-metrics = { path = "crates/metrics" }
 

--- a/crates/chain-state/Cargo.toml
+++ b/crates/chain-state/Cargo.toml
@@ -44,6 +44,9 @@ pin-project.workspace = true
 rayon = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
+# triedb
+rust-eth-triedb-common.workspace = true
+
 # optional deps for test-utils
 alloy-signer = { workspace = true, optional = true }
 alloy-signer-local = { workspace = true, optional = true }

--- a/crates/chain-state/src/in_memory.rs
+++ b/crates/chain-state/src/in_memory.rs
@@ -21,6 +21,7 @@ use reth_trie::{
     updates::TrieUpdatesSorted, HashedPostStateSorted, LazyTrieData, SortedTrieData,
     TrieInputSorted,
 };
+use rust_eth_triedb_common::DiffLayer;
 use std::{collections::BTreeMap, sync::Arc, time::Instant};
 use tokio::sync::{broadcast, watch};
 
@@ -760,6 +761,11 @@ pub struct ExecutedBlock<N: NodePrimitives = EthPrimitives> {
     /// This allows deferring the computation of the trie data which can be expensive.
     /// The data can be populated asynchronously after the block was validated.
     pub trie_data: DeferredTrieData,
+    /// Difflayer that result from triedb commit during mining.
+    ///
+    /// If present, this precomputed difflayer can be used directly when persisting
+    /// to triedb, avoiding re-computation from hashed state.
+    pub difflayer: Option<Arc<DiffLayer>>,
 }
 
 impl<N: NodePrimitives> Default for ExecutedBlock<N> {
@@ -776,6 +782,7 @@ impl<N: NodePrimitives> Default for ExecutedBlock<N> {
                 state: Default::default(),
             }),
             trie_data: DeferredTrieData::ready(ComputedTrieData::default()),
+            difflayer: None,
         }
     }
 }
@@ -798,7 +805,12 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         execution_output: Arc<BlockExecutionOutput<N::Receipt>>,
         trie_data: ComputedTrieData,
     ) -> Self {
-        Self { recovered_block, execution_output, trie_data: DeferredTrieData::ready(trie_data) }
+        Self {
+            recovered_block,
+            execution_output,
+            trie_data: DeferredTrieData::ready(trie_data),
+            difflayer: None,
+        }
     }
 
     /// Create a new [`ExecutedBlock`] with deferred trie data.
@@ -820,7 +832,7 @@ impl<N: NodePrimitives> ExecutedBlock<N> {
         execution_output: Arc<BlockExecutionOutput<N::Receipt>>,
         trie_data: DeferredTrieData,
     ) -> Self {
-        Self { recovered_block, execution_output, trie_data }
+        Self { recovered_block, execution_output, trie_data, difflayer: None }
     }
 
     /// Returns a reference to an inner [`SealedBlock`]

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -39,6 +39,9 @@ reth-trie-db.workspace = true
 
 # triedb
 rust-eth-triedb.workspace = true
+rust-eth-triedb-common.workspace = true
+rust-eth-triedb-pathdb.workspace = true
+rust-eth-triedb-state-trie.workspace = true
 
 # alloy
 alloy-evm.workspace = true
@@ -111,6 +114,9 @@ rand_08.workspace = true
 io-uring = ["rust-eth-triedb/io-uring"]
 jemalloc = [
     "rust-eth-triedb/jemalloc",
+    "rust-eth-triedb-common/jemalloc",
+    "rust-eth-triedb-pathdb/jemalloc",
+    "rust-eth-triedb-state-trie/jemalloc",
     "reth-db-common/jemalloc",
     "reth-provider/jemalloc",
     "reth-stages?/jemalloc",
@@ -119,6 +125,9 @@ jemalloc = [
 ]
 asm-keccak = [
     "rust-eth-triedb/asm-keccak",
+    "rust-eth-triedb-common/asm-keccak",
+    "rust-eth-triedb-pathdb/asm-keccak",
+    "rust-eth-triedb-state-trie/asm-keccak",
     "alloy-evm/asm-keccak",
     "alloy-primitives/asm-keccak",
     "reth-db-common/asm-keccak",
@@ -151,7 +160,6 @@ test-utils = [
     "reth-trie-common/test-utils",
     "reth-trie-db/test-utils",
     "reth-trie-sparse/test-utils",
-    "reth-prune-types?/test-utils",
     "reth-trie-parallel/test-utils",
     "reth-ethereum-primitives/test-utils",
     "reth-node-ethereum/test-utils",

--- a/crates/engine/tree/src/engine.rs
+++ b/crates/engine/tree/src/engine.rs
@@ -4,6 +4,7 @@ use crate::{
     backfill::BackfillAction,
     chain::{ChainHandler, FromOrchestrator, HandlerEvent},
     download::{BlockDownloader, DownloadAction, DownloadOutcome},
+    tree::CustomRequestMessage,
 };
 use alloy_primitives::{map::B256Set, B256};
 use crossbeam_channel::Sender;
@@ -11,6 +12,7 @@ use futures::{Stream, StreamExt};
 use reth_chain_state::ExecutedBlock;
 use reth_engine_primitives::{BeaconEngineMessage, ConsensusEngineEvent};
 use reth_ethereum_primitives::EthPrimitives;
+use reth_evm::ConfigureEvm;
 use reth_payload_primitives::PayloadTypes;
 use reth_primitives_traits::{Block, NodePrimitives, SealedBlock};
 use std::{
@@ -241,17 +243,26 @@ impl EngineApiKind {
 
 /// The request variants that the engine API handler can receive.
 #[derive(Debug)]
-pub enum EngineApiRequest<T: PayloadTypes, N: NodePrimitives> {
+pub enum EngineApiRequest<T: PayloadTypes, N: NodePrimitives, P, Evm>
+where
+    Evm: ConfigureEvm<Primitives = N>,
+{
     /// A request received from the consensus engine.
     Beacon(BeaconEngineMessage<T>),
+    /// A custom request received from the engine.
+    Custom(CustomRequestMessage<P, Evm, N>),
     /// Request to insert an already executed block, e.g. via payload building.
     InsertExecutedBlock(ExecutedBlock<N>),
 }
 
-impl<T: PayloadTypes, N: NodePrimitives> Display for EngineApiRequest<T, N> {
+impl<T: PayloadTypes, N: NodePrimitives, P, Evm> Display for EngineApiRequest<T, N, P, Evm>
+where
+    Evm: ConfigureEvm<Primitives = N>,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Beacon(msg) => msg.fmt(f),
+            Self::Custom(msg) => msg.fmt(f),
             Self::InsertExecutedBlock(block) => {
                 write!(f, "InsertExecutedBlock({:?})", block.recovered_block().num_hash())
             }
@@ -259,16 +270,22 @@ impl<T: PayloadTypes, N: NodePrimitives> Display for EngineApiRequest<T, N> {
     }
 }
 
-impl<T: PayloadTypes, N: NodePrimitives> From<BeaconEngineMessage<T>> for EngineApiRequest<T, N> {
+impl<T: PayloadTypes, N: NodePrimitives, P, Evm> From<BeaconEngineMessage<T>>
+    for EngineApiRequest<T, N, P, Evm>
+where
+    Evm: ConfigureEvm<Primitives = N>,
+{
     fn from(msg: BeaconEngineMessage<T>) -> Self {
         Self::Beacon(msg)
     }
 }
 
-impl<T: PayloadTypes, N: NodePrimitives> From<EngineApiRequest<T, N>>
-    for FromEngine<EngineApiRequest<T, N>, N::Block>
+impl<T: PayloadTypes, N: NodePrimitives, P, Evm> From<EngineApiRequest<T, N, P, Evm>>
+    for FromEngine<EngineApiRequest<T, N, P, Evm>, N::Block>
+where
+    Evm: ConfigureEvm<Primitives = N>,
 {
-    fn from(req: EngineApiRequest<T, N>) -> Self {
+    fn from(req: EngineApiRequest<T, N, P, Evm>) -> Self {
         Self::Request(req)
     }
 }

--- a/crates/engine/tree/src/launch.rs
+++ b/crates/engine/tree/src/launch.rs
@@ -67,7 +67,10 @@ pub fn build_engine_orchestrator<N, Client, S, V, C>(
     runtime: Runtime,
 ) -> ChainOrchestrator<
     EngineHandler<
-        EngineApiRequestHandler<EngineApiRequest<N::Payload, N::Primitives>, N::Primitives>,
+        EngineApiRequestHandler<
+            EngineApiRequest<N::Payload, N::Primitives, BlockchainProvider<N>, C>,
+            N::Primitives,
+        >,
         S,
         BasicBlockDownloader<Client, <N::Primitives as NodePrimitives>::Block>,
     >,

--- a/crates/engine/tree/src/tree/metrics.rs
+++ b/crates/engine/tree/src/tree/metrics.rs
@@ -546,6 +546,10 @@ pub struct BlockValidationMetrics {
     pub anchored_overlay_trie_updates_size: Histogram,
     /// Size of `AnchoredTrieInput` overlay `HashedPostStateSorted` (`total_len`)
     pub anchored_overlay_hashed_state_size: Histogram,
+    /// triedb validate execution duration
+    pub triedb_validate_execution_duration: Histogram,
+    /// triedb validate root duration
+    pub triedb_validate_root_duration: Histogram,
     /// Total number of times the triedb validation path was entered.
     pub triedb_validate_entry_total: Counter,
     /// Histogram of triedb validation duration.

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -21,7 +21,7 @@ use reth_engine_primitives::{
     BeaconEngineMessage, BeaconOnNewPayloadError, ConsensusEngineEvent, ExecutionPayload,
     ForkchoiceStateTracker, NewPayloadTimings, OnForkChoiceUpdated, SlowBlockInfo,
 };
-use reth_errors::{ConsensusError, ProviderResult};
+use reth_errors::{ConsensusError, ProviderResult, RethError, RethResult};
 use reth_evm::ConfigureEvm;
 use reth_payload_builder::{BuildNewPayload, PayloadBuilderHandle};
 use reth_payload_primitives::{BuiltPayload, NewPayloadError, PayloadTypes};
@@ -40,8 +40,16 @@ use reth_tasks::{spawn_os_thread, utils::increase_thread_priority};
 use reth_trie_db::ChangesetCache;
 use revm::interpreter::debug_unreachable;
 use revm_primitives::U256;
+use rust_eth_triedb_common::{DiffLayer, DiffLayers};
 use state::TreeState;
-use std::{collections::HashMap, fmt::Debug, ops, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Display},
+    marker::PhantomData,
+    ops,
+    sync::Arc,
+    time::Duration,
+};
 
 use crossbeam_channel::{Receiver, Sender};
 use tokio::sync::{
@@ -175,6 +183,36 @@ impl<N: NodePrimitives> EngineApiTreeState<N> {
     pub fn has_invalid_header(&mut self, hash: &B256) -> bool {
         self.invalid_headers.get(hash).is_some()
     }
+
+    /// Returns merged difflayers by parent block hash
+    pub(crate) fn merged_difflayer_by_hash(&self, parent_block_hash: B256) -> Option<DiffLayers> {
+        self.tree_state.merged_difflayer_by_hash(parent_block_hash)
+    }
+
+    /// Returns the difflayer for a specific block by its hash.
+    ///
+    /// This retrieves the single difflayer that was generated when the block was executed.
+    /// Returns `None` if the block is not found or has no difflayer.
+    pub fn difflayer_by_block_hash(&self, block_hash: B256) -> Option<Arc<DiffLayer>> {
+        self.tree_state.blocks_by_hash.get(&block_hash).and_then(|block| block.difflayer.clone())
+    }
+
+    /// Returns merged difflayers accumulated from the parent block hash up to the tip.
+    ///
+    /// This method walks back from the given parent block hash, merging all difflayers
+    /// from ancestor blocks that are in memory (not yet persisted).
+    ///
+    /// # Arguments
+    ///
+    /// * `parent_block_hash` - The hash of the parent block to start accumulating from
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(DiffLayers)` with all accumulated diff layers, or `None` if no
+    /// difflayers are found or the parent block is not in memory.
+    pub fn get_merged_difflayers(&self, parent_block_hash: B256) -> Option<DiffLayers> {
+        self.merged_difflayer_by_hash(parent_block_hash)
+    }
 }
 
 /// The outcome of a tree operation.
@@ -259,6 +297,7 @@ pub enum TreeAction {
 ///
 /// This type is responsible for processing engine API requests, maintaining the canonical state and
 /// emitting events.
+#[allow(clippy::type_complexity)]
 pub struct EngineApiTreeHandler<N, P, T, V, C>
 where
     N: NodePrimitives,
@@ -278,9 +317,9 @@ where
     /// them one by one so that we can handle incoming engine API in between and don't become
     /// unresponsive. This can happen during live sync transition where we're trying to close the
     /// gap (up to 3 epochs of blocks in the worst case).
-    incoming_tx: Sender<FromEngine<EngineApiRequest<T, N>, N::Block>>,
+    incoming_tx: Sender<FromEngine<EngineApiRequest<T, N, P, C>, N::Block>>,
     /// Incoming engine API requests.
-    incoming: Receiver<FromEngine<EngineApiRequest<T, N>, N::Block>>,
+    incoming: Receiver<FromEngine<EngineApiRequest<T, N, P, C>, N::Block>>,
     /// Outgoing events that are emitted to the handler.
     outgoing: UnboundedSender<EngineApiEvent<N>>,
     /// Channels to the persistence layer.
@@ -422,8 +461,10 @@ where
         evm_config: C,
         changeset_cache: ChangesetCache,
         runtime: reth_tasks::Runtime,
-    ) -> (Sender<FromEngine<EngineApiRequest<T, N>, N::Block>>, UnboundedReceiver<EngineApiEvent<N>>)
-    {
+    ) -> (
+        Sender<FromEngine<EngineApiRequest<T, N, P, C>, N::Block>>,
+        UnboundedReceiver<EngineApiEvent<N>>,
+    ) {
         let best_block_number = provider.best_block_number().unwrap_or(0);
         let header = provider.sealed_header(best_block_number).ok().flatten().unwrap_or_default();
 
@@ -473,7 +514,8 @@ where
     }
 
     /// Returns a new [`Sender`] to send messages to this type.
-    pub fn sender(&self) -> Sender<FromEngine<EngineApiRequest<T, N>, N::Block>> {
+    #[allow(clippy::type_complexity)]
+    pub fn sender(&self) -> Sender<FromEngine<EngineApiRequest<T, N, P, C>, N::Block>> {
         self.incoming_tx.clone()
     }
 
@@ -493,6 +535,41 @@ where
     const fn should_backpressure(&self) -> bool {
         self.persistence_state.in_progress() &&
             self.persistence_gap() >= self.config.persistence_backpressure_threshold()
+    }
+
+    /// Returns the difflayer for a specific block by its hash.
+    ///
+    /// This retrieves the single difflayer that was generated when the block was executed
+    /// and is currently held in memory (not yet persisted to disk).
+    ///
+    /// # Arguments
+    ///
+    /// * `block_hash` - The hash of the block to retrieve the difflayer for
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(Arc<DiffLayer>)` if the block exists in memory and has a difflayer,
+    /// `None` otherwise.
+    pub fn difflayer_by_block_hash(&self, block_hash: B256) -> Option<Arc<DiffLayer>> {
+        self.state.difflayer_by_block_hash(block_hash)
+    }
+
+    /// Returns merged difflayers accumulated from the parent block hash.
+    ///
+    /// This method walks back from the given parent block hash through the chain
+    /// of in-memory blocks, merging all difflayers to provide a consolidated view
+    /// of state changes since the last persisted block.
+    ///
+    /// # Arguments
+    ///
+    /// * `parent_block_hash` - The hash of the parent block to start accumulating from
+    ///
+    /// # Returns
+    ///
+    /// Returns `Some(DiffLayers)` with all accumulated diff layers merged together,
+    /// or `None` if no difflayers are found.
+    pub fn get_merged_difflayers(&self, parent_block_hash: B256) -> Option<DiffLayers> {
+        self.state.get_merged_difflayers(parent_block_hash)
     }
 
     /// Run the engine API handler.
@@ -589,7 +666,7 @@ where
     ///
     /// Unlike `wait_for_event`, this deliberately does not read from the tree input channel. Any
     /// requests sent to the tree remain queued upstream until persistence catches up.
-    fn wait_for_persistence_event(&mut self) -> LoopEvent<T, N> {
+    fn wait_for_persistence_event(&mut self) -> LoopEvent<T, N, P, C> {
         let maybe_persistence = self.persistence_state.rx.take();
 
         if let Some((persistence_rx, start_time, _action)) = maybe_persistence {
@@ -607,7 +684,7 @@ where
     ///
     /// Uses biased selection to prioritize persistence completion to update in-memory state and
     /// unblock further writes.
-    fn wait_for_event(&mut self) -> LoopEvent<T, N> {
+    fn wait_for_event(&mut self) -> LoopEvent<T, N, P, C> {
         // Take ownership of persistence rx if present
         let maybe_persistence = self.persistence_state.rx.take();
 
@@ -1520,16 +1597,65 @@ where
     /// Returns `ControlFlow::Break(())` if the engine should terminate.
     fn on_engine_message(
         &mut self,
-        msg: FromEngine<EngineApiRequest<T, N>, N::Block>,
+        msg: FromEngine<EngineApiRequest<T, N, P, C>, N::Block>,
     ) -> Result<ops::ControlFlow<()>, InsertBlockFatalError> {
+        const SLOW_HANDLER_WARN_THRESHOLD: std::time::Duration =
+            std::time::Duration::from_millis(300);
+
+        #[inline]
+        fn log_handler_duration(kind: &'static str, elapsed: std::time::Duration) {
+            tracing::debug!(
+                target: "engine::tree",
+                handler = kind,
+                elapsed_ms = elapsed.as_millis(),
+                "engine-tree handler finished"
+            );
+            if elapsed >= SLOW_HANDLER_WARN_THRESHOLD {
+                tracing::warn!(
+                    target: "engine::tree",
+                    handler = kind,
+                    elapsed_ms = elapsed.as_millis(),
+                    "engine-tree handler is slow"
+                );
+            }
+        }
+
+        #[inline]
+        fn log_handler_duration_with_block<B: core::fmt::Debug>(
+            kind: &'static str,
+            block: &B,
+            elapsed: std::time::Duration,
+        ) {
+            tracing::debug!(
+                target: "engine::tree",
+                handler = kind,
+                block = ?block,
+                elapsed_ms = elapsed.as_millis(),
+                "engine-tree handler finished"
+            );
+            if elapsed >= SLOW_HANDLER_WARN_THRESHOLD {
+                tracing::warn!(
+                    target: "engine::tree",
+                    handler = kind,
+                    block = ?block,
+                    elapsed_ms = elapsed.as_millis(),
+                    "engine-tree handler is slow"
+                );
+            }
+        }
+
         match msg {
             FromEngine::Event(event) => match event {
                 FromOrchestrator::BackfillSyncStarted => {
+                    let start = Instant::now();
                     debug!(target: "engine::tree", "received backfill sync started event");
                     self.backfill_sync_state = BackfillSyncState::Active;
+                    log_handler_duration("event.backfill_sync_started", start.elapsed());
                 }
                 FromOrchestrator::BackfillSyncFinished(ctrl) => {
+                    let start = Instant::now();
                     self.on_backfill_sync_finished(ctrl)?;
+                    log_handler_duration("event.backfill_sync_finished", start.elapsed());
                 }
                 FromOrchestrator::Terminate { tx } => {
                     debug!(target: "engine::tree", "received terminate request");
@@ -1542,9 +1668,14 @@ where
             FromEngine::Request(request) => {
                 match request {
                     EngineApiRequest::InsertExecutedBlock(block) => {
+                        let start = Instant::now();
                         let block_num_hash = block.recovered_block().num_hash();
                         if block_num_hash.number <= self.state.tree_state.canonical_block_number() {
                             // outdated block that can be skipped
+                            log_handler_duration(
+                                "request.insert_executed_block(outdated)",
+                                start.elapsed(),
+                            );
                             return Ok(ops::ControlFlow::Continue(()))
                         }
 
@@ -1566,6 +1697,7 @@ where
                         self.emit_event(EngineApiEvent::BeaconConsensus(
                             ConsensusEngineEvent::CanonicalBlockAdded(block, now.elapsed()),
                         ));
+                        log_handler_duration("request.insert_executed_block", start.elapsed());
                     }
                     EngineApiRequest::Beacon(request) => {
                         match request {
@@ -1611,8 +1743,13 @@ where
                                         .increment(1);
                                     warn!(target: "engine::tree", ?state, elapsed=?start.elapsed(), "Failed to deliver forkchoiceUpdated response, receiver dropped (request cancelled): {err:?}");
                                 }
+                                log_handler_duration(
+                                    "request.beacon.forkchoice_updated",
+                                    start.elapsed(),
+                                );
                             }
                             BeaconEngineMessage::NewPayload { payload, tx } => {
+                                let block_num_hash = payload.num_hash();
                                 let start = Instant::now();
                                 let gas_used = payload.gas_used();
                                 let num_hash = payload.num_hash();
@@ -1642,6 +1779,11 @@ where
 
                                 // handle the event if any
                                 self.on_maybe_tree_event(maybe_event)?;
+                                log_handler_duration_with_block(
+                                    "request.beacon.new_payload",
+                                    &block_num_hash,
+                                    start.elapsed(),
+                                );
                             }
                             BeaconEngineMessage::RethNewPayload {
                                 payload,
@@ -1730,21 +1872,41 @@ where
                                 self.on_maybe_tree_event(maybe_event)?;
                             }
                             BeaconEngineMessage::QueryTd { number, hash, tx } => {
+                                let start = Instant::now();
                                 debug!(target: "engine::tree", number=?number, hash=?hash, "querying header and TD by engine message");
                                 let output = self.query_header_with_td(number, hash);
 
                                 if let Err(err) = tx.send(output.map(|o| o.1).map_err(Into::into)) {
                                     error!(target: "engine::tree", "Failed to send event: {err:?}");
                                 }
+                                log_handler_duration("request.beacon.query_td", start.elapsed());
                             }
                         }
                     }
+                    EngineApiRequest::Custom(request) => match request {
+                        CustomRequestMessage::RequestDiffLayer { parent_hash, tx, .. } => {
+                            let start = Instant::now();
+                            let output = self
+                                .state
+                                .get_merged_difflayers(parent_hash)
+                                .ok_or_else(|| "DiffLayers not found".to_string());
+                            if tx.send(output.map_err(RethError::msg)).is_err() {
+                                error!(target: "engine::tree", "Failed to send event");
+                            }
+                            log_handler_duration(
+                                "request.custom.request_difflayer",
+                                start.elapsed(),
+                            );
+                        }
+                    },
                 }
             }
             FromEngine::DownloadedBlocks(blocks) => {
+                let start = Instant::now();
                 if let Some(event) = self.on_downloaded(blocks)? {
                     self.on_tree_event(event)?;
                 }
+                log_handler_duration("downloaded_blocks", start.elapsed());
             }
         }
         Ok(ops::ControlFlow::Continue(()))
@@ -3395,13 +3557,14 @@ where
 
 /// Events received in the main engine loop.
 #[derive(Debug)]
-enum LoopEvent<T, N>
+enum LoopEvent<T, N, P, C>
 where
     N: NodePrimitives,
     T: PayloadTypes,
+    C: ConfigureEvm<Primitives = N>,
 {
     /// An engine API message was received.
-    EngineMessage(FromEngine<EngineApiRequest<T, N>, N::Block>),
+    EngineMessage(FromEngine<EngineApiRequest<T, N, P, C>, N::Block>),
     /// A persistence task completed.
     PersistenceComplete {
         /// The unified result of the persistence operation.
@@ -3470,4 +3633,43 @@ pub trait WaitForCaches {
     ///
     /// Returns the time spent waiting for each cache separately.
     fn wait_for_caches(&self) -> CacheWaitDurations;
+}
+
+/// A custom request message for the engine tree handler.
+///
+/// Used by `reth-bsc` in `TrieDB` mode: during the miner flow, the miner needs the
+/// merged `DiffLayers` from the in-memory tree state so that `TrieDB` can compute
+/// the state root incrementally on top of the parent block's trie.
+#[derive(Debug)]
+pub enum CustomRequestMessage<P, Evm, N>
+where
+    Evm: ConfigureEvm<Primitives = N>,
+    N: NodePrimitives,
+{
+    /// Request the merged diff layers for a given parent hash.
+    ///
+    /// The miner sends this before calling `intermediate_and_commit_hashed_post_state`
+    /// so that `TrieDB` can apply cached trie diffs instead of reading everything from disk.
+    RequestDiffLayer {
+        /// The parent hash to get the diff layers for.
+        parent_hash: BlockHash,
+        /// The sender for returning the diff layers.
+        tx: oneshot::Sender<RethResult<DiffLayers>>,
+        /// Phantom data to hold the generic types.
+        _phantom: PhantomData<(P, Evm, N)>,
+    },
+}
+
+impl<P, Evm, N> Display for CustomRequestMessage<P, Evm, N>
+where
+    Evm: ConfigureEvm<Primitives = N>,
+    N: NodePrimitives,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RequestDiffLayer { parent_hash, .. } => {
+                write!(f, "RequestDiffLayer(parent_hash: {:?})", parent_hash)
+            }
+        }
+    }
 }

--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -34,6 +34,9 @@ use reth_trie_parallel::{
 use reth_trie_sparse::{
     ArenaParallelSparseTrie, ConfigurableSparseTrie, RevealableSparseTrie, SparseStateTrie,
 };
+use rust_eth_triedb::triedb_reth::TrieDBPrefetchState;
+use rust_eth_triedb_common::DiffLayers;
+use rust_eth_triedb_pathdb::PathDB;
 use std::{
     ops::Not,
     sync::{
@@ -50,8 +53,10 @@ mod preserved_sparse_trie;
 pub mod prewarm;
 pub mod receipt_root_task;
 pub mod sparse_trie;
+pub mod triedb_prefetcher;
 
 use preserved_sparse_trie::{PreservedSparseTrie, SharedPreservedSparseTrie};
+use triedb_prefetcher::TrieDBPrefetchHandle;
 
 /// Default node capacity for shrinking the sparse trie. This is used to limit the number of trie
 /// nodes in allocated sparse tries.
@@ -286,6 +291,7 @@ where
             state_root_handle: Some(state_root_handle),
             prewarm_handle,
             transactions: execution_rx,
+            trie_db_prefetch_result_rx: None,
             _span: span,
         }
     }
@@ -311,6 +317,65 @@ where
             state_root_handle: None,
             prewarm_handle,
             transactions: execution_rx,
+            trie_db_prefetch_result_rx: None,
+            _span: Span::current(),
+        }
+    }
+
+    /// Spawn cache prewarming with triedb prefetcher.
+    ///
+    /// Returns a [`PayloadHandle`] to communicate with the task.
+    #[allow(clippy::type_complexity)]
+    pub(super) fn spawn_cache_with_triedb_prefetcher<P, I: ExecutableTxIterator<Evm>>(
+        &self,
+        root_hash: B256,
+        path_db: PathDB,
+        difflayers: Option<DiffLayers>,
+        env: ExecutionEnv<Evm>,
+        transactions: I,
+        provider_builder: StateProviderBuilder<N, P>,
+    ) -> IteratorPayloadHandle<Evm, I, N>
+    where
+        P: BlockReader + StateProviderFactory + StateReader + Clone + 'static,
+    {
+        let (prewarm_rx, execution_rx) =
+            self.spawn_tx_iterator(transactions, env.transaction_count);
+
+        // Create a crossbeam channel for multi-proof messages (required by spawn_caching_with).
+        let (to_multi_proof, crossbeam_rx) = crossbeam_channel::unbounded::<MultiProofMessage>();
+
+        // Bridge the crossbeam receiver to a std::sync::mpsc channel because
+        // TrieDBPrefetchHandle::new expects a std::sync::mpsc::Receiver.
+        let (mpsc_tx, rev_multi_proof) = std::sync::mpsc::channel::<MultiProofMessage>();
+        self.executor.spawn_blocking(move || {
+            while let Ok(msg) = crossbeam_rx.recv() {
+                if mpsc_tx.send(msg).is_err() {
+                    break;
+                }
+            }
+        });
+
+        let prewarm_handle =
+            self.spawn_caching_with(env, prewarm_rx, provider_builder, Some(to_multi_proof), None);
+
+        let (prefetch_handle, prefetch_result_rx) = TrieDBPrefetchHandle::new(
+            root_hash,
+            path_db,
+            difflayers,
+            self.executor.clone(),
+            rev_multi_proof,
+        )
+        .expect("Failed to create TrieDBPrefetchHandle");
+
+        self.executor.spawn_blocking(move || {
+            prefetch_handle.run();
+        });
+
+        PayloadHandle {
+            state_root_handle: None,
+            prewarm_handle,
+            transactions: execution_rx,
+            trie_db_prefetch_result_rx: Some(prefetch_result_rx),
             _span: Span::current(),
         }
     }
@@ -759,11 +824,42 @@ pub struct PayloadHandle<Tx, Err, R> {
     prewarm_handle: CacheTaskHandle<R>,
     /// Stream of block transactions
     transactions: mpsc::Receiver<Result<Tx, Err>>,
+    /// Receiver for the trie db prefetch results
+    trie_db_prefetch_result_rx: Option<mpsc::Receiver<triedb_prefetcher::TrieDBPrefetchResult>>,
     /// Span for tracing
     _span: Span,
 }
 
 impl<Tx, Err, R: Send + Sync + 'static> PayloadHandle<Tx, Err, R> {
+    /// Receives the trie db prefetch result
+    ///
+    /// # Panics
+    ///
+    /// If payload processing was started without background prefetch task.
+    pub fn triedb_preftch_result(
+        &mut self,
+    ) -> Result<Option<Arc<TrieDBPrefetchState<PathDB>>>, ParallelStateRootError> {
+        let result = self
+            .trie_db_prefetch_result_rx
+            .take()
+            .expect("trie_db_prefetch_result_rx is None")
+            .recv()
+            .map_err(|_| {
+                ParallelStateRootError::Other(
+                    "trie db prefetch result receiver dropped".to_string(),
+                )
+            })?;
+
+        match result {
+            triedb_prefetcher::TrieDBPrefetchResult::PrefetchAccountResult(state) => {
+                Ok(Some(state))
+            }
+            triedb_prefetcher::TrieDBPrefetchResult::PrefetchStorageResult((_, _, _)) => {
+                panic!("received prefetch storage result, but expected prefetch account result");
+            }
+        }
+    }
+
     /// Awaits the state root
     ///
     /// # Panics

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -8,6 +8,9 @@ pub use reth_trie_parallel::state_root_task::{
     StateRootHandle, StateRootMessage,
 };
 
+/// Type alias for `StateRootMessage` used by the triedb prefetcher.
+pub type MultiProofMessage = StateRootMessage;
+
 /// The default max targets, for limiting the number of account and storage proof targets to be
 /// fetched by a single worker. If exceeded, chunking is forced regardless of worker availability.
 pub(crate) const DEFAULT_MAX_TARGETS_FOR_CHUNKING: usize = 300;

--- a/crates/engine/tree/src/tree/payload_processor/triedb_prefetcher.rs
+++ b/crates/engine/tree/src/tree/payload_processor/triedb_prefetcher.rs
@@ -1,0 +1,692 @@
+//! `TrieDBPrefetchTask` is a task that is responsible for prefetching the triedb from the database.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, RecvError, Sender},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
+
+use alloy_consensus::EMPTY_ROOT_HASH;
+use alloy_primitives::{hex, keccak256, map::B256Set, B256};
+use rayon::prelude::*;
+use reth_revm::state::EvmState;
+use reth_trie::{MultiProofTargets, MultiProofTargetsV2};
+use rust_eth_triedb::triedb_reth::TrieDBPrefetchState;
+use rust_eth_triedb_common::{DiffLayers, TrieDatabase};
+use rust_eth_triedb_pathdb::PathDB;
+use rust_eth_triedb_state_trie::{
+    SecureTrieBuilder, SecureTrieError, SecureTrieId, SecureTrieTrait, StateTrie,
+};
+use tracing::{error, info, trace, warn};
+
+use crate::tree::payload_processor::multiproof::MultiProofMessage;
+use reth_tasks::Runtime as WorkloadExecutor;
+
+/// Error type for `TrieDB` prefetch operations.
+#[derive(Debug, thiserror::Error)]
+pub enum TrieDBPrefetchError {
+    /// Secure trie error.
+    #[error("Secure trie error: {0}")]
+    SecureTrie(#[from] SecureTrieError),
+    /// Failed to build account trie.
+    #[error("Failed to build account trie: {0}")]
+    BuildAccountTrie(String),
+}
+
+/// Message type for `TrieDB` prefetch operations.
+#[allow(clippy::enum_variant_names)]
+pub(super) enum TrieDBPrefetchMessage {
+    PrefetchState(MultiProofTargets),
+    PrefetchSlots(B256Set),
+    PrefetchFinished(),
+}
+
+/// Result type for `TrieDB` prefetch operations.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum TrieDBPrefetchResult {
+    PrefetchAccountResult(Arc<TrieDBPrefetchState<PathDB>>),
+    PrefetchStorageResult((B256, StateTrie<PathDB>, usize)),
+}
+
+/// Convert `MultiProofTargetsV2` to the legacy `MultiProofTargets` format expected by triedb.
+///
+/// Extracts the hashed account keys and storage slot keys from the V2 format.
+fn multiproof_targets_v2_to_v1(targets: MultiProofTargetsV2) -> MultiProofTargets {
+    let mut result = MultiProofTargets::default();
+    for account_target in targets.account_targets {
+        result.entry(account_target.key()).or_default();
+    }
+    for (account_hash, storage_targets) in targets.storage_targets {
+        let slots = result.entry(account_hash).or_default();
+        for slot_target in storage_targets {
+            slots.insert(slot_target.key());
+        }
+    }
+    result
+}
+
+/// Convert EVM state to `TrieDB` prefetch state.
+pub fn evm_state_to_trie_db_prefetch_state(evm_state: &EvmState) -> MultiProofTargets {
+    let mut state = MultiProofTargets::default();
+    for (address, account) in evm_state {
+        let hashed_address = keccak256(address.as_slice());
+        let mut slots = B256Set::default();
+        for slot in account.storage.keys() {
+            let hashed_key = keccak256(B256::from(*slot));
+            slots.insert(hashed_key);
+        }
+        state.insert(hashed_address, slots);
+    }
+    state
+}
+
+/// A direct `TrieDB` prefetcher that can be driven from `EvmState` updates (e.g. miner-side).
+///
+/// This is a small public wrapper around the internal triedb prefetch tasks used by the engine.
+/// Unlike `TrieDBPrefetchHandle`, this does **not** require wiring the multiproof channel; users
+/// can call [`TrieDBStatePrefetcher::on_state_update`] directly.
+#[derive(Debug, Clone)]
+pub struct TrieDBStatePrefetcher {
+    inner: Arc<TrieDBStatePrefetcherInner>,
+}
+
+#[derive(Debug)]
+struct TrieDBStatePrefetcherInner {
+    state_tx: Sender<TrieDBPrefetchMessage>,
+    result_rx: Mutex<Option<Receiver<TrieDBPrefetchResult>>>,
+    cancel_flag: Arc<AtomicBool>,
+}
+
+impl TrieDBStatePrefetcher {
+    /// Creates and starts the prefetcher task(s).
+    pub fn new(
+        root_hash: B256,
+        path_db: PathDB,
+        difflayers: Option<DiffLayers>,
+        executor: WorkloadExecutor,
+    ) -> Result<Self, TrieDBPrefetchError> {
+        let spawn_exec = executor.clone();
+
+        let (state_tx, state_rx) = mpsc::channel();
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+
+        let (account_task, prefetch_result_rx) = TrieDBPrefetchAccountTask::new(
+            root_hash,
+            path_db,
+            difflayers,
+            executor,
+            state_rx,
+            cancel_flag.clone(),
+        )?;
+
+        // Spawn the account task (which in turn spawns per-account storage tasks).
+        // This uses the internal workload executor's tokio runtime.
+        spawn_exec.spawn_blocking(move || {
+            account_task.run();
+        });
+
+        Ok(Self {
+            inner: Arc::new(TrieDBStatePrefetcherInner {
+                state_tx,
+                result_rx: Mutex::new(Some(prefetch_result_rx)),
+                cancel_flag,
+            }),
+        })
+    }
+
+    /// Feed a state update into the prefetcher (typically called from an `OnStateHook`).
+    pub fn on_state_update(&self, update: &EvmState) {
+        if self.inner.cancel_flag.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let targets = evm_state_to_trie_db_prefetch_state(update);
+        if let Err(e) = self.inner.state_tx.send(TrieDBPrefetchMessage::PrefetchState(targets)) {
+            warn!(
+                target: "engine::trie_db_prefetch",
+                "TrieDBStatePrefetcher failed to send prefetch targets: {e:?}"
+            );
+        }
+    }
+
+    /// Finishes the prefetcher and returns the produced prefetch state, if available.
+    ///
+    /// This will signal all tasks to stop and then block until the final `PrefetchAccountResult`
+    /// is received (or the channel is dropped).
+    pub fn finish(self) -> Option<Arc<TrieDBPrefetchState<PathDB>>> {
+        self.inner.cancel_flag.store(true, Ordering::Relaxed);
+        let _ = self.inner.state_tx.send(TrieDBPrefetchMessage::PrefetchFinished());
+
+        let rx = self.inner.result_rx.lock().ok()?.take()?;
+        // Never block forever in miner/block-production paths: if the background task fails to
+        // respond, we fall back to "no prefetch".
+        match rx.recv_timeout(Duration::from_secs(2)).ok()? {
+            TrieDBPrefetchResult::PrefetchAccountResult(state) => Some(state),
+            TrieDBPrefetchResult::PrefetchStorageResult((_, _, _)) => None,
+        }
+    }
+}
+
+/// Handle for `TrieDB` prefetch operations.
+pub(super) struct TrieDBPrefetchHandle {
+    /// Executor for the task.
+    executor: WorkloadExecutor,
+    /// Receiver for the multi proof messages from executer evm.
+    message_rx: Receiver<MultiProofMessage>,
+    /// Sender for the trie db prefetch messages to account task.
+    state_message_tx: Sender<TrieDBPrefetchMessage>,
+    /// Cancellation flag shared across all prefetch tasks.
+    cancel_flag: Arc<AtomicBool>,
+}
+
+impl TrieDBPrefetchHandle {
+    pub(super) fn new(
+        root_hash: B256,
+        path_db: PathDB,
+        difflayers: Option<DiffLayers>,
+        executor: WorkloadExecutor,
+        message_rx: Receiver<MultiProofMessage>,
+    ) -> Result<(Self, Receiver<TrieDBPrefetchResult>), TrieDBPrefetchError> {
+        // Create the channel for the trie db prefetch messages to account task.
+        let (state_message_tx, state_message_rx) = mpsc::channel();
+
+        // Create a shared cancellation flag for all prefetch tasks.
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+
+        // Create the account task.
+        let (account_task, prefetch_result_rx) = TrieDBPrefetchAccountTask::new(
+            root_hash,
+            path_db,
+            difflayers,
+            executor.clone(),
+            state_message_rx,
+            cancel_flag.clone(),
+        )?;
+
+        // Create the handle for the trie db prefetch task.
+        let handle = Self { executor, message_rx, state_message_tx, cancel_flag };
+
+        // Spawn the account task.
+        handle.executor.spawn_blocking(move || {
+            account_task.run();
+        });
+
+        Ok((handle, prefetch_result_rx))
+    }
+
+    pub(super) fn run(self) {
+        loop {
+            match self.message_rx.recv() {
+                Ok(message) => {
+                    match message {
+                        MultiProofMessage::PrefetchProofs(targets) => {
+                            let targets = multiproof_targets_v2_to_v1(targets);
+                            if let Err(e) = self
+                                .state_message_tx
+                                .send(TrieDBPrefetchMessage::PrefetchState(targets))
+                            {
+                                error!(
+                                    target: "engine::trie_db_prefetch",
+                                    "Triedb prefetch han failed to send prefetch state message(prefetch proofs) to account task: {:?}", e.to_string()
+                                );
+                            }
+                        }
+                        MultiProofMessage::StateUpdate(_, update) => {
+                            let state = evm_state_to_trie_db_prefetch_state(&update);
+                            if let Err(e) = self
+                                .state_message_tx
+                                .send(TrieDBPrefetchMessage::PrefetchState(state))
+                            {
+                                error!(
+                                    target: "engine::trie_db_prefetch",
+                                    "Triedb prefetch handle failed to send prefetch state message(state update) to account task: {:?}", e.to_string()
+                                );
+                            }
+                        }
+                        MultiProofMessage::FinishedStateUpdates => {
+                            // Set cancellation flag to immediately stop all tasks
+                            self.cancel_flag.store(true, Ordering::Relaxed);
+                            // Send PrefetchFinished message to account task
+                            if let Err(e) = self
+                                .state_message_tx
+                                .send(TrieDBPrefetchMessage::PrefetchFinished())
+                            {
+                                trace!(
+                                    target: "engine::trie_db_prefetch",
+                                    "Triedb prefetch handle failed to send prefetch state finished message to account task: {:?}", e.to_string()
+                                );
+                            }
+                            break;
+                        }
+                        _ => {
+                            warn!(
+                                target: "engine::trie_db_prefetch",
+                                "Triedb prefetch task received unexpected message type: {:?}",
+                                std::any::type_name_of_val(&message)
+                            );
+                        }
+                    }
+                }
+                Err(RecvError) => {
+                    // Channel closed - this happens when all Senders are dropped
+                    // This is expected when the sender is closed intentionally
+                    error!(
+                        target: "engine::trie_db_prefetch",
+                        "Triedb prefetch task message channel closed, ending task"
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Task for prefetching the account trie.
+#[derive(Debug)]
+pub(super) struct TrieDBPrefetchAccountTask {
+    #[allow(dead_code)]
+    root_hash: B256,
+    path_db: PathDB,
+    difflayers: Option<DiffLayers>,
+    executor: WorkloadExecutor,
+
+    /// Receiver for the trie db prefetch messages from account task.
+    state_message_rx: Receiver<TrieDBPrefetchMessage>,
+    /// Sender for the trie db prefetch results to account task.
+    prefetch_result_tx: Sender<TrieDBPrefetchResult>,
+
+    /// `HashMap` for the storage tasks sender.
+    storage_tasks: HashMap<B256, Sender<TrieDBPrefetchMessage>>,
+    /// `HashMap` for the storage results.
+    storage_results: HashMap<B256, Receiver<TrieDBPrefetchResult>>,
+
+    /// Prefetch state for the account trie.
+    prefetch_state: Box<TrieDBPrefetchState<PathDB>>,
+
+    /// Cancellation flag shared across all prefetch tasks.
+    cancel_flag: Arc<AtomicBool>,
+}
+
+impl TrieDBPrefetchAccountTask {
+    pub(super) fn new(
+        root_hash: B256,
+        path_db: PathDB,
+        difflayers: Option<DiffLayers>,
+        executor: WorkloadExecutor,
+        state_message_rx: Receiver<TrieDBPrefetchMessage>,
+        cancel_flag: Arc<AtomicBool>,
+    ) -> Result<(Self, Receiver<TrieDBPrefetchResult>), TrieDBPrefetchError> {
+        let id = SecureTrieId::new(root_hash);
+        let account_trie = SecureTrieBuilder::new(path_db.clone())
+            .with_id(id)
+            .build_with_difflayer(difflayers.as_ref())
+            .map_err(|e| {
+                TrieDBPrefetchError::BuildAccountTrie(format!(
+                    "Failed to build account trie for root hash: 0x{}, error: {}",
+                    hex::encode(root_hash),
+                    e
+                ))
+            })?;
+
+        let prefetch_state = Box::new(TrieDBPrefetchState {
+            account_trie,
+            storage_roots: HashMap::new(),
+            storage_tries: HashMap::new(),
+        });
+
+        let (prefetch_result_tx, prefetch_result_rx) = mpsc::channel();
+        let task = Self {
+            root_hash,
+            path_db,
+            difflayers,
+            executor,
+            state_message_rx,
+            prefetch_result_tx,
+            storage_tasks: HashMap::new(),
+            storage_results: HashMap::new(),
+            prefetch_state,
+            cancel_flag,
+        };
+
+        Ok((task, prefetch_result_rx))
+    }
+
+    /// Concurrently send `PrefetchFinished` message to all storage tasks.
+    /// Returns (`successful_addresses`, `failed_addresses`) and removes failed ones from
+    /// `storage_tasks`.
+    pub(super) fn send_prefetch_finished_to_all_storage_tasks(&mut self) {
+        let results: Vec<(B256, Result<(), mpsc::SendError<TrieDBPrefetchMessage>>)> = self
+            .storage_tasks
+            .par_iter()
+            .map(|(hashed_address, storage_task)| {
+                let result = storage_task.send(TrieDBPrefetchMessage::PrefetchFinished());
+                (*hashed_address, result)
+            })
+            .collect();
+
+        for (hashed_address, result) in results {
+            match result {
+                Ok(()) => {}
+                Err(e) => {
+                    self.storage_tasks.remove(&hashed_address);
+                    self.storage_results.remove(&hashed_address);
+                    trace!(
+                        target: "engine::trie_db_prefetch",
+                        "Failed to send prefetch finished message to storage trie for address 0x{:x}: {:?}", hashed_address, e
+                    );
+                }
+            }
+        }
+    }
+
+    /// Wait for all `storage_results` and write them to `storage_tries`.
+    /// Returns (`successful_count`, `failed_addresses`).
+    pub(super) fn receive_prefetch_storage_results(&mut self) -> usize {
+        if self.storage_results.is_empty() {
+            return 0;
+        }
+
+        let start = std::time::Instant::now();
+        // Iterate over all storage_results and receive results serially
+        let receivers: Vec<(B256, Receiver<TrieDBPrefetchResult>)> =
+            self.storage_results.drain().collect();
+        let mut slot_count = 0;
+        for (hashed_address, receiver) in receivers {
+            match receiver.recv() {
+                Ok(TrieDBPrefetchResult::PrefetchStorageResult((
+                    addr,
+                    storage_trie,
+                    touched_slot_count,
+                ))) => {
+                    if addr == hashed_address {
+                        slot_count += touched_slot_count;
+                        self.prefetch_state.storage_tries.insert(hashed_address, storage_trie);
+                    } else {
+                        warn!(
+                            target: "engine::trie_db_prefetch",
+                            "Address mismatch in storage result: expected 0x{:x}, got 0x{:x}", hashed_address, addr
+                        );
+                    }
+                }
+                Ok(_) => {
+                    error!(
+                        target: "engine::trie_db_prefetch",
+                        "Unexpected result type for address 0x{:x}, prefetch account result", hashed_address
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        target: "engine::trie_db_prefetch",
+                        "Failed to receive prefetch storage result for address 0x{:x}: {:?}", hashed_address, e
+                    );
+                }
+            }
+        }
+        let duration = start.elapsed();
+        info!(
+            target: "engine::trie_db_prefetch",
+            "Completed prefetch storage results, accounts: {}, storage tries: {}, slots: {}, finished duration: {:?}", self.prefetch_state.storage_roots.len(), self.prefetch_state.storage_tries.len(), slot_count, duration
+        );
+        slot_count
+    }
+
+    pub(super) fn terminate_all_tasks(&mut self) {
+        self.send_prefetch_finished_to_all_storage_tasks();
+        self.receive_prefetch_storage_results();
+        if let Err(e) = self.prefetch_result_tx.send(TrieDBPrefetchResult::PrefetchAccountResult(
+            Arc::from(self.prefetch_state.clone()),
+        )) {
+            error!(
+                target: "engine::trie_db_prefetch",
+                "Failed to send prefetch account result: {:?}", e
+            );
+        }
+    }
+
+    pub(super) fn run(mut self) {
+        loop {
+            match self.state_message_rx.recv() {
+                Ok(message) => {
+                    match message {
+                        TrieDBPrefetchMessage::PrefetchState(targets) => {
+                            // Check cancellation before processing
+                            if self.cancel_flag.load(Ordering::Relaxed) {
+                                self.terminate_all_tasks();
+                                return;
+                            }
+                            for (address, slots) in targets.iter() {
+                                if self.cancel_flag.load(Ordering::Relaxed) {
+                                    self.terminate_all_tasks();
+                                    return;
+                                }
+                                if let Some(storage_root) = self.get_storage_root(*address) {
+                                    if !slots.is_empty() {
+                                        self.prefetch_slots(storage_root, *address, slots.clone());
+                                    }
+                                    if !self.prefetch_state.storage_roots.contains_key(address) {
+                                        self.prefetch_state
+                                            .storage_roots
+                                            .insert(*address, storage_root);
+                                        if let Err(e) = self
+                                            .prefetch_state
+                                            .account_trie
+                                            .touch_account_with_hash_state(*address)
+                                        {
+                                            warn!(
+                                                target: "engine::trie_db_prefetch",
+                                                "Failed to get account trie for address 0x{:x}: {:?}", address, e
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        TrieDBPrefetchMessage::PrefetchSlots(_) => {
+                            error!(
+                                target: "engine::trie_db_prefetch",
+                                "Triedb prefetch account task received unexpected message, prefetch slots"
+                            );
+                        }
+                        TrieDBPrefetchMessage::PrefetchFinished() => {
+                            self.terminate_all_tasks();
+                            return;
+                        }
+                    }
+                }
+                Err(RecvError) => {
+                    // Channel closed - this happens when all Senders are dropped
+                    // This is expected when the sender is closed intentionally
+                    error!(
+                        target: "engine::trie_db_prefetch",
+                        "Triedb prefetch account task message channel closed, ending task"
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    pub(super) fn get_storage_root(&self, hashed_address: B256) -> Option<B256> {
+        if let Some(storage_root) = self.prefetch_state.storage_roots.get(&hashed_address) {
+            return Some(*storage_root);
+        }
+
+        if let Some(storage_root) =
+            self.difflayers.as_ref().and_then(|d| d.get_storage_root(hashed_address))
+        {
+            return Some(storage_root);
+        }
+
+        match self.path_db.get_storage_root(hashed_address) {
+            Ok(Some(storage_root)) => Some(storage_root),
+            Ok(None) => Some(EMPTY_ROOT_HASH),
+            Err(e) => {
+                error!(
+                    target: "engine::trie_db_prefetch",
+                    "Failed to get storage root for hashed_address: 0x{}, error: {:?}", hex::encode(hashed_address), e
+                );
+                None
+            }
+        }
+    }
+
+    pub(super) fn prefetch_slots(
+        &mut self,
+        storage_root: B256,
+        hashed_address: B256,
+        slots: B256Set,
+    ) {
+        if !self.storage_tasks.contains_key(&hashed_address) {
+            let id = SecureTrieId::new(storage_root).with_owner(hashed_address);
+            let storage_trie = match SecureTrieBuilder::new(self.path_db.clone())
+                .with_id(id)
+                .build_with_difflayer(self.difflayers.as_ref())
+            {
+                Ok(trie) => trie,
+                Err(e) => {
+                    error!(
+                        target: "engine::trie_db_prefetch",
+                        "Failed to build storage trie for hashed_address: 0x{}, storage_root: 0x{}, error: {:?}",
+                        hex::encode(hashed_address),
+                        hex::encode(storage_root),
+                        e
+                    );
+                    return;
+                }
+            };
+
+            let (state_message_tx, state_message_rx) = mpsc::channel();
+            let (storage_task, storage_result_rx) = TrieDBPrefetchStorageTask::new(
+                hashed_address,
+                storage_trie,
+                state_message_rx,
+                self.cancel_flag.clone(),
+            );
+
+            self.storage_results.insert(hashed_address, storage_result_rx);
+
+            self.executor.spawn_blocking(move || {
+                storage_task.run();
+            });
+
+            self.storage_tasks.insert(hashed_address, state_message_tx);
+        };
+
+        let storage_task = self.storage_tasks.get(&hashed_address).unwrap();
+        if let Err(e) = storage_task.send(TrieDBPrefetchMessage::PrefetchSlots(slots)) {
+            error!(
+                target: "engine::trie_db_prefetch",
+                "Failed to send prefetch slot message to storage trie: {:?}", e
+            );
+        }
+    }
+}
+
+/// Task for prefetching the storage trie.
+#[derive(Debug)]
+pub(super) struct TrieDBPrefetchStorageTask {
+    hashed_address: B256,
+    storage_trie: StateTrie<PathDB>,
+    touched_slots: B256Set,
+
+    state_message_rx: Receiver<TrieDBPrefetchMessage>,
+    prefetch_result_tx: Sender<TrieDBPrefetchResult>,
+
+    /// Cancellation flag shared across all prefetch tasks.
+    cancel_flag: Arc<AtomicBool>,
+}
+
+impl TrieDBPrefetchStorageTask {
+    pub(super) fn new(
+        hashed_address: B256,
+        storage_trie: StateTrie<PathDB>,
+        state_message_rx: Receiver<TrieDBPrefetchMessage>,
+        cancel_flag: Arc<AtomicBool>,
+    ) -> (Self, Receiver<TrieDBPrefetchResult>) {
+        let (prefetch_result_tx, prefetch_result_rx) = mpsc::channel();
+        let task = Self {
+            hashed_address,
+            storage_trie,
+            touched_slots: B256Set::default(),
+            state_message_rx,
+            prefetch_result_tx,
+            cancel_flag,
+        };
+        (task, prefetch_result_rx)
+    }
+
+    pub(super) fn terminate(&self) {
+        if let Err(e) = self.prefetch_result_tx.send(TrieDBPrefetchResult::PrefetchStorageResult((
+            self.hashed_address,
+            self.storage_trie.clone(),
+            self.touched_slots.len(),
+        ))) {
+            error!(
+                target: "engine::trie_db_prefetch",
+                "Failed to send PrefetchStorageResult for address 0x{:x}: {:?}",
+                self.hashed_address, e
+            );
+        }
+    }
+
+    pub(super) fn run(mut self) {
+        loop {
+            match self.state_message_rx.recv() {
+                Ok(message) => {
+                    match message {
+                        TrieDBPrefetchMessage::PrefetchSlots(slots) => {
+                            // Check cancellation before processing
+                            if self.cancel_flag.load(Ordering::Relaxed) {
+                                self.terminate();
+                                return;
+                            }
+                            for slot in &slots {
+                                if self.cancel_flag.load(Ordering::Relaxed) {
+                                    self.terminate();
+                                    return;
+                                }
+                                if self.touched_slots.contains(slot) {
+                                    continue;
+                                }
+                                if let Err(e) =
+                                    self.storage_trie.touch_storage_with_hash_state(*slot)
+                                {
+                                    error!(
+                                        target: "engine::trie_db_prefetch",
+                                        "Failed to touch storage trie for slot 0x{:x}: {:?}", slot, e
+                                    );
+                                } else {
+                                    self.touched_slots.insert(*slot);
+                                }
+                            }
+                        }
+                        TrieDBPrefetchMessage::PrefetchFinished() => {
+                            self.terminate();
+                            return;
+                        }
+                        _ => {
+                            error!(
+                                target: "engine::trie_db_prefetch",
+                                "Triedb prefetch storage task received unexpected message, prefetch account"
+                            );
+                        }
+                    }
+                }
+                Err(RecvError) => {
+                    // Channel closed - this happens when all Senders are dropped
+                    // This is expected when the sender is closed intentionally
+                    error!(
+                        target: "engine::trie_db_prefetch",
+                        "Triedb prefetch storage task message channel closed, ending task (address: 0x{:x})",
+                        self.hashed_address
+                    );
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -88,6 +88,7 @@ use reth_trie::{trie_cursor::TrieCursorFactory, updates::TrieUpdates, HashedPost
 use reth_trie_db::ChangesetCache;
 use reth_trie_parallel::root::{ParallelStateRoot, ParallelStateRootError};
 use revm_primitives::{Address, KECCAK_EMPTY};
+use rust_eth_triedb::{get_global_triedb, TrieDBError};
 use std::{
     collections::HashMap,
     panic::{self, AssertUnwindSafe},
@@ -382,8 +383,29 @@ where
         V: PayloadValidator<T, Block = N::Block>,
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
+        /// A helper macro for handling errors after the input has been converted to a block
+        macro_rules! ensure_ok_post_block {
+            ($expr:expr, $block:expr) => {
+                match $expr {
+                    Ok(val) => val,
+                    Err(e) => {
+                        return Err(
+                            InsertBlockError::new($block.into_sealed_block(), e.into()).into()
+                        )
+                    }
+                }
+            };
+        }
+
         let parent_hash = input.parent_hash();
         let block_num_hash = input.num_hash();
+
+        // Look up difflayers for this parent; passed to the prefetcher and state root commit.
+        let difflayers = ctx.state().merged_difflayer_by_hash(parent_hash);
+
+        // Acquire the global triedb and extract the path_db handle for the prefetcher.
+        let mut triedb = get_global_triedb();
+        let path_db = triedb.get_mut_path_db_ref();
 
         trace!(target: "engine::tree", block=?block_num_hash, parent=?parent_hash, "Fetching block state provider (triedb path)");
 
@@ -444,16 +466,30 @@ where
         };
 
         let txs = self.tx_iterator_for(&input)?;
-        let mut handle =
-            self.payload_processor.spawn_cache_exclusive(env.clone(), txs, provider_builder, None);
 
+        // Spawn the payload processor with the triedb prefetcher. The prefetcher starts
+        // fetching trie proofs in the background while the block executes, so that the
+        // state-root commit below can proceed without blocking on trie I/O.
+        let mut handle = self.payload_processor.spawn_cache_with_triedb_prefetcher(
+            parent_block.state_root(),
+            path_db.clone(),
+            difflayers.clone(),
+            env.clone(),
+            txs,
+            provider_builder,
+        );
+
+        // Use cached state provider before executing, used in execution after prewarming threads
+        // complete.
         let mut state_provider: Box<dyn StateProvider + Send> = Box::new(state_provider);
         if let Some((caches, cache_metrics)) = handle.caches().zip(handle.cache_metrics()) {
             state_provider =
                 Box::new(CachedStateProvider::new(state_provider, caches, cache_metrics));
         }
 
-        let (output, senders, _receipt_rx) =
+        let execution_start = Instant::now();
+        // Execute the block and handle any execution errors.
+        let (output, senders, receipt_root_rx) =
             match self.execute_block(state_provider, env, &input, &mut handle) {
                 Ok(result) => result,
                 Err(e) => {
@@ -461,50 +497,150 @@ where
                 }
             };
 
+        self.metrics
+            .block_validation
+            .triedb_validate_execution_duration
+            .record(execution_start.elapsed().as_secs_f64());
+
+        // Spawn hashed_state computation as a background task so it runs in parallel
+        // with the receipt root wait below.
+        let hashed_state_output = output.clone();
+        let hashed_state_provider = self.provider.clone();
+        let hashed_state: LazyHashedPostState =
+            self.payload_processor.executor().spawn_blocking_named("hash-post-state", move || {
+                hashed_state_provider.hashed_post_state(&hashed_state_output.state)
+            });
+
+        // After executing the block we can stop prewarming transactions.
         handle.stop_prewarming_execution();
 
         let block = self.convert_to_block(input)?;
         let block = block.with_senders(senders);
 
-        trace!(target: "engine::tree", block=?block_num_hash, "Validating block consensus (triedb)");
-        if let Err(e) = self.validate_block_inner(&block, None) {
-            return Err(InsertBlockError::new(block.into_sealed_block(), e.into()).into())
-        }
+        // Wait for the receipt root computation to complete.
+        let receipt_root_bloom = receipt_root_rx.blocking_recv().ok();
 
-        if let Err(e) =
-            self.consensus.validate_header_against_parent(block.sealed_header(), &parent_block)
-        {
-            warn!(target: "engine::tree", ?block, "Failed to validate header {} against parent: {e}", block.hash());
-            return Err(InsertBlockError::new(block.into_sealed_block(), e.into()).into())
-        }
-
-        if let Err(err) = self.consensus.validate_block_post_execution(&block, &output.result, None)
-        {
-            self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
-            return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into())
-        }
-
-        let hashed_state = self.provider.hashed_post_state(&output.state);
-
-        if let Err(err) =
-            self.validator.validate_block_post_execution_with_hashed_state(&hashed_state, &block)
-        {
-            self.on_invalid_block(&parent_block, &block, &output, None, ctx.state_mut());
-            return Err(InsertBlockError::new(block.into_sealed_block(), err.into()).into())
-        }
+        let hashed_state = ensure_ok_post_block!(
+            self.validate_post_execution(
+                &block,
+                &parent_block,
+                &output,
+                &mut ctx,
+                None,
+                receipt_root_bloom,
+                hashed_state,
+            ),
+            block
+        );
 
         let output = Arc::new(output);
-        handle.terminate_caching(Some(output.clone()));
+        let valid_block_tx = handle.terminate_caching(Some(output.clone()));
 
-        // Skip state root computation — triedb handles state verification.
-        let trie_data = ComputedTrieData {
-            hashed_state: Arc::new(hashed_state.into_sorted()),
-            trie_updates: Arc::new(Default::default()),
-            anchored_trie_input: None,
+        // Wait for the prefetcher result (may be None if prefetch failed/wasn't available).
+        let prefetch_state = match handle.triedb_preftch_result() {
+            Ok(state) => state,
+            Err(e) => {
+                warn!(
+                    target: "engine::tree",
+                    block = ?block_num_hash,
+                    "Failed to get triedb prefetch result: {:?}, continuing without prefetcher",
+                    e
+                );
+                None
+            }
         };
-        let executed_block = ExecutedBlock::new(Arc::new(block), output, trie_data);
+        let had_prefetch_state = prefetch_state.is_some();
 
-        Ok((executed_block, None))
+        // Commit the state root via triedb, accelerated by the prefetch state.
+        let trie_hashed_state = hashed_state.get().to_triedb_hashed_post_state();
+        let block_state_root = block.state_root();
+        let root_start = Instant::now();
+        let (new_root, difflayer) = triedb
+            .intermediate_and_commit_hashed_post_state(
+                parent_block.state_root(),
+                difflayers.as_ref(),
+                &trie_hashed_state,
+                prefetch_state,
+            )
+            .map_err(|e: TrieDBError| {
+                InsertPayloadError::<N::Block>::from(InsertBlockError::new(
+                    block.clone().into_sealed_block(),
+                    ProviderError::other(e).into(),
+                ))
+            })?;
+        self.metrics
+            .block_validation
+            .triedb_validate_root_duration
+            .record(root_start.elapsed().as_secs_f64());
+
+        if new_root != block_state_root {
+            // Diagnostic: recompute without the prefetch state to determine whether the
+            // prefetch inputs are affecting correctness. Uses the non-committing API so
+            // the underlying DB/difflayers are not mutated.
+            let got_no_prefetch = if had_prefetch_state {
+                match triedb.intermediate_hashed_post_state(
+                    parent_block.state_root(),
+                    difflayers.as_ref(),
+                    &trie_hashed_state,
+                    None,
+                ) {
+                    Ok(root) => Some(root),
+                    Err(e) => {
+                        warn!(
+                            target: "engine::tree",
+                            error = ?e,
+                            "Failed to recompute triedb state root without prefetch_state"
+                        );
+                        None
+                    }
+                }
+            } else {
+                None
+            };
+            // Clean up any intermediate state the diagnostic may have left behind.
+            triedb.clean();
+
+            warn!(
+                target: "engine::tree",
+                invalid_hash = ?block.hash(),
+                invalid_number = block_num_hash.number,
+                parent_hash = ?parent_block.hash(),
+                parent_state_root = ?parent_block.state_root(),
+                got = ?new_root,
+                got_no_prefetch = ?got_no_prefetch,
+                expected = ?block_state_root,
+                tx_count = block.body().transaction_count(),
+                hashed_accounts = hashed_state.get().accounts.len(),
+                hashed_storages = hashed_state.get().storages.len(),
+                has_difflayers = difflayers.is_some(),
+                "mismatched block state root (triedb validate)"
+            );
+            self.on_invalid_block(&parent_block, &block, &*output, None, ctx.state_mut());
+            return Err(InsertBlockError::new(
+                block.into_sealed_block(),
+                ConsensusError::BodyStateRootDiff(
+                    GotExpected { got: new_root, expected: block_state_root }.into(),
+                )
+                .into(),
+            )
+            .into());
+        }
+
+        if let Some(valid_block_tx) = valid_block_tx {
+            let _ = valid_block_tx.send(());
+        }
+
+        Ok((
+            ExecutedBlock {
+                recovered_block: Arc::new(block),
+                execution_output: output,
+                // trie_data is unused in triedb mode: state root is managed by triedb,
+                // overlays and changeset computation are skipped when triedb is active.
+                trie_data: DeferredTrieData::ready(ComputedTrieData::default()),
+                difflayer: Some(difflayer),
+            },
+            None,
+        ))
     }
 
     /// Validates a block that has already been converted from a payload.
@@ -533,6 +669,7 @@ where
         Evm: ConfigureEngineEvm<T::ExecutionData, Primitives = N>,
     {
         if rust_eth_triedb::triedb_manager::is_triedb_active() {
+            // Track which triedb validation path is used and how long it takes.
             let block_num_hash = input.num_hash();
             let start = Instant::now();
             self.metrics.block_validation.triedb_validate_entry_total.increment(1);

--- a/crates/engine/tree/src/tree/state.rs
+++ b/crates/engine/tree/src/tree/state.rs
@@ -8,6 +8,7 @@ use alloy_primitives::{
 };
 use reth_chain_state::{DeferredTrieData, EthPrimitives, ExecutedBlock, LazyOverlay};
 use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives, SealedHeader};
+use rust_eth_triedb_common::DiffLayers;
 use std::{
     collections::{btree_map, hash_map, BTreeMap, VecDeque},
     ops::Bound,
@@ -159,6 +160,24 @@ impl<N: NodePrimitives> TreeState<N> {
     /// Should be called when the anchor changes (e.g., after persistence).
     pub(crate) fn invalidate_cached_overlay(&mut self) {
         self.cached_canonical_overlay = None;
+    }
+
+    /// Returns merged difflayers accumulated from the parent block hash.
+    pub(crate) fn merged_difflayer_by_hash(&self, parent_block_hash: B256) -> Option<DiffLayers> {
+        let mut difflayers = DiffLayers::default();
+        let mut parent_hash = parent_block_hash;
+        while let Some(executed) = self.blocks_by_hash.get(&parent_hash) {
+            parent_hash = executed.recovered_block().parent_hash();
+            if let Some(executed_difflayer) = &executed.difflayer {
+                difflayers.insert_difflayer(executed_difflayer.clone());
+            }
+        }
+
+        if difflayers.is_empty() {
+            return None;
+        }
+
+        Some(difflayers)
     }
 
     /// Insert executed block into the state.

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -148,7 +148,10 @@ struct TestHarness {
         MockEvmConfig,
     >,
     to_tree_tx: crossbeam_channel::Sender<
-        FromEngine<EngineApiRequest<EthEngineTypes, EthPrimitives>, Block>,
+        FromEngine<
+            EngineApiRequest<EthEngineTypes, EthPrimitives, MockEthProvider, MockEvmConfig>,
+            Block,
+        >,
     >,
     from_tree_rx: UnboundedReceiver<EngineApiEvent>,
     blocks: Vec<ExecutedBlock>,

--- a/crates/evm/evm/Cargo.toml
+++ b/crates/evm/evm/Cargo.toml
@@ -19,6 +19,7 @@ reth-primitives-traits.workspace = true
 reth-storage-api.workspace = true
 reth-storage-errors.workspace = true
 reth-trie-common.workspace = true
+rust-eth-triedb-common = { workspace = true, optional = true }
 
 revm.workspace = true
 
@@ -41,6 +42,7 @@ reth-ethereum-primitives.workspace = true
 default = ["std"]
 std = [
     "dep:rayon",
+    "dep:rust-eth-triedb-common",
     "reth-primitives-traits/std",
     "alloy-eips/std",
     "alloy-primitives/std",

--- a/crates/evm/evm/src/execute.rs
+++ b/crates/evm/evm/src/execute.rs
@@ -25,6 +25,8 @@ use revm::{
     context::result::ExecutionResult,
     database::{states::bundle_state::BundleRetention, BundleState, State},
 };
+#[cfg(feature = "std")]
+use rust_eth_triedb_common::DiffLayer;
 
 /// A type that knows how to execute a block. It is assumed to operate on a
 /// [`crate::Evm`] internally and use [`State`] as database.
@@ -306,6 +308,17 @@ pub struct BlockBuilderOutcome<N: NodePrimitives> {
     pub block: RecoveredBlock<N::Block>,
 }
 
+/// Extended output of block building that can carry a triedb difflayer (if produced by the
+/// block builder).
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+pub struct BlockBuilderOutcomeWithDiffLayer<N: NodePrimitives> {
+    /// The standard block builder outcome.
+    pub inner: BlockBuilderOutcome<N>,
+    /// Triedb difflayer produced during state root computation (if any).
+    pub difflayer: Option<Arc<DiffLayer>>,
+}
+
 /// A type that knows how to execute and build a block.
 ///
 /// It wraps an inner [`BlockExecutor`] and provides a way to execute transactions and
@@ -367,6 +380,24 @@ pub trait BlockBuilder {
         state_provider: impl StateProvider,
         state_root_precomputed: Option<(B256, TrieUpdates)>,
     ) -> Result<BlockBuilderOutcome<Self::Primitives>, BlockExecutionError>;
+
+    /// Completes the block building process and also returns an optional triedb difflayer if the
+    /// builder produced one.
+    ///
+    /// Default implementation returns no difflayer.
+    #[cfg(feature = "std")]
+    fn finish_with_difflayer(
+        self,
+        state_provider: impl StateProvider,
+    ) -> Result<BlockBuilderOutcomeWithDiffLayer<Self::Primitives>, BlockExecutionError>
+    where
+        Self: Sized,
+    {
+        Ok(BlockBuilderOutcomeWithDiffLayer {
+            inner: self.finish(state_provider, None)?,
+            difflayer: None,
+        })
+    }
 
     /// Provides mutable access to the inner [`BlockExecutor`].
     fn executor_mut(&mut self) -> &mut Self::Executor;

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -190,6 +190,16 @@ impl EngineNodeLauncher {
         let event_sender = EventSender::default();
 
         let beacon_engine_handle = ConsensusEngineHandle::new(consensus_engine_tx.clone());
+        let (engine_api_tx, _engine_api_rx) = unbounded_channel::<
+            EngineApiRequest<
+                <<T as FullNodeTypes>::Types as NodeTypes>::Payload,
+                <<T as FullNodeTypes>::Types as NodeTypes>::Primitives,
+                BlockchainProvider<
+                    NodeTypesWithDBAdapter<<T as FullNodeTypes>::Types, <T as FullNodeTypes>::DB>,
+                >,
+                <CB::Components as NodeComponents<T>>::Evm,
+            >,
+        >();
 
         // extract the jwt secret from the args if possible
         let jwt_secret = ctx.auth_jwt_secret()?;
@@ -283,6 +293,7 @@ impl EngineNodeLauncher {
             engine_events,
             beacon_engine_handle,
             engine_shutdown: _,
+            engine_api_tx: _,
         } = add_ons.launch_add_ons(add_ons_ctx).await?;
 
         // Create engine shutdown handle
@@ -421,6 +432,7 @@ impl EngineNodeLauncher {
                 engine_events,
                 beacon_engine_handle,
                 engine_shutdown,
+                engine_api_tx: Some(engine_api_tx),
             },
         };
         // Notify on node started

--- a/crates/node/builder/src/rpc.rs
+++ b/crates/node/builder/src/rpc.rs
@@ -16,9 +16,11 @@ use jsonrpsee::{core::middleware::layer::Either, RpcModule};
 use parking_lot::Mutex;
 use reth_chain_state::CanonStateSubscriptions;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec, EthereumHardforks, Hardforks};
+use reth_engine_tree::engine::EngineApiRequest;
 use reth_node_api::{
     AddOnsContext, BlockTy, EngineApiValidator, EngineTypes, FullNodeComponents, FullNodeTypes,
-    NodeAddOns, NodeTypes, PayloadTypes, PayloadValidator, PrimitivesTy, TreeConfig,
+    NodeAddOns, NodeTypes, NodeTypesWithDBAdapter, PayloadTypes, PayloadValidator, PrimitivesTy,
+    TreeConfig,
 };
 use reth_node_core::{
     cli::config::RethTransactionPoolConfig,
@@ -26,6 +28,7 @@ use reth_node_core::{
     version::{version_metadata, CLIENT_CODE},
 };
 use reth_payload_builder::{PayloadBuilderHandle, PayloadStore};
+use reth_provider::providers::BlockchainProvider;
 use reth_rpc::{
     eth::{core::EthRpcConverterFor, DevSigner, EthApiTypes, FullEthApiServer},
     AdminApi,
@@ -46,7 +49,7 @@ use std::{
     ops::{Deref, DerefMut},
     sync::Arc,
 };
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc::UnboundedSender, oneshot};
 
 /// Contains the handles to the spawned RPC servers.
 ///
@@ -324,6 +327,18 @@ where
     }
 }
 
+/// Internal alias for the Engine API sender type tied to a node.
+type EngineApiTx<Node> = UnboundedSender<
+    EngineApiRequest<
+        <<Node as FullNodeTypes>::Types as NodeTypes>::Payload,
+        <<Node as FullNodeTypes>::Types as NodeTypes>::Primitives,
+        BlockchainProvider<
+            NodeTypesWithDBAdapter<<Node as FullNodeTypes>::Types, <Node as FullNodeTypes>::DB>,
+        >,
+        <Node as FullNodeComponents>::Evm,
+    >,
+>;
+
 /// Handle to the launched RPC servers.
 pub struct RpcHandle<Node: FullNodeComponents, EthApi: EthApiTypes> {
     /// Handles to launched servers.
@@ -339,6 +354,11 @@ pub struct RpcHandle<Node: FullNodeComponents, EthApi: EthApiTypes> {
     pub beacon_engine_handle: ConsensusEngineHandle<<Node::Types as NodeTypes>::Payload>,
     /// Handle to trigger engine shutdown.
     pub engine_shutdown: EngineShutdown,
+    /// Sender for engine API requests flowing from RPC to engine service.
+    ///
+    /// Factory requirement (for clarity): `ProviderFactory` implements
+    /// `DatabaseProviderFactory<Provider: BlockReader> + Clone + Send + Sync + 'static`.
+    pub engine_api_tx: Option<EngineApiTx<Node>>,
 }
 
 impl<Node: FullNodeComponents, EthApi: EthApiTypes> Clone for RpcHandle<Node, EthApi> {
@@ -349,6 +369,7 @@ impl<Node: FullNodeComponents, EthApi: EthApiTypes> Clone for RpcHandle<Node, Et
             engine_events: self.engine_events.clone(),
             beacon_engine_handle: self.beacon_engine_handle.clone(),
             engine_shutdown: self.engine_shutdown.clone(),
+            engine_api_tx: self.engine_api_tx.clone(),
         }
     }
 }
@@ -966,6 +987,7 @@ where
             engine_events,
             beacon_engine_handle: engine_handle,
             engine_shutdown: EngineShutdown::default(),
+            engine_api_tx: None,
         })
     }
 

--- a/crates/stages/stages/src/stages/execution/mod.rs
+++ b/crates/stages/stages/src/stages/execution/mod.rs
@@ -564,14 +564,19 @@ where
                 );
 
                 let (new_root, difflayer) = triedb
-                    .commit_hashed_post_state(root_hash, None, &triedb_hashed_post_state)
+                    .intermediate_and_commit_hashed_post_state(
+                        root_hash,
+                        None,
+                        &triedb_hashed_post_state,
+                        None,
+                    )
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
 
                 if new_root != validate_root {
                     return Err(StageError::Fatal(Box::new(ProviderError::Database(DatabaseError::Other(format!("execution update triedb, start={}, end={}, new_root({:?}) != validate_root({:?})", start_block, stage_progress, new_root, validate_root))))));
                 }
                 triedb
-                    .flush(stage_progress, new_root, &difflayer)
+                    .flush(stage_progress, new_root, &Some(difflayer))
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
 
                 info!(target: "sync::stages::execution",
@@ -653,7 +658,12 @@ where
 
                 info!(target: "sync::stages::execution", "Begin unwind execution update triedb, latest_block_number={}, unwind_to={}, latest_state_root={:?}, target_root={:?}, accounts={}, storages={}", latest_block_number, unwind_to, latest_state_root, validate_root, hashed_post_state.accounts.len(), hashed_post_state.storages.len());
                 let (new_root, difflayer) = triedb
-                    .commit_hashed_post_state(latest_state_root, None, &triedb_hashed_post_state)
+                    .intermediate_and_commit_hashed_post_state(
+                        latest_state_root,
+                        None,
+                        &triedb_hashed_post_state,
+                        None,
+                    )
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
                 info!(target: "sync::stages::execution", "End unwind execution update triedb, new_root={:?}, target_root={:?}", new_root, validate_root);
 
@@ -662,7 +672,7 @@ where
                 }
 
                 triedb
-                    .flush(latest_block_number, new_root, &difflayer)
+                    .flush(latest_block_number, new_root, &Some(difflayer))
                     .map_err(|e| StageError::Fatal(Box::new(e)))?;
             } else {
                 warn!(

--- a/crates/storage/db-common/src/init.rs
+++ b/crates/storage/db-common/src/init.rs
@@ -392,12 +392,13 @@ where
     }
 
     let (root, nodes, diff_storage_roots) = triedb
-        .batch_update_and_commit(
+        .finalise(
             alloy_trie::EMPTY_ROOT_HASH,
             None,
             state_accounts,
             HashSet::new(),
             storage_states,
+            None,
         )
         .map_err(|_| {
             ProviderError::Database(DatabaseError::Other(
@@ -405,8 +406,7 @@ where
             ))
         })?;
 
-    let diff_nodes = (*nodes.to_diff_nodes()).clone();
-    let difflayer = Some(Arc::new(DiffLayer::new(diff_nodes, diff_storage_roots)));
+    let difflayer = Some(Arc::new(DiffLayer::new(nodes.to_diff_nodes(), diff_storage_roots)));
     triedb.flush(0, root, &difflayer).map_err(|_| {
         ProviderError::Database(DatabaseError::Other("Failed to flush state".to_string()))
     })?;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -735,66 +735,77 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
                     )?;
                     timings.write_state += start.elapsed();
 
+                    let trie_data = block.trie_data();
+
                     if let Some(ref mut triedb) = triedb_opt {
                         // TrieDB mode: update TrieDB instead of writing hashed state to MDBX
                         let start = Instant::now();
 
-                        let trie_data = block.trie_data();
+                        if let Some(ref difflayer) = block.difflayer {
+                            // The difflayer was precomputed during validation (newPayload).
+                            // Root was already verified there, so just flush to disk.
+                            debug!(
+                                target: "providers::db",
+                                block_number,
+                                state_root = ?state_root,
+                                "Flushing precomputed triedb difflayer in save_blocks",
+                            );
+                            triedb
+                                .flush(block_number, state_root, &Some(difflayer.clone()))
+                                .map_err(ProviderError::other)?;
+                        } else {
+                            // No precomputed difflayer; compute and commit from hashed state.
+                            let (latest_block_number, latest_state_root) =
+                                triedb.latest_persist_state().map_err(ProviderError::other)?;
 
-                        let (latest_block_number, latest_state_root) =
-                            triedb.latest_persist_state().map_err(ProviderError::other)?;
+                            if block_number > 0 && latest_block_number != block_number - 1 {
+                                return Err(ProviderError::Database(reth_db_api::DatabaseError::Other(format!(
+                                    "triedb state gap in save_blocks: latest_block_number={}, expected={}, block_number={}",
+                                    latest_block_number,
+                                    block_number - 1,
+                                    block_number
+                                ))));
+                            }
 
-                        // Validate that triedb state is consistent
-                        if block_number > 0 && latest_block_number != block_number - 1 {
-                            return Err(ProviderError::Database(reth_db_api::DatabaseError::Other(format!(
-                                "triedb state gap in save_blocks: latest_block_number={}, expected={}, block_number={}",
-                                latest_block_number,
-                                block_number - 1,
-                                block_number
-                            ))));
+                            let triedb_hashed_post_state =
+                                trie_data.hashed_state.to_triedb_hashed_post_state();
+
+                            debug!(
+                                target: "providers::db",
+                                block_number,
+                                latest_triedb_block = latest_block_number,
+                                parent_root = ?latest_state_root,
+                                expected_root = ?state_root,
+                                "Computing triedb state root in save_blocks",
+                            );
+
+                            let (new_root, difflayer) = triedb
+                                .intermediate_and_commit_hashed_post_state(
+                                    latest_state_root,
+                                    None,
+                                    &triedb_hashed_post_state,
+                                    None,
+                                )
+                                .map_err(ProviderError::other)?;
+
+                            if new_root != state_root {
+                                return Err(ProviderError::Database(reth_db_api::DatabaseError::Other(format!(
+                                    "triedb update failed in save_blocks: new_root({:?}) != expected_root({:?}), block_number={}",
+                                    new_root,
+                                    state_root,
+                                    block_number
+                                ))));
+                            }
+
+                            triedb
+                                .flush(block_number, new_root, &Some(difflayer))
+                                .map_err(ProviderError::other)?;
                         }
-
-                        let triedb_hashed_post_state =
-                            trie_data.hashed_state.to_triedb_hashed_post_state();
-
-                        debug!(
-                            target: "providers::db",
-                            "Begin update triedb in save_blocks, block_number={}, latest_triedb_block={}, parent_root={:?}, expected_root={:?}",
-                            block_number,
-                            latest_block_number,
-                            latest_state_root,
-                            state_root,
-                        );
-
-                        let (new_root, difflayer) = triedb
-                            .commit_hashed_post_state(
-                                latest_state_root,
-                                None,
-                                &triedb_hashed_post_state,
-                            )
-                            .map_err(ProviderError::other)?;
-
-                        if new_root != state_root {
-                            return Err(ProviderError::Database(reth_db_api::DatabaseError::Other(format!(
-                                "triedb update failed in save_blocks: new_root({:?}) != expected_root({:?}), block_number={}",
-                                new_root,
-                                state_root,
-                                block_number
-                            ))));
-                        }
-
-                        triedb
-                            .flush(block_number, new_root, &difflayer)
-                            .map_err(ProviderError::other)?;
-
-                        debug!(
-                            target: "providers::db",
-                            "End update triedb in save_blocks, block_number={}, new_root={:?}",
-                            block_number,
-                            new_root
-                        );
 
                         timings.write_hashed_state += start.elapsed();
+                    } else {
+                        // Non-TrieDB mode: write hashed state to MDBX
+                        self.write_hashed_state(&trie_data.hashed_state)?;
                     }
                 }
             }

--- a/crates/trie/common/src/hashed_state.rs
+++ b/crates/trie/common/src/hashed_state.rs
@@ -29,8 +29,8 @@ use rust_eth_triedb::TrieDBHashedPostState;
 #[cfg(feature = "std")]
 use rust_eth_triedb_state_trie::account::StateAccount;
 
-/// In-memory hashed state that stores account and storage changes with keccak256-hashed keys
-/// in hash maps.
+/// In-memory hashed state that stores account and storage changes with keccak256-hashed keys in
+/// hash maps.
 #[derive(PartialEq, Eq, Clone, Default, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HashedPostState {


### PR DESCRIPTION
## Summary

Cherry-picks commit `23d41a871` from `develop` — **feat: enable miner triedb (#111)**.

This PR brings miner TrieDB support onto `develop-v2`, including:
- `TrieDBPrefetchHandle` / `TrieDBStatePrefetcher` background prefetch task
- `DiffLayer` carried on `ExecutedBlock` for in-memory trie diffing
- `merged_difflayer_by_hash` on `EngineApiTreeState` for stacking in-memory diffs
- `spawn_cache_with_triedb_prefetcher` on `PayloadProcessor` — returns early with `state_root: None` when TrieDB is active (skips sparse-trie pipeline)
- `validate_block_with_state_with_triedb` integrated with difflayer lookup and diagnostic state-root recompute on mismatch
- TrieDB-specific metrics: `triedb_validate_entry_total`, `triedb_validate_entry_duration`

**Next commit to rebase:** `8ebf318e3` — `feat(txpool): reannounce local pending transactions (#115)`

## Conflict resolution notes

- `crates/engine/service/src/service.rs` — deleted in HEAD (service refactored), accepted deletion
- `crates/storage/provider/src/writer/mod.rs` — deleted in cherry-pick, kept HEAD's extended version
- All other conflicts resolved by keeping HEAD's newer API shapes and grafting the cherry-pick's triedb additions on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)