### PR TITLE
feat(txpool): reannounce local pending transactions (cherry-pick #115)

### DIFF
--- a/crates/net/network/src/transactions/config.rs
+++ b/crates/net/network/src/transactions/config.rs
@@ -1,10 +1,10 @@
 use core::fmt;
-use std::{fmt::Debug, str::FromStr};
+use std::{fmt::Debug, str::FromStr, time::Duration};
 
 use super::{
-    PeerMetadata, DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
+    PeerMetadata, DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER, DEFAULT_REANNOUNCE_TIME,
     DEFAULT_SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESP_ON_PACK_GET_POOLED_TRANSACTIONS_REQ,
-    SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE,
+    MIN_REANNOUNCE_TIME, SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE,
 };
 use crate::transactions::constants::tx_fetcher::{
     DEFAULT_MAX_CAPACITY_CACHE_PENDING_FETCH, DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS,
@@ -15,6 +15,11 @@ use alloy_primitives::B256;
 use derive_more::{Constructor, Display};
 use reth_eth_wire::NetworkPrimitives;
 use reth_network_types::peers::kind::PeerKind;
+use tracing::warn;
+
+const fn default_reannounce_time() -> Duration {
+    DEFAULT_REANNOUNCE_TIME
+}
 
 /// Configuration for managing transactions within the network.
 #[derive(Debug, Clone)]
@@ -30,6 +35,9 @@ pub struct TransactionsManagerConfig {
     /// Which peers we accept incoming transactions or announcements from.
     #[cfg_attr(feature = "serde", serde(default))]
     pub ingress_policy: TransactionIngressPolicy,
+    /// Age threshold for periodically reannouncing local pending transactions as hashes.
+    #[cfg_attr(feature = "serde", serde(default = "default_reannounce_time"))]
+    pub reannounce_time: Duration,
 }
 
 impl Default for TransactionsManagerConfig {
@@ -39,7 +47,25 @@ impl Default for TransactionsManagerConfig {
             max_transactions_seen_by_peer_history: DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
             propagation_mode: TransactionPropagationMode::default(),
             ingress_policy: TransactionIngressPolicy::default(),
+            reannounce_time: default_reannounce_time(),
         }
+    }
+}
+
+impl TransactionsManagerConfig {
+    /// Returns a config with any invalid reannounce interval clamped to the supported minimum.
+    pub fn sanitized(mut self) -> Self {
+        if self.reannounce_time < MIN_REANNOUNCE_TIME {
+            warn!(
+                target: "net::tx",
+                provided = ?self.reannounce_time,
+                updated = ?MIN_REANNOUNCE_TIME,
+                "Sanitizing invalid transaction reannounce time"
+            );
+            self.reannounce_time = MIN_REANNOUNCE_TIME;
+        }
+
+        self
     }
 }
 
@@ -368,5 +394,16 @@ mod tests {
         assert!(TransactionPropagationMode::from_str("max:").is_err());
         assert!(TransactionPropagationMode::from_str("max").is_err());
         assert!(TransactionPropagationMode::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_reannounce_time_sanitized() {
+        let config = TransactionsManagerConfig {
+            reannounce_time: Duration::from_secs(1),
+            ..Default::default()
+        }
+        .sanitized();
+
+        assert_eq!(config.reannounce_time, MIN_REANNOUNCE_TIME);
     }
 }

--- a/crates/net/network/src/transactions/constants.rs
+++ b/crates/net/network/src/transactions/constants.rs
@@ -35,6 +35,8 @@ pub const SOFT_LIMIT_BYTE_SIZE_POOLED_TRANSACTIONS_RESPONSE: usize = 2 * 1024 * 
 
 /// Constants used by [`TransactionsManager`](super::TransactionsManager).
 pub mod tx_manager {
+    use std::time::Duration;
+
     use super::SOFT_LIMIT_COUNT_HASHES_IN_NEW_POOLED_TRANSACTIONS_BROADCAST_MESSAGE;
 
     /// Default limit for number of transactions to keep track of for a single peer.
@@ -53,6 +55,20 @@ pub mod tx_manager {
     ///
     /// Default is 100 KiB, i.e. 3 200 transaction hashes.
     pub const DEFAULT_MAX_COUNT_BAD_IMPORTS: u32 = 100 * 1024 / 32;
+
+    /// Maximum number of local pending transactions to reannounce on each timer tick.
+    pub const DEFAULT_MAX_COUNT_REANNOUNCED_LOCAL_TRANSACTIONS: usize = 1024;
+
+    /// Interval between checks for local pending transactions that should be reannounced.
+    pub const DEFAULT_REANNOUNCE_LOCAL_TRANSACTIONS_INTERVAL: Duration = Duration::from_secs(60);
+
+    /// Default age threshold for reannouncing local pending transactions.
+    ///
+    /// This effectively disables the feature unless configured otherwise.
+    pub const DEFAULT_REANNOUNCE_TIME: Duration = Duration::from_secs(10 * 365 * 24 * 60 * 60);
+
+    /// Minimum allowed age threshold for reannouncing local pending transactions.
+    pub const MIN_REANNOUNCE_TIME: Duration = DEFAULT_REANNOUNCE_LOCAL_TRANSACTIONS_INTERVAL;
 }
 
 /// Constants used by [`TransactionFetcher`](super::TransactionFetcher).

--- a/crates/net/network/src/transactions/mod.rs
+++ b/crates/net/network/src/transactions/mod.rs
@@ -77,7 +77,10 @@ use std::{
     task::{Context, Poll},
     time::{Duration, Instant},
 };
-use tokio::sync::{mpsc, oneshot, oneshot::error::RecvError};
+use tokio::{
+    sync::{mpsc, oneshot, oneshot::error::RecvError},
+    time::{self, Interval, MissedTickBehavior},
+};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, trace};
 
@@ -334,6 +337,8 @@ pub struct TransactionsManager<Pool, N: NetworkPrimitives = EthNetworkPrimitives
     pending_transactions: mpsc::Receiver<TxHash>,
     /// Incoming events from the [`NetworkManager`](crate::NetworkManager).
     transaction_events: UnboundedMeteredReceiver<NetworkTransactionEvent<N>>,
+    /// Periodic timer that retries hash-only announcements for older local pending transactions.
+    reannounce_local_transactions: Interval,
     /// How the `TransactionsManager` is configured.
     config: TransactionsManagerConfig,
     /// Network Policies
@@ -378,6 +383,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         transactions_manager_config: TransactionsManagerConfig,
         policies: NetworkPolicies<N>,
     ) -> Self {
+        let transactions_manager_config = transactions_manager_config.sanitized();
         let network_events = network.event_listener();
 
         let (command_tx, command_rx) = mpsc::unbounded_channel();
@@ -395,6 +401,11 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
         metrics
             .capacity_pending_pool_imports
             .increment(pending_pool_imports_info.max_pending_pool_imports as u64);
+        let mut reannounce_local_transactions = time::interval_at(
+            time::Instant::now() + DEFAULT_REANNOUNCE_LOCAL_TRANSACTIONS_INTERVAL,
+            DEFAULT_REANNOUNCE_LOCAL_TRANSACTIONS_INTERVAL,
+        );
+        reannounce_local_transactions.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
         Self {
             pool,
@@ -413,6 +424,7 @@ impl<Pool: TransactionPool, N: NetworkPrimitives> TransactionsManager<Pool, N> {
                 from_network,
                 NETWORK_POOL_TRANSACTIONS_SCOPE,
             ),
+            reannounce_local_transactions,
             config: transactions_manager_config,
             policies,
             metrics,
@@ -966,6 +978,20 @@ where
         peer_id: PeerId,
         propagation_mode: PropagationMode,
     ) {
+        if let Some(propagated) = self.propagate_hashes_to_peer(hashes, peer_id, propagation_mode) {
+            self.pool.on_propagated(propagated);
+        }
+    }
+
+    /// Propagate the transaction hashes to the given peer.
+    ///
+    /// Note: This will only send the hashes for transactions that exist in the pool.
+    fn propagate_hashes_to_peer(
+        &mut self,
+        hashes: Vec<TxHash>,
+        peer_id: PeerId,
+        propagation_mode: PropagationMode,
+    ) -> Option<PropagatedTransactions> {
         trace!(target: "net::tx", "Start propagating transactions as hashes");
 
         // This fetches a transactions from the pool, including the blob transactions, which are
@@ -973,7 +999,7 @@ where
         let propagated = {
             let Some(peer) = self.peers.get_mut(&peer_id) else {
                 // no such peer
-                return
+                return None
             };
 
             let to_propagate =
@@ -999,7 +1025,7 @@ where
 
             if new_pooled_hashes.is_empty() {
                 // nothing to propagate
-                return
+                return None
             }
 
             if let Some(peer) = self.peers.get_mut(&peer_id) {
@@ -1020,8 +1046,7 @@ where
             propagated
         };
 
-        // notify pool so events get fired
-        self.pool.on_propagated(propagated);
+        Some(propagated)
     }
 
     /// Propagate the transactions to all connected peers either as full objects or hashes.
@@ -1134,6 +1159,64 @@ where
 
         // notify pool so events get fired
         self.pool.on_propagated(propagated);
+    }
+
+    /// Reannounces local pending transactions as hashes to a square root subset of peers.
+    fn reannounce_local_pending_transactions(&mut self, now: Instant) {
+        let hashes = transaction_hashes_to_reannounce(
+            self.pool.get_local_pending_transactions(),
+            now,
+            self.config.reannounce_time,
+        );
+        let propagated = self.reannounce_transaction_hashes(hashes);
+        if !propagated.0.is_empty() {
+            self.pool.on_propagated(propagated);
+        }
+    }
+
+    /// Reannounces the provided transaction hashes as hash-only gossip to a square root subset of
+    /// eligible peers.
+    fn reannounce_transaction_hashes(&mut self, hashes: Vec<TxHash>) -> PropagatedTransactions {
+        let mut propagated = PropagatedTransactions::default();
+
+        if hashes.is_empty() ||
+            self.peers.is_empty() ||
+            self.network.is_initially_syncing() ||
+            self.network.tx_gossip_disabled()
+        {
+            return propagated
+        }
+
+        let mut peers = self
+            .peers
+            .iter_mut()
+            .filter_map(|(peer_id, peer)| {
+                self.policies.propagation_policy().can_propagate(peer).then_some(*peer_id)
+            })
+            .collect::<Vec<_>>();
+        peers.truncate((peers.len() as f64).sqrt() as usize);
+        if peers.is_empty() {
+            return propagated
+        }
+
+        debug!(
+            target: "net::tx",
+            txs = hashes.len(),
+            peers = peers.len(),
+            "Reannouncing local pending transactions"
+        );
+
+        for peer_id in peers {
+            if let Some(peer_propagated) =
+                self.propagate_hashes_to_peer(hashes.clone(), peer_id, PropagationMode::Forced)
+            {
+                for (hash, kinds) in peer_propagated.0 {
+                    propagated.0.entry(hash).or_default().extend(kinds);
+                }
+            }
+        }
+
+        propagated
     }
 
     /// Request handler for an incoming request for transactions
@@ -1606,6 +1689,10 @@ where
             this.on_new_pending_transactions(new_txs);
         }
 
+        if this.reannounce_local_transactions.poll_tick(cx).is_ready() {
+            this.reannounce_local_pending_transactions(Instant::now());
+        }
+
         // Advance incoming transaction events (stream new txns/announcements from
         // network manager and queue for import to pool/fetch txns).
         //
@@ -1768,6 +1855,23 @@ impl<T: SignedTransaction> PropagateTransaction<T> {
     fn tx_hash(&self) -> &TxHash {
         self.transaction.tx_hash()
     }
+}
+
+fn transaction_hashes_to_reannounce<T: PoolTransaction>(
+    pending: impl IntoIterator<Item = Arc<ValidPoolTransaction<T>>>,
+    now: Instant,
+    reannounce_time: Duration,
+) -> Vec<TxHash> {
+    pending
+        .into_iter()
+        .filter(|tx| {
+            tx.propagate &&
+                tx.is_local() &&
+                now.saturating_duration_since(tx.timestamp) >= reannounce_time
+        })
+        .map(|tx| *tx.hash())
+        .take(DEFAULT_MAX_COUNT_REANNOUNCED_LOCAL_TRANSACTIONS)
+        .collect()
 }
 
 /// Helper type to construct the appropriate message to send to the peer based on whether the peer
@@ -2202,6 +2306,7 @@ mod tests {
     use reth_transaction_pool::{
         error::{Eip4844PoolTransactionError, InvalidPoolTransactionError, PoolError},
         test_utils::{testing_pool, MockTransaction, MockTransactionFactory, TestPool},
+        TransactionOrigin,
     };
     use secp256k1::SecretKey;
     use std::{
@@ -3082,6 +3187,96 @@ mod tests {
 
         let peer = tx_manager.peers.get(&peer_id).expect("peer should exist");
         assert!(peer.seen_transactions.contains(tx.get_hash()));
+    }
+
+    #[test]
+    fn test_transaction_hashes_to_reannounce_filters_local_age_and_propagation() {
+        let mut factory = MockTransactionFactory::default();
+        let now = Instant::now();
+
+        let mut old_local =
+            factory.validated_with_origin(TransactionOrigin::Local, MockTransaction::eip1559());
+        old_local.propagate = true;
+        old_local.timestamp = now - Duration::from_secs(60);
+        let old_local_hash = *old_local.hash();
+
+        let mut fresh_local =
+            factory.validated_with_origin(TransactionOrigin::Local, MockTransaction::eip1559());
+        fresh_local.propagate = true;
+        fresh_local.timestamp = now - Duration::from_secs(59);
+
+        let mut old_external =
+            factory.validated_with_origin(TransactionOrigin::External, MockTransaction::eip1559());
+        old_external.propagate = true;
+        old_external.timestamp = now - Duration::from_secs(60);
+
+        let mut old_local_no_propagation =
+            factory.validated_with_origin(TransactionOrigin::Local, MockTransaction::eip1559());
+        old_local_no_propagation.propagate = false;
+        old_local_no_propagation.timestamp = now - Duration::from_secs(60);
+
+        let hashes = transaction_hashes_to_reannounce(
+            vec![
+                Arc::new(old_local),
+                Arc::new(fresh_local),
+                Arc::new(old_external),
+                Arc::new(old_local_no_propagation),
+            ],
+            now,
+            Duration::from_secs(60),
+        );
+
+        assert_eq!(hashes, vec![old_local_hash]);
+    }
+
+    #[test]
+    fn test_transaction_hashes_to_reannounce_respects_max_per_interval() {
+        let mut factory = MockTransactionFactory::default();
+        let now = Instant::now();
+        let pending = (0..(DEFAULT_MAX_COUNT_REANNOUNCED_LOCAL_TRANSACTIONS + 1))
+            .map(|_| {
+                let mut tx = factory
+                    .validated_with_origin(TransactionOrigin::Local, MockTransaction::eip1559());
+                tx.propagate = true;
+                tx.timestamp = now - Duration::from_secs(60);
+                Arc::new(tx)
+            })
+            .collect::<Vec<_>>();
+
+        let hashes = transaction_hashes_to_reannounce(pending, now, Duration::from_secs(60));
+
+        assert_eq!(hashes.len(), DEFAULT_MAX_COUNT_REANNOUNCED_LOCAL_TRANSACTIONS);
+    }
+
+    #[tokio::test]
+    async fn test_reannounce_transaction_hashes_force_hashes_to_sqrt_peers() {
+        reth_tracing::init_test_tracing();
+
+        let (mut tx_manager, network) = new_tx_manager().await;
+        network.handle().update_sync_state(SyncState::Idle);
+
+        let mut factory = MockTransactionFactory::default();
+        let tx = factory.create_eip1559();
+        let hash = *tx.hash();
+
+        tx_manager
+            .pool
+            .add_transaction(TransactionOrigin::Local, tx.transaction.clone())
+            .await
+            .unwrap();
+
+        for _ in 0..4 {
+            let peer_id = PeerId::random();
+            let (mut peer, _rx) = new_mock_session(peer_id, EthVersion::Eth68);
+            peer.seen_transactions.insert(hash);
+            tx_manager.peers.insert(peer_id, peer);
+        }
+
+        let propagated = tx_manager.reannounce_transaction_hashes(vec![hash]);
+        let kinds = propagated.0.get(&hash).unwrap();
+
+        assert_eq!(kinds.len(), 2);
+        assert!(kinds.iter().all(PropagateKind::is_hash));
     }
 
     #[tokio::test]

--- a/crates/node/builder/src/builder/mod.rs
+++ b/crates/node/builder/src/builder/mod.rs
@@ -841,10 +841,13 @@ impl<Node: FullNodeTypes> BuilderContext<Node> {
             + 'static,
         Node::Provider: BlockReaderFor<N>,
     {
+        let mut tx_config = self.config().network.transactions_manager_config();
+        tx_config.reannounce_time = self.config().txpool.reannounce_time;
+
         self.start_network_with(
             builder,
             pool,
-            self.config().network.transactions_manager_config(),
+            tx_config,
             self.config().network.tx_propagation_policy,
         )
     }

--- a/crates/node/core/src/args/network.rs
+++ b/crates/node/core/src/args/network.rs
@@ -30,7 +30,8 @@ use reth_network::{
                 DEFAULT_MAX_COUNT_CONCURRENT_REQUESTS_PER_PEER,
             },
             tx_manager::{
-                DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS, DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER,
+                DEFAULT_MAX_COUNT_PENDING_POOL_IMPORTS,
+                DEFAULT_MAX_COUNT_TRANSACTIONS_SEEN_BY_PEER, DEFAULT_REANNOUNCE_TIME,
             },
         },
         TransactionFetcherConfig, TransactionPropagationMode, TransactionsManagerConfig,
@@ -471,6 +472,7 @@ impl NetworkArgs {
             max_transactions_seen_by_peer_history: self.max_seen_tx_history,
             propagation_mode: self.propagation_mode,
             ingress_policy: self.tx_ingress_policy,
+            reannounce_time: DEFAULT_REANNOUNCE_TIME,
         }
     }
 

--- a/crates/node/core/src/args/txpool.rs
+++ b/crates/node/core/src/args/txpool.rs
@@ -5,6 +5,7 @@ use alloy_eips::eip1559::{ETHEREUM_BLOCK_GAS_LIMIT_30M, MIN_PROTOCOL_BASE_FEE};
 use alloy_primitives::Address;
 use clap::{builder::Resettable, Args};
 use reth_cli_util::{parse_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms};
+use reth_network::transactions::constants::tx_manager::DEFAULT_REANNOUNCE_TIME;
 use reth_transaction_pool::{
     blobstore::disk::DEFAULT_MAX_CACHED_BLOBS,
     maintain::MAX_QUEUED_TRANSACTION_LIFETIME,
@@ -52,6 +53,7 @@ pub struct DefaultTxPoolValues {
     new_tx_listener_buffer_size: usize,
     max_new_pending_txs_notifications: usize,
     max_queued_lifetime: Duration,
+    reannounce_time: Duration,
     transactions_backup_path: Option<PathBuf>,
     disable_transactions_backup: bool,
     max_batch_size: usize,
@@ -230,6 +232,12 @@ impl DefaultTxPoolValues {
         self
     }
 
+    /// Set the default local transaction reannounce threshold.
+    pub const fn with_reannounce_time(mut self, v: Duration) -> Self {
+        self.reannounce_time = v;
+        self
+    }
+
     /// Set the default transactions backup path
     pub fn with_transactions_backup_path(mut self, v: Option<PathBuf>) -> Self {
         self.transactions_backup_path = v;
@@ -279,6 +287,7 @@ impl Default for DefaultTxPoolValues {
             new_tx_listener_buffer_size: NEW_TX_LISTENER_BUFFER_SIZE,
             max_new_pending_txs_notifications: MAX_NEW_PENDING_TXS_NOTIFICATIONS,
             max_queued_lifetime: MAX_QUEUED_TRANSACTION_LIFETIME,
+            reannounce_time: DEFAULT_REANNOUNCE_TIME,
             transactions_backup_path: None,
             disable_transactions_backup: false,
             max_batch_size: 1,
@@ -395,6 +404,12 @@ pub struct TxPoolArgs {
     #[arg(long = "txpool.lifetime", value_parser = parse_duration_from_secs_or_ms, value_name = "DURATION", default_value = format_duration_as_secs_or_ms(DefaultTxPoolValues::get_global().max_queued_lifetime))]
     pub max_queued_lifetime: Duration,
 
+    /// Age threshold for hash-only reannouncement of local pending transactions.
+    ///
+    /// Default is effectively disabled at 10 years. Minimum is 1 minute.
+    #[arg(long = "txpool.reannouncetime", alias = "txpool.reannounce-time", value_parser = parse_duration_from_secs_or_ms, value_name = "DURATION", default_value = format_duration_as_secs_or_ms(DefaultTxPoolValues::get_global().reannounce_time))]
+    pub reannounce_time: Duration,
+
     /// Path to store the local transaction backup at, to survive node restarts.
     #[arg(long = "txpool.transactions-backup", alias = "txpool.journal", value_name = "PATH", default_value = Resettable::from(DefaultTxPoolValues::get_global().transactions_backup_path.as_ref().map(|v| v.to_string_lossy().into())))]
     pub transactions_backup_path: Option<PathBuf>,
@@ -461,6 +476,7 @@ impl Default for TxPoolArgs {
             new_tx_listener_buffer_size,
             max_new_pending_txs_notifications,
             max_queued_lifetime,
+            reannounce_time,
             transactions_backup_path,
             disable_transactions_backup,
             max_batch_size,
@@ -493,6 +509,7 @@ impl Default for TxPoolArgs {
             new_tx_listener_buffer_size,
             max_new_pending_txs_notifications,
             max_queued_lifetime,
+            reannounce_time,
             transactions_backup_path,
             disable_transactions_backup,
             max_batch_size,
@@ -622,6 +639,7 @@ mod tests {
             new_tx_listener_buffer_size: 256,
             max_new_pending_txs_notifications: 128,
             max_queued_lifetime: Duration::from_secs(7200),
+            reannounce_time: Duration::from_secs(1200),
             transactions_backup_path: Some(PathBuf::from("/tmp/txpool-backup")),
             disable_transactions_backup: false,
             max_batch_size: 10,
@@ -681,6 +699,8 @@ mod tests {
             "128",
             "--txpool.lifetime",
             "7200",
+            "--txpool.reannouncetime",
+            "1200",
             "--txpool.transactions-backup",
             "/tmp/txpool-backup",
             "--txpool.max-batch-size",

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -672,6 +672,13 @@ TxPool:
 
           [default: 10800]
 
+      --txpool.reannouncetime <DURATION>
+          Age threshold for hash-only reannouncement of local pending transactions.
+
+          Default is effectively disabled at 10 years. Minimum is 1 minute.
+
+          [default: 315360000]
+
       --txpool.transactions-backup <PATH>
           Path to store the local transaction backup at, to survive node restarts
 


### PR DESCRIPTION
Cherry-picks commit 8ebf318e32dfe2159664c50f75f8494665a2a8ce
("feat(txpool): reannounce local pending transactions #115") from bnb-chain/reth onto develop-v2.

Adds periodic re-announcement of local pending transactions to peers that only received hashes (ETH68+), preventing transactions from getting stuck when peers fail to fetch them.

- New `--txpool.reannouncetime` CLI flag (default 1h) to configure the age threshold
- Background task re-announces eligible transactions once per announcement interval
- Only re-announces transactions that originated locally and haven't been seen by peers

Next commit to rebase: 1f4b44ca09dd0bfef58d498c88bbd0e2c68b0e7c