### PR TITLE
chore: add pr template (cherry-pick #128)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### Description
+
+add a description of your changes here...
+
+### Rationale
+
+tell us why we need these changes...
+
+### Example
+
+add an example CLI or API response...
+
+### Changes
+
+Notable changes: 
+* add each change in a bullet point here
+* ...
+
+### Potential Impacts
+* add potential impacts for other components here
+* ...


### PR DESCRIPTION
Cherry-picks commit a4d428dec2e3bc0cb4db141f7a5f62e83afd6a3e
("chore: add pr template #128") from bnb-chain/reth onto develop-v2.

Adds a GitHub pull request template (`.github/pull_request_template.md`) to standardize PR descriptions across the repository.

Next commit to rebase: 1f4b44ca09dd0bfef58d498c88bbd0e2c68b0e7c