### PR TITLE
chore: point reth-core crates to v0.1.1-v2 branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7809,8 +7809,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96e584e01478c951911946a7864f18e967c1cd90965e136e2d1b51aa3da9126"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.1.1-v2#5e11acfdc8e02201f3e83635b7ff9724ab36f63a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7830,8 +7829,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c342ae46f5a886b8bf506205b9501b1032b896defd0f4f156edb423007fef880"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.1.1-v2#5e11acfdc8e02201f3e83635b7ff9724ab36f63a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9517,8 +9515,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca36e245593498020c31e707154fc13391164eb90444da76d67361f646e7669"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.1.1-v2#5e11acfdc8e02201f3e83635b7ff9724ab36f63a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10067,8 +10064,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-traits"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ebbc3cc6f1808c2838bf8da9928f3ef9b8a6f969c6522174c1598ddb34bc0f"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.1.1-v2#5e11acfdc8e02201f3e83635b7ff9724ab36f63a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10602,8 +10598,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a621aef55fe4da8935abede9d1d105f227bcb673f212b3575a748a6a2f8f688e"
+source = "git+https://github.com/bnb-chain/reth-core.git?branch=v0.1.1-v2#5e11acfdc8e02201f3e83635b7ff9724ab36f63a"
 dependencies = [
  "zstd",
 ]
@@ -14013,28 +14008,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "reth-codecs"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=main#c75e1970c2bb0dd6b7c522841d490237e4c5f756"
-
-[[patch.unused]]
-name = "reth-codecs-derive"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=main#c75e1970c2bb0dd6b7c522841d490237e4c5f756"
-
-[[patch.unused]]
-name = "reth-primitives-traits"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=main#c75e1970c2bb0dd6b7c522841d490237e4c5f756"
-
-[[patch.unused]]
-name = "reth-rpc-traits"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=main#c75e1970c2bb0dd6b7c522841d490237e4c5f756"
-
-[[patch.unused]]
-name = "reth-zstd-compressors"
-version = "0.3.0"
-source = "git+https://github.com/bnb-chain/reth-core.git?branch=main#c75e1970c2bb0dd6b7c522841d490237e4c5f756"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,8 +326,8 @@ reth-cli = { path = "crates/cli/cli" }
 reth-cli-commands = { path = "crates/cli/commands" }
 reth-cli-runner = { path = "crates/cli/runner" }
 reth-cli-util = { path = "crates/cli/util" }
-reth-codecs = { version = "0.1.1", default-features = false }
-reth-codecs-derive = "0.1.1"
+reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.1.1-v2", default-features = false }
+reth-codecs-derive = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.1.1-v2" }
 reth-config = { path = "crates/config", default-features = false }
 reth-consensus = { path = "crates/consensus/consensus", default-features = false }
 reth-consensus-common = { path = "crates/consensus/common", default-features = false }
@@ -395,7 +395,7 @@ reth-payload-builder-primitives = { path = "crates/payload/builder-primitives" }
 reth-payload-primitives = { path = "crates/payload/primitives" }
 reth-payload-validator = { path = "crates/payload/validator" }
 reth-payload-util = { path = "crates/payload/util" }
-reth-primitives-traits = { version = "0.1.1", default-features = false }
+reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.1.1-v2", default-features = false }
 reth-provider = { path = "crates/storage/provider" }
 reth-prune = { path = "crates/prune/prune" }
 reth-prune-types = { path = "crates/prune/types", default-features = false }
@@ -411,7 +411,7 @@ reth-rpc-eth-types = { path = "crates/rpc/rpc-eth-types", default-features = fal
 reth-rpc-layer = { path = "crates/rpc/rpc-layer" }
 reth-rpc-server-types = { path = "crates/rpc/rpc-server-types" }
 reth-rpc-convert = { path = "crates/rpc/rpc-convert" }
-reth-rpc-traits = { version = "0.1.1", default-features = false }
+reth-rpc-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.1.1-v2", default-features = false }
 reth-stages = { path = "crates/stages/stages" }
 reth-stages-api = { path = "crates/stages/api" }
 reth-stages-types = { path = "crates/stages/types", default-features = false }
@@ -430,7 +430,7 @@ reth-trie-common = { path = "crates/trie/common", default-features = false }
 reth-trie-db = { path = "crates/trie/db" }
 reth-trie-parallel = { path = "crates/trie/parallel" }
 reth-trie-sparse = { path = "crates/trie/sparse", default-features = false }
-reth-zstd-compressors = { version = "0.1.1", default-features = false }
+reth-zstd-compressors = { git = "https://github.com/bnb-chain/reth-core.git", branch = "v0.1.1-v2", default-features = false }
 
 # triedb
 # Note: To enable io-uring support, add `io-uring = ["rust-eth-triedb/io-uring"]` to the [features] section
@@ -716,13 +716,6 @@ reth-metrics = { path = "crates/metrics" }
 # This is needed because rust-eth-triedb depends on bnb-chain/reth.git
 [patch."https://github.com/bnb-chain/reth.git"]
 reth-metrics = { path = "crates/metrics" }
-
-[patch.crates-io]
-reth-primitives-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "main" }
-reth-codecs = { git = "https://github.com/bnb-chain/reth-core.git", branch = "main" }
-reth-codecs-derive = { git = "https://github.com/bnb-chain/reth-core.git", branch = "main" }
-reth-rpc-traits = { git = "https://github.com/bnb-chain/reth-core.git", branch = "main" }
-reth-zstd-compressors = { git = "https://github.com/bnb-chain/reth-core.git", branch = "main" }
 
 # alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }
 # alloy-contract = { git = "https://github.com/alloy-rs/alloy", rev = "3049f232fbb44d1909883e154eb38ec5962f53a3" }

--- a/deny.toml
+++ b/deny.toml
@@ -12,10 +12,12 @@ ignore = [
     "RUSTSEC-2025-0141",
     # https://rustsec.org/advisories/RUSTSEC-2023-0089 atomic-polyfill is unmaintained, transitive dep via test-fuzz
     "RUSTSEC-2023-0089",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0002 lru upgrade requires a discv5 bump first
-    "RUSTSEC-2026-0002",
     # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand unsoundness with custom logger, no fix available yet
     "RUSTSEC-2026-0097",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0105 core2 is unmaintained
+    "RUSTSEC-2026-0105",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0104 rustls-webpki vulnerability, no fix available yet
+    "RUSTSEC-2026-0104",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Switches the `[patch.crates-io]` overrides for all five `bnb-chain/reth-core` crates from `main` to the `v0.1.1-v2` release branch.