### PR TITLE
fix: resolve some issues in cross region test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,20 @@ Reth is a high-performance Ethereum execution client written in Rust, focusing o
    RUSTFLAGS="-D warnings" cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked
    ```
 
+   **Doc comments — `clippy::doc_markdown` is enforced.** Any bare
+   identifier that matches a type, module, constant, path, or CamelCase
+   name in a `///` or `//!` comment must be wrapped in backticks, or
+   clippy fails under `-D warnings`. Examples:
+   - `tree_state` (module), `MockEthProvider` (type), `B256::ZERO`
+     (path), `HeaderNotFound` (variant) → all need backticks.
+   - Plain English words, arguments documented via `?arg`, and code
+     inside `` ```rust `` blocks do not.
+
+   Also backtick-wrap crate/URL-looking tokens: `bnb-chain/reth`,
+   `paradigmxyz/reth`, `std::fs`, etc. When unsure, run clippy before
+   committing — the fix is usually a one-character change but the
+   rebuild to verify is slow.
+
 3. **Testing**: Use nextest for faster test execution
    ```bash
    cargo nextest run --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10270,6 +10270,7 @@ dependencies = [
  "revm-state",
  "rocksdb",
  "rust-eth-triedb",
+ "rust-eth-triedb-common",
  "strum 0.27.2",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9371,6 +9371,7 @@ dependencies = [
  "fdlimit",
  "futures",
  "jsonrpsee",
+ "metrics",
  "parking_lot",
  "rayon",
  "reth-basic-payload-builder",

--- a/crates/cli/runner/src/lib.rs
+++ b/crates/cli/runner/src/lib.rs
@@ -217,8 +217,11 @@ pub struct CliContext {
     pub task_executor: TaskExecutor,
 }
 
-/// Default timeout for graceful shutdown of tasks.
-const DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+/// Default timeout for graceful shutdown of tasks. Must cover the
+/// engine-tree's final `persist_until_complete` flush of every in-memory
+/// canonical block up to the head; 5 s is not enough with production-validator
+/// buffer sizes on debug builds or slow disks.
+const DEFAULT_GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
 
 /// Configuration for [`CliRunner`].
 #[derive(Debug, Clone)]

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -1,22 +1,25 @@
 use crate::metrics::PersistenceMetrics;
+use alloy_consensus::EMPTY_ROOT_HASH;
 use alloy_eips::BlockNumHash;
 use crossbeam_channel::Sender as CrossbeamSender;
 use reth_chain_state::ExecutedBlock;
 use reth_errors::ProviderError;
 use reth_ethereum_primitives::EthPrimitives;
-use reth_primitives_traits::NodePrimitives;
+use reth_primitives_traits::{AlloyBlockHeader, NodePrimitives};
 use reth_provider::{
     providers::ProviderNodeTypes, BlockExecutionWriter, BlockHashReader, ChainStateBlockWriter,
-    DBProvider, DatabaseProviderFactory, ProviderFactory, SaveBlocksMode,
+    DBProvider, DatabaseProviderFactory, HeaderProvider, ProviderFactory, SaveBlocksMode,
 };
 use reth_prune::{PrunerError, PrunerOutput, PrunerWithFactory};
 use reth_stages_api::{MetricEvent, MetricEventsSender};
+use reth_trie::{HashedPostState, KeccakKeyHasher};
+use rust_eth_triedb::{get_global_triedb, triedb_manager::is_triedb_active};
 use std::{
     sync::mpsc::{Receiver, SendError, Sender},
     time::Instant,
 };
 use thiserror::Error;
-use tracing::{debug, error};
+use tracing::{debug, error, info, warn};
 
 /// Writes parts of reth's in memory tree state to the database and static files.
 ///
@@ -128,6 +131,82 @@ where
         let provider_rw = self.provider.database_provider_rw()?;
 
         let new_tip_hash = provider_rw.block_hash(new_tip_num)?;
+
+        // Rewind direction (pathdb ahead of new tip, e.g. after a reorg where the
+        // miner's blocks were flushed to pathdb but the canonical chain rolled
+        // back). pathdb must flush the reverse diff BEFORE the MDBX commit so
+        // that any crash window leaves pathdb no higher than MDBX. Reading the
+        // changeset must also happen before `remove_block_and_execution_above`
+        // erases it — hence `take_block_and_execution_above` here instead.
+        if is_triedb_active() {
+            let mut triedb = get_global_triedb();
+            match triedb.latest_persist_state() {
+                Ok((pathdb_block, pathdb_root)) if pathdb_block > new_tip_num => {
+                    let chain = provider_rw.take_block_and_execution_above(new_tip_num)?;
+                    let execution_state = chain.execution_outcome();
+
+                    let hashed_post_state = HashedPostState::from_bundle_state_to_unwind::<
+                        KeccakKeyHasher,
+                    >(execution_state.bundle.state());
+                    let triedb_hashed_post_state = hashed_post_state.to_triedb_hashed_post_state();
+
+                    let validate_root = if new_tip_num == 0 {
+                        EMPTY_ROOT_HASH
+                    } else {
+                        provider_rw
+                            .sealed_header(new_tip_num)?
+                            .map(|h| h.state_root())
+                            .ok_or_else(|| ProviderError::HeaderNotFound(new_tip_num.into()))?
+                    };
+
+                    info!(
+                        target: "engine::persistence",
+                        pathdb_block,
+                        ?pathdb_root,
+                        new_tip_num,
+                        ?validate_root,
+                        "Rewinding pathdb to match new canonical tip after reorg",
+                    );
+
+                    let (new_root, difflayer) = triedb
+                        .intermediate_and_commit_hashed_post_state(
+                            pathdb_root,
+                            None,
+                            &triedb_hashed_post_state,
+                            None,
+                        )
+                        .map_err(ProviderError::other)?;
+
+                    if new_root != validate_root {
+                        return Err(ProviderError::other(std::io::Error::other(format!(
+                            "pathdb rewind root mismatch: new_root={new_root:?}, expected={validate_root:?}, new_tip={new_tip_num}"
+                        )))
+                        .into());
+                    }
+
+                    triedb
+                        .flush(new_tip_num, new_root, &Some(difflayer))
+                        .map_err(ProviderError::other)?;
+
+                    provider_rw.commit()?;
+
+                    debug!(
+                        target: "engine::persistence",
+                        ?new_tip_num, ?new_tip_hash,
+                        "Removed blocks from disk (with pathdb rewind)",
+                    );
+                    self.metrics.remove_blocks_above_duration_seconds.record(start_time.elapsed());
+                    return Ok(new_tip_hash.map(|hash| BlockNumHash { hash, number: new_tip_num }));
+                }
+                Ok(_) => {}
+                Err(err) => warn!(
+                    target: "engine::persistence",
+                    ?err,
+                    "Failed to query pathdb latest_persist_state during reorg",
+                ),
+            }
+        }
+
         provider_rw.remove_block_and_execution_above(new_tip_num)?;
         provider_rw.commit()?;
 
@@ -150,8 +229,25 @@ where
         if last_block.is_some() {
             let provider_rw = self.provider.database_provider_rw()?;
 
-            provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
+            // Forward direction. save_blocks validates the state transition and
+            // defers the rocksdb flush; we commit MDBX first so MDBX is the
+            // source of truth for the canonical tip, then apply the pathdb
+            // flush. A crash between the two leaves pathdb lagging MDBX, which
+            // is recoverable; the reverse would be the "pathdb gap" deadlock.
+            let pending_triedb_flushes = provider_rw.save_blocks(blocks, SaveBlocksMode::Full)?;
             provider_rw.commit()?;
+
+            for pending in pending_triedb_flushes {
+                let block_number = pending.block_number();
+                if let Err(err) = pending.apply() {
+                    error!(
+                        target: "engine::persistence",
+                        ?err, block_number,
+                        "Failed to apply deferred triedb flush after MDBX commit",
+                    );
+                    return Err(err.into());
+                }
+            }
         }
 
         debug!(target: "engine::persistence", first=?first_block, last=?last_block, "Saved range of blocks");

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3215,16 +3215,25 @@ where
         Ok(None)
     }
 
-    /// Query the header and TD of the given block number and hash.
-    /// If the block is not found, the header and TD of the last block will be returned.
+    /// Query the header and TD of the given `(number, hash)`.
+    ///
+    /// - If `hash` is on the canonical chain, returns the provider's header and TD directly.
+    /// - If `hash` is an in-memory fork block held in `tree_state`, walks its parent chain
+    ///   (accumulating each fork block's difficulty) until a canonical ancestor is reached, and
+    ///   adds the canonical TD as the base.
+    /// - Returns `Ok((fork_header, None))` when a canonical ancestor is found but its TD entry is
+    ///   missing, or when the walk falls below `last_block_number` and the final canonical lookup
+    ///   also fails. Callers treat `None` as "TD unknown".
+    /// - Returns `Err(ProviderError::HeaderNotFound)` when `hash` itself is in neither place, or
+    ///   when the walk above `last_block_number` reaches a parent that is in neither.
     pub fn query_header_with_td(
         &self,
         number: BlockNumber,
         hash: BlockHash,
     ) -> ProviderResult<(N::BlockHeader, Option<U256>)> {
-        // query header td from canonical chain
+        // Canonical DB hit: return header and TD directly.
         if let Some(block_number) = self.provider.block_number(hash)? {
-            tracing::debug!(target: "engine::tree", number=?number, hash=?hash, "querying TD from canonical chain");
+            tracing::debug!(target: "engine::tree", ?number, ?hash, "querying TD from canonical chain");
             let header = self
                 .provider
                 .header_by_number(block_number)?
@@ -3233,9 +3242,7 @@ where
             return Ok((header, td))
         }
 
-        // query header td from last block number
-        tracing::debug!(target: "engine::tree", number=?number, hash=?hash, "querying TD from fork headers");
-        let mut ret_td = U256::ZERO;
+        tracing::debug!(target: "engine::tree", ?number, ?hash, "querying TD from fork headers");
         let ret_header = self
             .state
             .tree_state
@@ -3243,71 +3250,76 @@ where
             .get(&hash)
             .map(|b| b.recovered_block.clone_header())
             .ok_or(ProviderError::HeaderNotFound(hash.into()))?;
-        ret_td = ret_td.wrapping_add(ret_header.difficulty());
+        let mut ret_td = ret_header.difficulty();
 
         let last_block_number = self.provider.last_block_number()?;
-        let (mut current_number, mut current_hash) = (number - 1, ret_header.parent_hash());
+        let mut current_number = number - 1;
+        let mut current_hash = ret_header.parent_hash();
+
+        // Walk fork parents while still above the persisted canonical tip.
+        // Each hop either hits a canonical ancestor (done) or steps to the
+        // next in-memory fork parent; a parent that is in neither place at
+        // this level is a real gap and surfaces as `HeaderNotFound`.
         while current_number >= last_block_number {
-            match self.provider.block_number(current_hash)? {
-                Some(block_number) => {
-                    // add canonical chain td
-                    match self.provider.header_td_by_number(block_number)? {
-                        Some(td) => {
-                            ret_td = ret_td.wrapping_add(td);
-                            return Ok((ret_header, Some(ret_td)))
-                        }
-                        None => {
-                            tracing::warn!(target: "engine::tree", current_number=?current_number, current_hash=?current_hash,
-                                "header td not found for block number, just return none");
-                            return Ok((ret_header, None))
-                        }
-                    }
-                }
-                None => {
-                    // continue to query forks
-                    let header = self
-                        .state
-                        .tree_state
-                        .blocks_by_hash
-                        .get(&current_hash)
-                        .map(|b| b.recovered_block.header())
-                        .ok_or(ProviderError::HeaderNotFound(current_hash.into()))?;
-                    current_hash = header.parent_hash();
-                    ret_td = ret_td.wrapping_add(header.difficulty());
-                }
+            if let Some(block_number) = self.provider.block_number(current_hash)? {
+                return self.resolve_fork_td(ret_header, ret_td, block_number)
             }
+            let parent = self
+                .state
+                .tree_state
+                .blocks_by_hash
+                .get(&current_hash)
+                .map(|b| b.recovered_block.clone_header())
+                .ok_or(ProviderError::HeaderNotFound(current_hash.into()))?;
+            ret_td = ret_td.wrapping_add(parent.difficulty());
+            current_hash = parent.parent_hash();
             current_number -= 1;
         }
 
-        if current_number < last_block_number {
-            // The loop walks fork blocks backwards while `current_number >=
-            // last_block_number`. When the fork attaches exactly at the tip of
-            // the canonical chain (fork parent is at `last_block_number`), the
-            // loop body never runs and we fall through with current_hash
-            // pointing at a canonical ancestor. Do one more lookup instead of
-            // returning None — otherwise the fork reports TD=None and loses the
-            // td-comparison race to peers that look it up correctly.
-            if let Some(block_number) = self.provider.block_number(current_hash)? {
-                return match self.provider.header_td_by_number(block_number)? {
-                    Some(td) => {
-                        ret_td = ret_td.wrapping_add(td);
-                        Ok((ret_header, Some(ret_td)))
-                    }
-                    None => {
-                        tracing::warn!(
-                            target: "engine::tree",
-                            ?current_number, ?current_hash,
-                            "header td not found for canonical ancestor, return none",
-                        );
-                        Ok((ret_header, None))
-                    }
-                }
-            }
-            tracing::warn!(target: "engine::tree", current_number=?current_number, current_hash=?current_hash, last_block_number=?last_block_number,
-                 "cannot find header td for block number, query beyond last block number, just return none");
-            return Ok((ret_header, None))
+        // Fork at or below the canonical tip — the loop above was skipped,
+        // so `current_hash` still points at the fork's direct parent,
+        // which is typically a canonical ancestor we can resolve with one
+        // more lookup.
+        //
+        //   canonical:  …──●──●   ← tip (last_block_number)
+        //                     ↑
+        //                     └── current_hash: probe once more
+        //
+        // If this lookup also misses, return `Ok((ret_header, None))`
+        // ("TD unknown"), not `Err` — callers depend on that contract.
+        if let Some(block_number) = self.provider.block_number(current_hash)? {
+            return self.resolve_fork_td(ret_header, ret_td, block_number)
         }
-        Ok((ret_header, Some(ret_td)))
+        tracing::warn!(
+            target: "engine::tree",
+            ?current_number, ?current_hash, ?last_block_number,
+            "fork walked below last_block_number without hitting a canonical ancestor",
+        );
+        Ok((ret_header, None))
+    }
+
+    /// Combines the accumulated fork-chain difficulty `ret_td` with the TD
+    /// of the canonical ancestor at `block_number` to produce the total
+    /// difficulty of the fork block identified by `ret_header`. If the
+    /// canonical TD entry is missing, returns `(ret_header, None)` —
+    /// callers treat `None` as "TD unknown".
+    fn resolve_fork_td(
+        &self,
+        ret_header: N::BlockHeader,
+        ret_td: U256,
+        block_number: BlockNumber,
+    ) -> ProviderResult<(N::BlockHeader, Option<U256>)> {
+        Ok(match self.provider.header_td_by_number(block_number)? {
+            Some(td) => (ret_header, Some(ret_td.wrapping_add(td))),
+            None => {
+                tracing::warn!(
+                    target: "engine::tree",
+                    ?block_number,
+                    "canonical ancestor has no TD entry; returning None",
+                );
+                (ret_header, None)
+            }
+        })
     }
 }
 

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3245,6 +3245,29 @@ where
         }
 
         if current_number < last_block_number {
+            // The loop walks fork blocks backwards while `current_number >=
+            // last_block_number`. When the fork attaches exactly at the tip of
+            // the canonical chain (fork parent is at `last_block_number`), the
+            // loop body never runs and we fall through with current_hash
+            // pointing at a canonical ancestor. Do one more lookup instead of
+            // returning None — otherwise the fork reports TD=None and loses the
+            // td-comparison race to peers that look it up correctly.
+            if let Some(block_number) = self.provider.block_number(current_hash)? {
+                return match self.provider.header_td_by_number(block_number)? {
+                    Some(td) => {
+                        ret_td = ret_td.wrapping_add(td);
+                        Ok((ret_header, Some(ret_td)))
+                    }
+                    None => {
+                        tracing::warn!(
+                            target: "engine::tree",
+                            ?current_number, ?current_hash,
+                            "header td not found for canonical ancestor, return none",
+                        );
+                        Ok((ret_header, None))
+                    }
+                }
+            }
             tracing::warn!(target: "engine::tree", current_number=?current_number, current_hash=?current_hash, last_block_number=?last_block_number,
                  "cannot find header td for block number, query beyond last block number, just return none");
             return Ok((ret_header, None))

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -2823,6 +2823,41 @@ where
             Ok(Some(_)) => {}
         }
 
+        // Pathdb gap: when TrieDB is active, executing this block requires either a
+        // chain of in-memory difflayers to bridge back to the pathdb disk layer, or a
+        // parent whose state root equals that disk layer. After a restart the
+        // difflayer chain is empty, and if we reconnect to a fork whose parent
+        // diverges from pathdb's last flush, re-executing would read stale trie nodes
+        // and compute a wrong state root. Buffer as Disconnected so the P2P layer
+        // walks ancestors sequentially until a block touches the disk layer.
+        if rust_eth_triedb::triedb_manager::is_triedb_active() {
+            let has_difflayers =
+                self.state.tree_state.merged_difflayer_by_hash(block_id.parent).is_some();
+            if !has_difflayers {
+                let triedb = rust_eth_triedb::triedb_manager::get_global_triedb();
+                if let Ok((_, persist_root)) = triedb.latest_persist_state() &&
+                    let Ok(Some(parent_header)) = self.sealed_header_by_hash(block_id.parent) &&
+                    parent_header.state_root() != persist_root
+                {
+                    warn!(
+                        target: "engine::tree",
+                        block = ?block_num_hash,
+                        parent = ?block_id.parent,
+                        parent_state_root = ?parent_header.state_root(),
+                        pathdb_persist_root = ?persist_root,
+                        "Triedb pathdb gap: no difflayers and parent state root diverges from disk layer; buffering as Disconnected",
+                    );
+                    let block = convert_to_block(self, input)?;
+                    let missing_ancestor = block.parent_num_hash();
+                    self.state.buffer.insert_block(block);
+                    return Ok(InsertPayloadOk::Inserted(BlockStatus::Disconnected {
+                        head: self.state.tree_state.current_canonical_head,
+                        missing_ancestor,
+                    }));
+                }
+            }
+        }
+
         // determine whether we are on a fork chain by comparing the block number with the
         // canonical head. This is a simple check that is sufficient for the event emission below.
         // A block is considered a fork if its number is less than or equal to the canonical head,

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -2009,6 +2009,17 @@ mod tests {
             }
             other => panic!("Expected PrefetchProofs2 in channel, got {:?}", other),
         }
+
+        // Close worker channels and give the proof workers a brief window to
+        // finish their current jobs and release the RocksDB handles they hold
+        // from `test_provider_factory`. Without this, Linux CI hits
+        // `pthread lock: Invalid argument` at process exit because the static
+        // tokio Runtime (in `get_test_runtime_handle`) is never dropped
+        // gracefully, so workers are killed mid-op while holding RocksDB
+        // background-thread mutexes.
+        drop(task);
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        drop(test_provider);
     }
 
     /// Verifies that BAL messages are processed correctly and generate state updates.
@@ -2049,5 +2060,12 @@ mod tests {
 
         // Should need to wait for the results of those proofs to arrive
         assert!(!should_finish, "Should continue waiting for proofs");
+
+        // Give workers a moment to release their RocksDB handles before
+        // process exit — see `test_pending_message_processed_before_next_iteration`
+        // for the underlying pthread-at-exit issue on Linux CI.
+        drop(task);
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        drop(test_provider);
     }
 }

--- a/crates/engine/tree/src/tree/tests.rs
+++ b/crates/engine/tree/src/tree/tests.rs
@@ -2022,3 +2022,224 @@ mod forkchoice_updated_tests {
         assert_eq!(last_persisted_number, canonical_tip);
     }
 }
+
+// -----------------------------------------------------------------------------
+// Characterization tests for `query_header_with_td`.
+//
+// These lock down the observable behavior of the function across every
+// distinct control-flow path, so a refactor can be verified against the
+// current implementation. With the default `MockEthProvider`, the trait
+// method `header_td_by_number` returns `Ok(None)` and test blocks carry
+// zero difficulty, so the returned `Option<U256>` is always `None` and TD
+// summation is not exercised — what these tests do verify is:
+//
+//   - which header is returned (canonical DB vs in-memory fork)
+//   - whether the call returns `Ok` or `Err(HeaderNotFound(_))`
+//   - which branch resolves each scenario
+// -----------------------------------------------------------------------------
+
+/// Builds a `TestHarness` with nothing pre-populated so each test can set
+/// up canonical DB and `tree_state` directly.
+fn td_query_harness() -> (TestHarness, TestBlockBuilder) {
+    let harness = TestHarness::new(MAINNET.clone());
+    let builder = TestBlockBuilder::eth();
+    (harness, builder)
+}
+
+/// Inserts a block only into the canonical (`MockEthProvider`) side, leaving
+/// `tree_state` untouched.
+fn persist_canonical(harness: &TestHarness, block: &ExecutedBlock) {
+    let recovered = block.recovered_block().clone();
+    harness.persist_blocks(vec![recovered]);
+}
+
+/// Inserts a block only into the in-memory `tree_state`, leaving the
+/// canonical provider untouched.
+fn insert_tree_only(harness: &mut TestHarness, block: &ExecutedBlock) {
+    harness.tree.state.tree_state.insert_executed(block.clone());
+}
+
+#[test]
+fn query_header_with_td_canonical_hit_returns_db_header() {
+    let (mut harness, mut builder) = td_query_harness();
+    let blocks: Vec<_> = builder.get_executed_blocks(0..3).collect();
+    for block in &blocks {
+        persist_canonical(&harness, block);
+    }
+    // Leave tree_state empty so resolution can only come from canonical.
+    let _ = &mut harness;
+
+    let target = blocks[1].recovered_block();
+    let (header, td) = harness
+        .tree
+        .query_header_with_td(target.number(), target.hash())
+        .expect("canonical hit should succeed");
+
+    assert_eq!(header.number, target.number());
+    assert_eq!(SealedHeader::seal_slow(header).hash(), target.hash());
+    assert_eq!(td, None);
+}
+
+#[test]
+fn query_header_with_td_unknown_hash_is_header_not_found() {
+    let (mut harness, mut builder) = td_query_harness();
+    // Populate a couple of canonical blocks just so last_block_number resolves.
+    let blocks: Vec<_> = builder.get_executed_blocks(0..2).collect();
+    for block in &blocks {
+        persist_canonical(&harness, block);
+    }
+    let _ = &mut harness;
+
+    let bogus = B256::random();
+    let err = harness.tree.query_header_with_td(10, bogus).unwrap_err();
+
+    assert_matches!(err, ProviderError::HeaderNotFound(_));
+}
+
+#[test]
+fn query_header_with_td_fork_direct_canonical_parent_above_tip() {
+    // Canonical tip at 0; fork at height 1 whose parent is canonical 0.
+    // Loop condition `0 >= 0` is TRUE, so the main loop runs once and
+    // resolves via its canonical-hit arm.
+    let (mut harness, mut builder) = td_query_harness();
+    let canonical_0 = builder.get_executed_block_with_number(0, B256::ZERO);
+    persist_canonical(&harness, &canonical_0);
+
+    let fork_1 = builder.get_executed_block_with_number(1, canonical_0.recovered_block().hash());
+    insert_tree_only(&mut harness, &fork_1);
+
+    let (header, td) = harness
+        .tree
+        .query_header_with_td(1, fork_1.recovered_block().hash())
+        .expect("fork lookup should succeed");
+
+    assert_eq!(header.number, 1);
+    assert_eq!(
+        SealedHeader::seal_slow(header).hash(),
+        fork_1.recovered_block().hash(),
+        "must return the in-memory fork header, not any canonical header",
+    );
+    assert_eq!(td, None);
+}
+
+#[test]
+fn query_header_with_td_fork_multi_hop_walk_to_canonical() {
+    // Canonical tip at 0; three fork blocks above it (1, 2, 3) in
+    // tree_state. The main loop walks through 3 -> 2 -> 1 in tree_state
+    // and finally resolves at canonical 0.
+    let (mut harness, mut builder) = td_query_harness();
+    let canonical_0 = builder.get_executed_block_with_number(0, B256::ZERO);
+    persist_canonical(&harness, &canonical_0);
+
+    let fork_1 = builder.get_executed_block_with_number(1, canonical_0.recovered_block().hash());
+    let fork_2 = builder.get_executed_block_with_number(2, fork_1.recovered_block().hash());
+    let fork_3 = builder.get_executed_block_with_number(3, fork_2.recovered_block().hash());
+    insert_tree_only(&mut harness, &fork_1);
+    insert_tree_only(&mut harness, &fork_2);
+    insert_tree_only(&mut harness, &fork_3);
+
+    let (header, td) = harness
+        .tree
+        .query_header_with_td(3, fork_3.recovered_block().hash())
+        .expect("fork walk should succeed");
+
+    assert_eq!(header.number, 3);
+    assert_eq!(SealedHeader::seal_slow(header).hash(), fork_3.recovered_block().hash(),);
+    assert_eq!(td, None);
+}
+
+#[test]
+fn query_header_with_td_fork_parent_unknown_above_tip_errors() {
+    // Canonical tip at 0, fork block at height 5 whose parent is neither
+    // canonical nor in tree_state. Main loop runs (5 - 1 = 4 >= 0), hits
+    // the None arm for both provider and tree_state, returns
+    // HeaderNotFound.
+    let (mut harness, mut builder) = td_query_harness();
+    let canonical_0 = builder.get_executed_block_with_number(0, B256::ZERO);
+    persist_canonical(&harness, &canonical_0);
+
+    let orphan = builder.get_executed_block_with_number(5, B256::random());
+    insert_tree_only(&mut harness, &orphan);
+
+    let err = harness.tree.query_header_with_td(5, orphan.recovered_block().hash()).unwrap_err();
+    assert_matches!(err, ProviderError::HeaderNotFound(_));
+}
+
+#[test]
+fn query_header_with_td_equal_height_fork_attaches_at_tip() {
+    // Canonical chain has blocks 0 and 1 (tip = 1). A fork block ALSO at
+    // height 1 sits in tree_state with parent = canonical 0.
+    // `current_number = number - 1 = 0 < last_block_number = 1`, so the
+    // main while-loop body never runs. This is the fallback scenario that
+    // commit 3e06cdbef added: the final canonical lookup on `current_hash`
+    // must resolve, returning the fork header (not the canonical one).
+    let (mut harness, mut builder) = td_query_harness();
+    let canonical_0 = builder.get_executed_block_with_number(0, B256::ZERO);
+    let canonical_1 =
+        builder.get_executed_block_with_number(1, canonical_0.recovered_block().hash());
+    persist_canonical(&harness, &canonical_0);
+    persist_canonical(&harness, &canonical_1);
+
+    let fork_1 = builder.get_executed_block_with_number(1, canonical_0.recovered_block().hash());
+    insert_tree_only(&mut harness, &fork_1);
+
+    let (header, td) = harness
+        .tree
+        .query_header_with_td(1, fork_1.recovered_block().hash())
+        .expect("fork at tip height should resolve via fallback");
+
+    assert_eq!(
+        SealedHeader::seal_slow(header).hash(),
+        fork_1.recovered_block().hash(),
+        "must return the fork header, not the canonical sibling",
+    );
+    assert_eq!(td, None);
+}
+
+#[test]
+fn query_header_with_td_fork_below_tip_direct_canonical_parent() {
+    // Canonical chain 0..4 (tip = 3). A fork block at height 1 with parent
+    // = canonical 0 sits in tree_state. `current_number = 0 < 3`, loop
+    // skipped, fallback resolves via canonical ancestor.
+    let (mut harness, mut builder) = td_query_harness();
+    let canonicals: Vec<_> = builder.get_executed_blocks(0..4).collect();
+    for block in &canonicals {
+        persist_canonical(&harness, block);
+    }
+
+    let fork_1 = builder.get_executed_block_with_number(1, canonicals[0].recovered_block().hash());
+    insert_tree_only(&mut harness, &fork_1);
+
+    let (header, td) = harness
+        .tree
+        .query_header_with_td(1, fork_1.recovered_block().hash())
+        .expect("below-tip fork with canonical parent should resolve");
+
+    assert_eq!(SealedHeader::seal_slow(header).hash(), fork_1.recovered_block().hash(),);
+    assert_eq!(td, None);
+}
+
+#[test]
+fn query_header_with_td_fork_below_tip_unknown_parent_returns_ok_none() {
+    // Canonical tip = 3. Fork at height 1 whose parent is a random hash
+    // that lives in neither canonical nor tree_state. Main loop skipped
+    // (0 < 3). Fallback `block_number(unknown)` is None. This case
+    // returns `Ok((fork_header, None))` — the legacy behavior the caller
+    // depends on (Err here would turn `QueryTd` into a failure).
+    let (mut harness, mut builder) = td_query_harness();
+    let canonicals: Vec<_> = builder.get_executed_blocks(0..4).collect();
+    for block in &canonicals {
+        persist_canonical(&harness, block);
+    }
+
+    let orphan_fork = builder.get_executed_block_with_number(1, B256::random());
+    insert_tree_only(&mut harness, &orphan_fork);
+
+    let (header, td) = harness
+        .tree
+        .query_header_with_td(1, orphan_fork.recovered_block().hash())
+        .expect("below-tip fork with unknown parent must not return Err");
+
+    assert_eq!(SealedHeader::seal_slow(header).hash(), orphan_fork.recovered_block().hash(),);
+    assert_eq!(td, None);
+}

--- a/crates/ethereum/node/tests/e2e/eth.rs
+++ b/crates/ethereum/node/tests/e2e/eth.rs
@@ -187,6 +187,64 @@ async fn test_engine_graceful_shutdown() -> eyre::Result<()> {
 }
 
 #[tokio::test]
+async fn test_engine_graceful_shutdown_via_signal() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let (mut nodes, tasks, wallet) = setup::<EthereumNode>(
+        1,
+        Arc::new(
+            ChainSpecBuilder::default()
+                .chain(MAINNET.chain)
+                .genesis(serde_json::from_str(include_str!("../assets/genesis.json")).unwrap())
+                .cancun_activated()
+                .build(),
+        ),
+        false,
+        eth_payload_attributes,
+    )
+    .await?;
+
+    let mut node = nodes.pop().unwrap();
+
+    let raw_tx = TransactionTestContext::transfer_tx_bytes(1, wallet.inner).await;
+    let tx_hash = node.rpc.inject_tx(raw_tx).await?;
+    let payload = node.advance_block().await?;
+    node.assert_new_block(tx_hash, payload.block().hash(), payload.block().number).await?;
+
+    assert_eq!(node.inner.provider.best_block_number()?, 1, "expected 1 block before shutdown");
+    assert_eq!(node.inner.provider.last_block_number()?, 0, "block should not be persisted yet");
+
+    // Simulate the production SIGTERM path: graceful_shutdown_with_timeout fires the
+    // Shutdown signal every GracefulShutdown future in the node is awaiting, which
+    // drives the consensus engine's graceful arm added by this change. The call
+    // consumes `self` and spins synchronously, so move it to a dedicated OS thread
+    // and keep the tokio runtime alive to drive the actual flush work.
+    let shutdown_thread = std::thread::Builder::new()
+        .name("test-graceful-shutdown".into())
+        .spawn(move || tasks.graceful_shutdown_with_timeout(std::time::Duration::from_secs(30)))
+        .expect("failed to spawn shutdown thread");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+    let mut db_block = 0u64;
+    while std::time::Instant::now() < deadline {
+        db_block = node.inner.provider.last_block_number()?;
+        if db_block == 1 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    let shutdown_completed = shutdown_thread.join().expect("shutdown thread panicked");
+
+    assert_eq!(
+        db_block, 1,
+        "database should have persisted block 1 via graceful signal path (shutdown_completed={shutdown_completed})",
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_testing_build_block_v1_osaka() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
     let tasks = TaskManager::current();

--- a/crates/net/eth-wire/src/errors/p2p.rs
+++ b/crates/net/eth-wire/src/errors/p2p.rs
@@ -68,7 +68,7 @@ pub enum P2PStreamError {
     SendBufferFull,
 
     /// Disconnected error.
-    #[error("disconnected")]
+    #[error("disconnected: {0}")]
     Disconnected(DisconnectReason),
 
     /// Unknown disconnect reason error.
@@ -129,4 +129,21 @@ pub enum PingerError {
     /// An unexpected pong was received while the pinger was in the `Ready` state.
     #[error("pong received while ready")]
     UnexpectedPong,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn p2p_disconnected_display_includes_reason() {
+        let err = P2PStreamError::Disconnected(DisconnectReason::UselessPeer);
+        assert_eq!(format!("{err}"), "disconnected: useless peer");
+    }
+
+    #[test]
+    fn p2p_handshake_disconnected_display_shape_unchanged() {
+        let err = P2PHandshakeError::Disconnected(DisconnectReason::UselessPeer);
+        assert_eq!(format!("{err}"), "disconnected by peer: useless peer");
+    }
 }

--- a/crates/net/network/src/error.rs
+++ b/crates/net/network/src/error.rs
@@ -143,8 +143,7 @@ impl SessionError for EthStreamError {
                             P2PHandshakeError::HelloNotInHandshake |
                             P2PHandshakeError::NonHelloMessageInHandshake |
                             P2PHandshakeError::Disconnected(
-                                DisconnectReason::UselessPeer |
-                                    DisconnectReason::IncompatibleP2PProtocolVersion |
+                                DisconnectReason::IncompatibleP2PProtocolVersion |
                                     DisconnectReason::ProtocolBreach
                             )
                     ) | P2PStreamError::UnknownReservedMessageId(_) |
@@ -152,8 +151,7 @@ impl SessionError for EthStreamError {
                         P2PStreamError::ParseSharedCapability(_) |
                         P2PStreamError::CapabilityNotShared |
                         P2PStreamError::Disconnected(
-                            DisconnectReason::UselessPeer |
-                                DisconnectReason::IncompatibleP2PProtocolVersion |
+                            DisconnectReason::IncompatibleP2PProtocolVersion |
                                 DisconnectReason::ProtocolBreach
                         ) |
                         P2PStreamError::MismatchedProtocolVersion { .. }
@@ -317,11 +315,24 @@ mod tests {
     fn test_is_fatal_disconnect() {
         let err = PendingSessionHandshakeError::Eth(EthStreamError::P2PStreamError(
             P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
-                DisconnectReason::UselessPeer,
+                DisconnectReason::ProtocolBreach,
             )),
         ));
 
         assert!(err.is_fatal_protocol_error());
+    }
+
+    #[test]
+    fn test_useless_peer_not_fatal_during_handshake() {
+        // Cross-region peers frequently tag each other as useless due to skew in
+        // received-head tracking. Treating UselessPeer as fatal removes the peer
+        // from the manager and bans it, starving the node of valid neighbors.
+        let err = PendingSessionHandshakeError::Eth(EthStreamError::P2PStreamError(
+            P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
+                DisconnectReason::UselessPeer,
+            )),
+        ));
+        assert!(!err.is_fatal_protocol_error());
     }
 
     #[test]

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -352,6 +352,11 @@ impl PeersManager {
         // we only need to check the peer id here as the ip address will have been checked at
         // on_incoming_pending_session. We also check if the peer is in the backoff list here.
         if self.ban_list.is_banned_peer(&peer_id) {
+            tracing::warn!(
+                target: "net::peers",
+                ?peer_id, ?addr, reason = "banned_by_list",
+                "rejecting established inbound session",
+            );
             self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
             return;
         }
@@ -359,6 +364,11 @@ impl PeersManager {
         // check if the peer is trustable or not
         let mut is_trusted = self.trusted_peer_ids.contains(&peer_id);
         if self.trusted_nodes_only && !is_trusted {
+            tracing::warn!(
+                target: "net::peers",
+                ?peer_id, ?addr, reason = "trusted_nodes_only",
+                "rejecting established inbound session",
+            );
             self.queued_actions.push_back(PeerAction::DisconnectUntrustedIncoming { peer_id });
             return;
         }
@@ -370,6 +380,11 @@ impl PeersManager {
             Entry::Occupied(mut entry) => {
                 let peer = entry.get_mut();
                 if peer.is_banned() {
+                    tracing::warn!(
+                        target: "net::peers",
+                        ?peer_id, ?addr, reason = "reputation_below_threshold",
+                        "rejecting established inbound session",
+                    );
                     self.queued_actions.push_back(PeerAction::DisconnectBannedIncoming { peer_id });
                     return;
                 }
@@ -408,15 +423,22 @@ impl PeersManager {
 
     /// Bans the peer temporarily with the configured ban timeout
     fn ban_peer(&mut self, peer_id: PeerId) {
-        let ban_duration = if let Some(peer) = self.peers.get(&peer_id) &&
-            (peer.is_trusted() || peer.is_static())
-        {
+        let trusted_or_static =
+            self.peers.get(&peer_id).is_some_and(|p| p.is_trusted() || p.is_static());
+
+        let ban_duration = if trusted_or_static {
             // For misbehaving trusted or static peers, we provide a bit more leeway when
             // penalizing them.
             self.backoff_durations.low / 2
         } else {
             self.ban_duration
         };
+
+        tracing::warn!(
+            target: "net::peers",
+            ?peer_id, duration = ?ban_duration, trusted = trusted_or_static,
+            "banning peer",
+        );
 
         self.ban_list.ban_peer_until(peer_id, std::time::Instant::now() + ban_duration);
         self.queued_actions.push_back(PeerAction::BanPeer { peer_id });
@@ -483,11 +505,9 @@ impl PeersManager {
     /// reputation changes that can be attributed to network conditions. If the peer is a
     /// trusted peer, it will also be less strict with the reputation slashing.
     pub(crate) fn apply_reputation_change(&mut self, peer_id: &PeerId, rep: ReputationChangeKind) {
-        trace!(target: "net::peers", ?peer_id, reputation=?rep, "applying reputation change");
-
-        let outcome = if let Some(peer) = self.peers.get_mut(peer_id) {
+        let (outcome, new_reputation) = if let Some(peer) = self.peers.get_mut(peer_id) {
             // First check if we should reset the reputation
-            if rep.is_reset() {
+            let outcome = if rep.is_reset() {
                 peer.reset_reputation()
             } else {
                 let mut reputation_change = self.reputation_weights.change(rep).as_i32();
@@ -510,10 +530,27 @@ impl PeersManager {
                     }
                 }
                 peer.apply_reputation(reputation_change, rep)
-            }
+            };
+            (outcome, peer.reputation)
         } else {
             return;
         };
+
+        // DEBUG when the change leaves ban-state unchanged; INFO when it transitions it.
+        match outcome {
+            ReputationChangeOutcome::None => tracing::debug!(
+                target: "net::peers",
+                ?peer_id, kind = ?rep, new_reputation, ?outcome,
+                "reputation change applied",
+            ),
+            ReputationChangeOutcome::Ban |
+            ReputationChangeOutcome::DisconnectAndBan |
+            ReputationChangeOutcome::Unban => tracing::info!(
+                target: "net::peers",
+                ?peer_id, kind = ?rep, new_reputation, ?outcome,
+                "reputation change applied",
+            ),
+        }
 
         match outcome {
             ReputationChangeOutcome::None => {}
@@ -648,6 +685,11 @@ impl PeersManager {
 
         if err.is_fatal_protocol_error() {
             trace!(target: "net::peers", ?remote_addr, ?peer_id, %err, "fatal connection error");
+            tracing::warn!(
+                target: "net::peers",
+                ?remote_addr, ?peer_id, err = %err,
+                "removing and banning peer on fatal protocol error",
+            );
             // remove the peer to which we can't establish a connection due to protocol related
             // issues.
             if let Entry::Occupied(mut entry) = self.peers.entry(*peer_id) {
@@ -1635,7 +1677,7 @@ mod tests {
             &socket_addr,
             &peer,
             &EthStreamError::P2PStreamError(P2PStreamError::Disconnected(
-                DisconnectReason::UselessPeer,
+                DisconnectReason::ProtocolBreach,
             )),
         );
 
@@ -1659,6 +1701,49 @@ mod tests {
         .await;
 
         assert!(!peers.peers.contains_key(&peer));
+    }
+
+    #[tokio::test]
+    async fn test_useless_peer_does_not_ban_on_active_drop() {
+        // Regression: cross-region peers flag each other as useless while still being
+        // valid neighbors. UselessPeer must not remove + ban — otherwise repeated
+        // handshakes drain the peer pool.
+        let peer = PeerId::random();
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
+        let mut peers = PeersManager::default();
+        peers.add_peer(peer, PeerAddr::from_tcp(socket_addr), None);
+
+        match event!(peers) {
+            PeerAction::PeerAdded(peer_id) => assert_eq!(peer_id, peer),
+            _ => unreachable!(),
+        }
+        match event!(peers) {
+            PeerAction::Connect { peer_id, .. } => assert_eq!(peer_id, peer),
+            _ => unreachable!(),
+        }
+
+        poll_fn(|cx| {
+            assert!(peers.poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+
+        peers.on_active_session_dropped(
+            &socket_addr,
+            &peer,
+            &EthStreamError::P2PStreamError(P2PStreamError::Disconnected(
+                DisconnectReason::UselessPeer,
+            )),
+        );
+
+        poll_fn(|cx| {
+            assert!(peers.poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+
+        assert!(peers.peers.contains_key(&peer), "peer should remain in the table");
+        assert!(!peers.ban_list.is_banned_peer(&peer), "peer should not be banned");
     }
 
     #[tokio::test]
@@ -1746,7 +1831,7 @@ mod tests {
             &socket_addr,
             &peer,
             &PendingSessionHandshakeError::Eth(EthStreamError::P2PStreamError(
-                P2PStreamError::Disconnected(DisconnectReason::UselessPeer),
+                P2PStreamError::Disconnected(DisconnectReason::ProtocolBreach),
             )),
         );
 
@@ -1857,7 +1942,7 @@ mod tests {
 
         let err = PendingSessionHandshakeError::Eth(EthStreamError::P2PStreamError(
             P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
-                DisconnectReason::UselessPeer,
+                DisconnectReason::ProtocolBreach,
             )),
         ));
 

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -1985,6 +1985,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_dropped_incoming() {
+        // Uses ProtocolBreach (not UselessPeer) because this test asserts the
+        // fatal-drop path overwrites the pending-connection throttle with the
+        // shorter ban_duration — UselessPeer was declassified from the fatal
+        // list, so using it here would leave the 30s throttle in place and the
+        // post-sleep unban check would never fire.
         let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 0, 1, 2)), 8008);
         let ban_duration = Duration::from_millis(500);
         let config = PeersConfig { ban_duration, ..PeersConfig::test() };
@@ -1994,7 +1999,7 @@ mod tests {
         assert_eq!(peers.connection_info.num_pending_in, 1);
         let err = PendingSessionHandshakeError::Eth(EthStreamError::P2PStreamError(
             P2PStreamError::HandshakeError(P2PHandshakeError::Disconnected(
-                DisconnectReason::UselessPeer,
+                DisconnectReason::ProtocolBreach,
             )),
         ));
 

--- a/crates/node/builder/Cargo.toml
+++ b/crates/node/builder/Cargo.toml
@@ -82,6 +82,7 @@ jsonrpsee.workspace = true
 fdlimit.workspace = true
 rayon.workspace = true
 serde_json.workspace = true
+metrics.workspace = true
 
 ## triedb
 rust-eth-triedb.workspace = true

--- a/crates/node/builder/src/launch/alignment.rs
+++ b/crates/node/builder/src/launch/alignment.rs
@@ -1,0 +1,124 @@
+//! Pure decision logic for aligning MDBX to `TrieDB` pathdb at startup.
+//!
+//! The I/O wrapper lives in `common.rs::align_mdbx_to_triedb_at_startup`. Keep
+//! the decision function free of I/O so its behaviour can be exhaustively
+//! covered by unit tests without a database fixture.
+
+use alloy_primitives::{BlockNumber, B256};
+
+/// Hard cap on how many blocks startup alignment is willing to unwind MDBX.
+/// Larger gaps almost always mean misconfiguration (wrong pathdb directory,
+/// mixed chains) and must be resolved by the operator, not by silent recovery.
+pub(crate) const MAX_STARTUP_UNWIND_BLOCKS: u64 = 1024;
+
+/// Outcome of evaluating startup alignment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AlignmentOutcome {
+    /// `mdbx_tip == pathdb_block`. No work required.
+    Aligned,
+    /// `mdbx_tip > pathdb_block` and all safety checks passed. Caller unwinds
+    /// MDBX + static files + stage checkpoints down to `to`.
+    NeedsUnwind { to: BlockNumber },
+    /// `mdbx_tip < pathdb_block`. Invariant violation; caller fails hard.
+    TriedbAhead { pathdb_block: BlockNumber, mdbx_tip: BlockNumber },
+    /// `mdbx_tip - pathdb_block > max_unwind`. Caller fails hard.
+    ExceedsLimit { mdbx_tip: BlockNumber, pathdb_block: BlockNumber, gap: u64, limit: u64 },
+    /// `pathdb_root != mdbx_header.state_root()` at `pathdb_block`. Caller fails hard.
+    RootMismatch { block: BlockNumber, triedb_root: B256, mdbx_root: B256 },
+}
+
+/// Evaluate alignment from inputs only; no I/O.
+///
+/// `mdbx_root_at_pathdb_block` is the MDBX header's state root at
+/// `pathdb_block`. The caller need only fetch it when `mdbx_tip > pathdb_block`
+/// (this function ignores the value on the equal / `<` branches).
+///
+/// `ExceedsLimit` takes precedence over `RootMismatch` — a very large gap
+/// signals misconfiguration and must be investigated by the operator before
+/// trusting either backend.
+pub(crate) fn decide_startup_alignment(
+    pathdb_block: BlockNumber,
+    pathdb_root: B256,
+    mdbx_tip: BlockNumber,
+    mdbx_root_at_pathdb_block: B256,
+    max_unwind: u64,
+) -> AlignmentOutcome {
+    use core::cmp::Ordering;
+
+    match mdbx_tip.cmp(&pathdb_block) {
+        Ordering::Equal => AlignmentOutcome::Aligned,
+        Ordering::Less => AlignmentOutcome::TriedbAhead { pathdb_block, mdbx_tip },
+        Ordering::Greater => {
+            let gap = mdbx_tip - pathdb_block;
+            if gap > max_unwind {
+                return AlignmentOutcome::ExceedsLimit {
+                    mdbx_tip,
+                    pathdb_block,
+                    gap,
+                    limit: max_unwind,
+                };
+            }
+            if pathdb_root != mdbx_root_at_pathdb_block {
+                return AlignmentOutcome::RootMismatch {
+                    block: pathdb_block,
+                    triedb_root: pathdb_root,
+                    mdbx_root: mdbx_root_at_pathdb_block,
+                };
+            }
+            AlignmentOutcome::NeedsUnwind { to: pathdb_block }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root(byte: u8) -> B256 {
+        B256::repeat_byte(byte)
+    }
+
+    #[test]
+    fn equal_tips_return_aligned() {
+        let r = root(1);
+        assert_eq!(
+            decide_startup_alignment(100, r, 100, r, MAX_STARTUP_UNWIND_BLOCKS),
+            AlignmentOutcome::Aligned
+        );
+    }
+
+    #[test]
+    fn gap_within_limit_and_root_matches_returns_needs_unwind() {
+        let r = root(3);
+        assert_eq!(
+            decide_startup_alignment(100, r, 105, r, MAX_STARTUP_UNWIND_BLOCKS),
+            AlignmentOutcome::NeedsUnwind { to: 100 }
+        );
+    }
+
+    #[test]
+    fn gap_exceeds_limit_returns_exceeds_limit() {
+        let r = root(5);
+        let pathdb = 100;
+        let tip = pathdb + MAX_STARTUP_UNWIND_BLOCKS + 1;
+        assert_eq!(
+            decide_startup_alignment(pathdb, r, tip, r, MAX_STARTUP_UNWIND_BLOCKS),
+            AlignmentOutcome::ExceedsLimit {
+                mdbx_tip: tip,
+                pathdb_block: pathdb,
+                gap: MAX_STARTUP_UNWIND_BLOCKS + 1,
+                limit: MAX_STARTUP_UNWIND_BLOCKS,
+            }
+        );
+    }
+
+    #[test]
+    fn root_mismatch_takes_precedence_over_unwind() {
+        let triedb_r = root(6);
+        let mdbx_r = root(7);
+        assert_eq!(
+            decide_startup_alignment(100, triedb_r, 105, mdbx_r, MAX_STARTUP_UNWIND_BLOCKS),
+            AlignmentOutcome::RootMismatch { block: 100, triedb_root: triedb_r, mdbx_root: mdbx_r }
+        );
+    }
+}

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -67,9 +67,10 @@ use reth_node_metrics::{
 };
 use reth_provider::{
     providers::{NodeTypesForProvider, ProviderNodeTypes, RocksDBProvider, StaticFileProvider},
-    BlockHashReader, BlockNumReader, BlockReaderIdExt, DatabaseProviderFactory, HeaderProvider,
-    ProviderError, ProviderFactory, ProviderResult, RocksDBProviderFactory, StageCheckpointReader,
-    StaticFileProviderBuilder, StaticFileProviderFactory,
+    BlockExecutionWriter, BlockHashReader, BlockNumReader, BlockReaderIdExt, DBProvider,
+    DatabaseProviderFactory, HeaderProvider, ProviderError, ProviderFactory, ProviderResult,
+    RocksDBProviderFactory, StageCheckpointReader, StaticFileProviderBuilder,
+    StaticFileProviderFactory,
 };
 use reth_prune::{PruneModes, PrunerBuilder};
 use reth_rpc_builder::config::RethRpcServerConfig;
@@ -1033,7 +1034,15 @@ where
     /// This returns the configured `debug.tip` if set, otherwise it will check if backfill was
     /// previously interrupted and returns the block hash of the last checkpoint, see also
     /// [`Self::check_pipeline_consistency`]
-    pub fn initial_backfill_target(&self) -> ProviderResult<Option<B256>> {
+    pub fn initial_backfill_target(&self) -> ProviderResult<Option<B256>>
+    where
+        <T::Provider as DatabaseProviderFactory>::ProviderRW: BlockExecutionWriter,
+    {
+        // Make MDBX and TrieDB agree on the canonical tip before anything else
+        // consults on-disk state. After this returns Ok the two backends are
+        // in sync (or TrieDB is inactive).
+        self.align_mdbx_to_triedb_at_startup()?;
+
         let mut initial_target = self.node_config().debug.tip;
 
         if initial_target.is_none() {
@@ -1072,6 +1081,147 @@ where
         }
 
         Ok(())
+    }
+
+    /// Align MDBX to `TrieDB` pathdb at startup.
+    ///
+    /// When `TrieDB` is active, reads pathdb's persisted tip and MDBX's tip. If MDBX is
+    /// ahead, unwinds MDBX (state + blocks + static files + stage checkpoints) down to
+    /// the pathdb tip. Equal tips are a no-op. Hard-fails on:
+    ///   - pathdb ahead of MDBX (system invariant violation),
+    ///   - gap > [`alignment::MAX_STARTUP_UNWIND_BLOCKS`] (operator must investigate),
+    ///   - pathdb root disagrees with the MDBX header state root at `pathdb_block`.
+    ///
+    /// Called from [`Self::initial_backfill_target`] before the consensus engine and
+    /// pipeline are built, so no other subsystem observes a transient mismatch. The
+    /// MDBX unwind commits atomically; concurrent RO readers (RPC already up) see
+    /// either the pre- or post-unwind state under MDBX MVCC.
+    pub fn align_mdbx_to_triedb_at_startup(&self) -> ProviderResult<()>
+    where
+        <T::Provider as DatabaseProviderFactory>::ProviderRW: BlockExecutionWriter,
+    {
+        use crate::launch::alignment::{
+            decide_startup_alignment, AlignmentOutcome, MAX_STARTUP_UNWIND_BLOCKS,
+        };
+
+        if !is_triedb_active() {
+            return Ok(());
+        }
+
+        let triedb = rust_eth_triedb::get_global_triedb();
+        let (pathdb_block, pathdb_root) =
+            triedb.latest_persist_state().map_err(ProviderError::other)?;
+
+        let mdbx_tip = self.blockchain_db().last_block_number()?;
+        let gap = mdbx_tip.saturating_sub(pathdb_block);
+        metrics::gauge!("reth_startup_alignment_last_gap").set(gap as f64);
+
+        // Fast-path the no-unwind cases without fetching a header.
+        if mdbx_tip == pathdb_block {
+            info!(
+                target: "reth::cli",
+                mdbx_tip, pathdb_block, gap = 0u64, outcome = "noop",
+                "Startup alignment: backends already in sync",
+            );
+            return Ok(());
+        }
+        if mdbx_tip < pathdb_block {
+            error!(
+                target: "reth::cli",
+                mdbx_tip, pathdb_block, outcome = "failed:triedb_ahead",
+                "Startup alignment: triedb pathdb is ahead of mdbx — aborting",
+            );
+            return Err(ProviderError::other(std::io::Error::other(format!(
+                "triedb pathdb (#{pathdb_block}) is ahead of mdbx tip (#{mdbx_tip}); \
+                 invariant is maintained by save_blocks ordering and is not \
+                 automatically recoverable — restore pathdb from snapshot or resync"
+            ))));
+        }
+
+        // mdbx_tip > pathdb_block: need the header at pathdb_block for root validation.
+        let mdbx_root_at_pathdb_block = self
+            .blockchain_db()
+            .header_by_number(pathdb_block)?
+            .ok_or_else(|| ProviderError::HeaderNotFound(pathdb_block.into()))?
+            .state_root();
+
+        let outcome = decide_startup_alignment(
+            pathdb_block,
+            pathdb_root,
+            mdbx_tip,
+            mdbx_root_at_pathdb_block,
+            MAX_STARTUP_UNWIND_BLOCKS,
+        );
+
+        match outcome {
+            AlignmentOutcome::Aligned => Ok(()), // unreachable; fast-path handled above
+            AlignmentOutcome::TriedbAhead { .. } => {
+                // unreachable; fast-path handled above
+                Ok(())
+            }
+            AlignmentOutcome::ExceedsLimit { mdbx_tip, pathdb_block, gap, limit } => {
+                error!(
+                    target: "reth::cli",
+                    mdbx_tip, pathdb_block, gap, limit,
+                    outcome = "failed:exceeds_limit",
+                    "Startup alignment: gap exceeds safety limit — aborting",
+                );
+                Err(ProviderError::other(std::io::Error::other(format!(
+                    "startup alignment refused: mdbx tip #{mdbx_tip} is {gap} blocks \
+                     ahead of triedb pathdb #{pathdb_block} (limit {limit}); verify \
+                     pathdb path / chain config or run `reth stage unwind` explicitly"
+                ))))
+            }
+            AlignmentOutcome::RootMismatch { block, triedb_root, mdbx_root } => {
+                error!(
+                    target: "reth::cli",
+                    block, ?triedb_root, ?mdbx_root,
+                    outcome = "failed:root_mismatch",
+                    "Startup alignment: pathdb root disagrees with mdbx header — aborting",
+                );
+                Err(ProviderError::other(std::io::Error::other(format!(
+                    "triedb/mdbx state root mismatch at block #{block}: \
+                     triedb={triedb_root:?}, mdbx header={mdbx_root:?}"
+                ))))
+            }
+            AlignmentOutcome::NeedsUnwind { to } => {
+                // Unwinding to block 0 wipes the chain and leaves MDBX with a huge
+                // free list. If pathdb reports block 0 while MDBX has progressed,
+                // the likely cause is a misconfigured pathdb directory — fail loudly
+                // instead of blindly wiping state.
+                if to == 0 {
+                    error!(
+                        target: "reth::cli",
+                        mdbx_tip, pathdb_block = to,
+                        outcome = "failed:unwind_to_genesis",
+                        "Startup alignment: refusing to unwind MDBX to genesis — verify pathdb path",
+                    );
+                    return Err(ProviderError::other(std::io::Error::other(format!(
+                        "startup alignment would unwind MDBX to genesis \
+                         (pathdb_block=0, mdbx_tip={mdbx_tip}); verify pathdb path \
+                         or resync from scratch"
+                    ))));
+                }
+                let gap = mdbx_tip - to;
+                info!(
+                    target: "reth::cli",
+                    mdbx_tip, pathdb_block = to, gap, outcome = "unwinding",
+                    "Startup alignment: unwinding MDBX to match TrieDB pathdb tip",
+                );
+
+                let provider_rw = self.blockchain_db().database_provider_rw()?;
+                provider_rw.remove_block_and_execution_above(to)?;
+                provider_rw.commit()?;
+                metrics::counter!("reth_startup_alignment_unwinds_total").increment(1);
+
+                info!(
+                    target: "reth::cli",
+                    new_tip = to, gap, outcome = "unwound",
+                    "Startup alignment: MDBX unwound; proceeding",
+                );
+                Ok(())
+            }
+        }
     }
 
     /// Check if the pipeline is consistent (all stages have the checkpoint block numbers no less
@@ -1143,21 +1293,23 @@ where
     }
 
     /// Check if the pipeline is consistent under `TrieDB`.
+    ///
+    /// Precondition: [`Self::align_mdbx_to_triedb_at_startup`] has already run, so
+    /// `mdbx_tip == pathdb_tip`. This function only detects pipeline-interrupt
+    /// inconsistencies — stages whose checkpoints trail the first stage because a
+    /// prior pipeline run died mid-flight. Cross-backend alignment is the
+    /// exclusive job of the alignment step.
     pub fn check_pipeline_consistency_under_triedb(&self) -> ProviderResult<Option<B256>> {
-        // If no target was provided, check if the stages are congruent - check if the
-        // checkpoint of the last stage matches the checkpoint of the first.
-        let mut first_stage_checkpoint = self
+        let first_stage_checkpoint = self
             .blockchain_db()
             .get_stage_checkpoint(*StageId::ALL.first().unwrap())?
             .unwrap_or_default()
             .block_number;
 
         let triedb = rust_eth_triedb::get_global_triedb();
-        let (triedb_checkpoint_block_number, triedb_checkpoint_state_root) =
-            triedb.latest_persist_state().unwrap();
+        let (triedb_checkpoint_block_number, _triedb_checkpoint_state_root) =
+            triedb.latest_persist_state().map_err(ProviderError::other)?;
 
-        // Skip the first stage as we've already retrieved it and comparing all other checkpoints
-        // against it.
         for stage_id in &StageId::ALL {
             let stage_checkpoint = self
                 .blockchain_db()
@@ -1165,67 +1317,36 @@ where
                 .unwrap_or_default()
                 .block_number;
 
-            // If the checkpoint of any stage is less than the checkpoint of the first stage,
-            // retrieve and return the block hash of the latest header and use it as the target.
             if stage_checkpoint < first_stage_checkpoint {
-                if triedb_checkpoint_block_number > first_stage_checkpoint {
+                // If pathdb progressed past the first stage (prior pipeline run wrote
+                // triedb then died before advancing stage checkpoints), target the
+                // pathdb tip so the backfill resumes from there.
+                let target = if triedb_checkpoint_block_number > first_stage_checkpoint {
                     info!(
                         target: "consensus::engine",
                         triedb_checkpoint_block_number,
                         first_stage_checkpoint,
-                        "TrieDB checkpoint is ahead of the first stage checkpoint, using TrieDB checkpoint as the target"
+                        "TrieDB checkpoint ahead of first stage checkpoint; targeting TrieDB",
                     );
-                    first_stage_checkpoint = triedb_checkpoint_block_number;
-                }
+                    triedb_checkpoint_block_number
+                } else {
+                    first_stage_checkpoint
+                };
                 info!(
                     target: "consensus::engine",
-                    first_stage_checkpoint,
+                    first_stage_checkpoint = target,
                     inconsistent_stage_id = %stage_id,
                     inconsistent_stage_checkpoint = stage_checkpoint,
-                    "Pipeline sync progress is inconsistent"
+                    "Pipeline sync progress is inconsistent",
                 );
-                return self.blockchain_db().block_hash(first_stage_checkpoint);
+                return self.blockchain_db().block_hash(target);
             }
         }
 
-        info!(target: "consensus::engine", "Pipeline sync progress is consistent, will check live sync progress");
-
-        let last_persisted_block_number = self.blockchain_db().last_block_number()?;
-        let last_persisted_header = self
-            .blockchain_db()
-            .header_by_number(last_persisted_block_number)?
-            .ok_or_else(|| {
-                reth_provider::ProviderError::HeaderNotFound(alloy_eips::BlockHashOrNumber::Number(
-                    last_persisted_block_number,
-                ))
-            })?;
-        let last_persisted_state_root = last_persisted_header.state_root();
-
-        if last_persisted_block_number > triedb_checkpoint_block_number {
-            info!(target: "consensus::engine",
-            last_persisted_block_number,
-            last_persisted_state_root = ?last_persisted_state_root,
-            triedb_checkpoint_block_number,
-            triedb_checkpoint_state_root = ?triedb_checkpoint_state_root,
-            "Last persisted state is ahead of the TrieDB state, start pipeline sync to align");
-            return self.blockchain_db().block_hash(last_persisted_block_number);
-        } else if last_persisted_block_number < triedb_checkpoint_block_number {
-            info!(target: "consensus::engine",
-            last_persisted_block_number,
-            last_persisted_state_root = ?last_persisted_state_root,
-            triedb_checkpoint_block_number,
-            triedb_checkpoint_state_root = ?triedb_checkpoint_state_root,
-            "Last persisted state is behind of the TrieDB state, start pipeline sync to align");
-            return self.blockchain_db().block_hash(last_persisted_block_number);
-        }
-
-        info!(target: "consensus::engine",
-            last_persisted_block_number,
-            last_persisted_state_root = ?last_persisted_state_root,
-            triedb_checkpoint_block_number,
-            triedb_checkpoint_state_root = ?triedb_checkpoint_state_root,
-            "Last persisted state equal TrieDB state, start live sync");
-
+        info!(
+            target: "consensus::engine",
+            "Pipeline sync progress is consistent and backends are aligned; starting live sync",
+        );
         Ok(None)
     }
     /// Expire the pre-merge transactions if the node is configured to do so and the chain has a

--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -1089,7 +1089,7 @@ where
     /// ahead, unwinds MDBX (state + blocks + static files + stage checkpoints) down to
     /// the pathdb tip. Equal tips are a no-op. Hard-fails on:
     ///   - pathdb ahead of MDBX (system invariant violation),
-    ///   - gap > [`alignment::MAX_STARTUP_UNWIND_BLOCKS`] (operator must investigate),
+    ///   - gap > `MAX_STARTUP_UNWIND_BLOCKS` (operator must investigate),
     ///   - pathdb root disagrees with the MDBX header state root at `pathdb_block`.
     ///
     /// Called from [`Self::initial_backfill_target`] before the consensus engine and

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -36,13 +36,12 @@ use reth_provider::{
 };
 use reth_tasks::TaskExecutor;
 use reth_tokio_util::EventSender;
-use reth_tracing::tracing::{debug, error, info};
+use reth_tracing::tracing::{debug, error, info, warn};
 use reth_trie_db::ChangesetCache;
 use rust_eth_triedb::triedb_manager::is_triedb_active;
 use std::{future::Future, pin::Pin, sync::Arc};
 use tokio::sync::{mpsc::unbounded_channel, oneshot};
 use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::warn;
 
 /// The engine node launcher.
 #[derive(Debug)]
@@ -324,101 +323,146 @@ impl EngineNodeLauncher {
         let startup_sync_state_idle = ctx.node_config().debug.startup_sync_state_idle;
 
         info!(target: "reth::cli", "Starting consensus engine");
-        let consensus_engine = async move {
-            if let Some(initial_target) = initial_target {
-                debug!(target: "reth::cli", %initial_target,  "start backfill sync");
-                // network_handle's sync state is already initialized at Syncing
-                engine_service.orchestrator_mut().start_backfill_sync(initial_target);
-            } else if startup_sync_state_idle {
-                network_handle.update_sync_state(SyncState::Idle);
-            }
+        ctx.task_executor().spawn_critical_with_graceful_shutdown_signal(
+            "consensus engine",
+            move |graceful| async move {
+                if let Some(initial_target) = initial_target {
+                    debug!(target: "reth::cli", %initial_target,  "start backfill sync");
+                    // network_handle's sync state is already initialized at Syncing
+                    engine_service.orchestrator_mut().start_backfill_sync(initial_target);
+                } else if startup_sync_state_idle {
+                    network_handle.update_sync_state(SyncState::Idle);
+                }
 
-            let mut res = Ok(());
-            let mut shutdown_rx = shutdown_rx.fuse();
+                let mut res = Ok(());
+                let mut shutdown_rx = shutdown_rx.fuse();
+                let mut graceful = std::pin::pin!(graceful);
+                // First shutdown wins: once either the TaskManager graceful signal
+                // or EngineShutdown has sent `FromOrchestrator::Terminate`, gate
+                // the other arm so the engine-tree doesn't receive a second
+                // Terminate (which would panic on done_tx send).
+                let mut terminating = false;
 
-            // advance the chain and await payloads built locally to add into the engine api
-            // tree handler to prevent re-execution if that block is received as payload from
-            // the CL
-            loop {
-                tokio::select! {
-                    shutdown_req = &mut shutdown_rx => {
-                        if let Ok(req) = shutdown_req {
-                            debug!(target: "reth::cli", "received engine shutdown request");
-                            engine_service.orchestrator_mut().handler_mut().handler_mut().on_event(
-                                FromOrchestrator::Terminate { tx: req.done_tx }.into()
+                // advance the chain and await payloads built locally to add into the engine api
+                // tree handler to prevent re-execution if that block is received as payload from
+                // the CL
+                loop {
+                    tokio::select! {
+                        // TaskManager graceful-shutdown signal (SIGTERM/Ctrl-C path).
+                        // Holds the GracefulShutdownGuard across the flush so
+                        // graceful_shutdown_with_timeout blocks until the
+                        // persist_until_complete round-trip finishes.
+                        _guard = &mut graceful, if !terminating => {
+                            let canonical_tip = provider.best_block_number().ok();
+                            let persisted_before = provider.last_block_number().ok();
+                            info!(
+                                target: "reth::cli",
+                                ?canonical_tip, ?persisted_before,
+                                "Graceful shutdown: starting engine flush",
                             );
+                            let flush_start = std::time::Instant::now();
+                            let (done_tx, done_rx) = oneshot::channel();
+                            engine_service.orchestrator_mut().handler_mut().handler_mut().on_event(
+                                FromOrchestrator::Terminate { tx: done_tx }.into()
+                            );
+                            match done_rx.await {
+                                Ok(()) => info!(
+                                    target: "reth::cli",
+                                    duration_ms = flush_start.elapsed().as_millis() as u64,
+                                    ?persisted_before,
+                                    persisted_after = ?provider.last_block_number().ok(),
+                                    "Graceful shutdown: engine flush complete",
+                                ),
+                                Err(err) => warn!(
+                                    target: "reth::cli",
+                                    %err,
+                                    duration_ms = flush_start.elapsed().as_millis() as u64,
+                                    "Graceful shutdown: done-channel closed before completion",
+                                ),
+                            }
+                            // `break` enforces the invariant; no need to set
+                            // `terminating = true` here.
+                            break;
                         }
-                    }
-                    payload = built_payloads.select_next_some() => {
-                        if let Some(executed_block) = payload.executed_block() {
-                            debug!(target: "reth::cli", block=?executed_block.recovered_block.num_hash(),  "inserting built payload");
-                            engine_service.orchestrator_mut().handler_mut().handler_mut().on_event(EngineApiRequest::InsertExecutedBlock(executed_block.into_executed_payload()).into());
+                        shutdown_req = &mut shutdown_rx, if !terminating => {
+                            if let Ok(req) = shutdown_req {
+                                debug!(target: "reth::cli", "received engine shutdown request");
+                                terminating = true;
+                                engine_service.orchestrator_mut().handler_mut().handler_mut().on_event(
+                                    FromOrchestrator::Terminate { tx: req.done_tx }.into()
+                                );
+                            }
                         }
-                    }
-                    req = engine_api_rx.recv() => {
-                        if let Some(req) = req {
-                            engine_service.orchestrator_mut().handler_mut().handler_mut().on_event(req.into());
+                        payload = built_payloads.select_next_some() => {
+                            if let Some(executed_block) = payload.executed_block() {
+                                debug!(target: "reth::cli", block=?executed_block.recovered_block.num_hash(),  "inserting built payload");
+                                engine_service.orchestrator_mut().handler_mut().handler_mut().on_event(EngineApiRequest::InsertExecutedBlock(executed_block.into_executed_payload()).into());
+                            }
                         }
-                    }
-                    event = engine_service.next() => {
-                        let Some(event) = event else { break };
-                        debug!(target: "reth::cli", "Event: {event}");
-                        match event {
-                            ChainEvent::BackfillSyncFinished => {
-                                if terminate_after_backfill {
-                                    debug!(target: "reth::cli", "Terminating after initial backfill");
+                        req = engine_api_rx.recv() => {
+                            if let Some(req) = req {
+                                engine_service.orchestrator_mut().handler_mut().handler_mut().on_event(req.into());
+                            }
+                        }
+                        event = engine_service.next() => {
+                            let Some(event) = event else { break };
+                            debug!(target: "reth::cli", "Event: {event}");
+                            match event {
+                                ChainEvent::BackfillSyncFinished => {
+                                    if terminate_after_backfill {
+                                        debug!(target: "reth::cli", "Terminating after initial backfill");
+                                        break
+                                    }
+                                    if startup_sync_state_idle {
+                                        network_handle.update_sync_state(SyncState::Idle);
+                                    }
+                                }
+                                ChainEvent::BackfillSyncStarted => {
+                                    network_handle.update_sync_state(SyncState::Syncing);
+                                }
+                                ChainEvent::FatalError => {
+                                    error!(target: "reth::cli", "Fatal error in consensus engine");
+                                    res = Err(eyre::eyre!("Fatal error in consensus engine"));
                                     break
                                 }
-                                if startup_sync_state_idle {
-                                    network_handle.update_sync_state(SyncState::Idle);
-                                }
-                            }
-                            ChainEvent::BackfillSyncStarted => {
-                                network_handle.update_sync_state(SyncState::Syncing);
-                            }
-                            ChainEvent::FatalError => {
-                                error!(target: "reth::cli", "Fatal error in consensus engine");
-                                res = Err(eyre::eyre!("Fatal error in consensus engine"));
-                                break
-                            }
-                            ChainEvent::Handler(ev) => {
-                                if let Some(head) = ev.canonical_header() {
-                                    // Once we're progressing via live sync, we can consider the node is not syncing anymore
-                                    network_handle.update_sync_state(SyncState::Idle);
-                                    let head_block = Head {
-                                        number: head.number(),
-                                        hash: head.hash(),
-                                        difficulty: head.difficulty(),
-                                        timestamp: head.timestamp(),
-                                        // For Ethereum, total_difficulty becomes a constant at Paris
-                                        // so the first branch is the fast path. For chains where
-                                        // Paris never activates (BSC), fall back to the real TD from
-                                        // the provider so the status message doesn't advertise 0 and
-                                        // get filtered out by remote peers as a useless sync source.
-                                        total_difficulty: chainspec.final_paris_total_difficulty()
-                                            .filter(|_| chainspec.is_paris_active_at_block(head.number()))
-                                            .or_else(|| provider.header_td_by_number(head.number()).ok().flatten())
-                                            .unwrap_or_default(),
-                                    };
-                                    network_handle.update_status(head_block);
+                                ChainEvent::Handler(ev) => {
+                                    if let Some(head) = ev.canonical_header() {
+                                        // Once we're progressing via live sync, we can consider the node is not syncing anymore
+                                        network_handle.update_sync_state(SyncState::Idle);
+                                        let head_block = Head {
+                                            number: head.number(),
+                                            hash: head.hash(),
+                                            difficulty: head.difficulty(),
+                                            timestamp: head.timestamp(),
+                                            // For Ethereum, total_difficulty becomes a constant at Paris
+                                            // so the first branch is the fast path. For chains where
+                                            // Paris never activates (BSC), fall back to the real TD from
+                                            // the provider so the status message doesn't advertise 0 and
+                                            // get filtered out by remote peers as a useless sync source.
+                                            total_difficulty: chainspec.final_paris_total_difficulty()
+                                                .filter(|_| chainspec.is_paris_active_at_block(head.number()))
+                                                .or_else(|| provider.header_td_by_number(head.number()).ok().flatten())
+                                                .unwrap_or_default(),
+                                        };
+                                        network_handle.update_status(head_block);
 
-                                    let updated = BlockRangeUpdate {
-                                        earliest: provider.earliest_block_number().unwrap_or_default(),
-                                        latest: head.number(),
-                                        latest_hash: head.hash(),
-                                    };
-                                    network_handle.update_block_range(updated);
+                                        let updated = BlockRangeUpdate {
+                                            earliest: provider.earliest_block_number().unwrap_or_default(),
+                                            latest: head.number(),
+                                            latest_hash: head.hash(),
+                                        };
+                                        network_handle.update_block_range(updated);
+                                    }
+                                    event_sender.notify(ev);
                                 }
-                                event_sender.notify(ev);
                             }
                         }
                     }
                 }
-            }
 
-            let _ = exit.send(res);
-        };
-        ctx.task_executor().spawn_critical("consensus engine", Box::pin(consensus_engine));
+                let _ = exit.send(res);
+            },
+        );
 
         let engine_events_for_ethstats = engine_events.new_listener();
 

--- a/crates/node/builder/src/launch/engine.rs
+++ b/crates/node/builder/src/launch/engine.rs
@@ -32,7 +32,7 @@ use reth_node_core::{
 use reth_node_events::node;
 use reth_provider::{
     providers::{BlockchainProvider, NodeTypesForProvider},
-    BlockNumReader, MetadataProvider,
+    BlockNumReader, HeaderProvider, MetadataProvider,
 };
 use reth_tasks::TaskExecutor;
 use reth_tokio_util::EventSender;
@@ -390,8 +390,14 @@ impl EngineNodeLauncher {
                                         hash: head.hash(),
                                         difficulty: head.difficulty(),
                                         timestamp: head.timestamp(),
+                                        // For Ethereum, total_difficulty becomes a constant at Paris
+                                        // so the first branch is the fast path. For chains where
+                                        // Paris never activates (BSC), fall back to the real TD from
+                                        // the provider so the status message doesn't advertise 0 and
+                                        // get filtered out by remote peers as a useless sync source.
                                         total_difficulty: chainspec.final_paris_total_difficulty()
                                             .filter(|_| chainspec.is_paris_active_at_block(head.number()))
+                                            .or_else(|| provider.header_td_by_number(head.number()).ok().flatten())
                                             .unwrap_or_default(),
                                     };
                                     network_handle.update_status(head_block);

--- a/crates/node/builder/src/launch/mod.rs
+++ b/crates/node/builder/src/launch/mod.rs
@@ -4,6 +4,7 @@ pub mod common;
 mod exex;
 pub mod invalid_block_hook;
 
+pub(crate) mod alignment;
 pub(crate) mod debug;
 pub(crate) mod engine;
 

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -29,6 +29,7 @@ reth-trie-db = { workspace = true, features = ["metrics"] }
 
 # triedb
 rust-eth-triedb.workspace = true
+rust-eth-triedb-common.workspace = true
 reth-nippy-jar.workspace = true
 reth-codecs.workspace = true
 reth-chain-state.workspace = true

--- a/crates/storage/provider/src/providers/blockchain_provider.rs
+++ b/crates/storage/provider/src/providers/blockchain_provider.rs
@@ -1008,10 +1008,14 @@ mod tests {
                 let execution_output = (*lowest_memory_block.execution_output).clone();
                 lowest_memory_block.execution_output = Arc::new(execution_output);
 
-                // Push to disk
+                // Push to disk. MockNodeTypesWithDB does not activate TrieDB so
+                // save_blocks never produces pending flushes.
                 let provider_rw = hook_provider.database_provider_rw().unwrap();
-                provider_rw.save_blocks(vec![lowest_memory_block], SaveBlocksMode::Full).unwrap();
+                let pending = provider_rw
+                    .save_blocks(vec![lowest_memory_block], SaveBlocksMode::Full)
+                    .unwrap();
                 provider_rw.commit().unwrap();
+                debug_assert!(pending.is_empty());
 
                 // Remove from memory
                 hook_provider.canonical_in_memory_state.remove_persisted_blocks(num_hash);

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -77,6 +77,7 @@ use revm_database::states::{
     PlainStateReverts, PlainStorageChangeset, PlainStorageRevert, StateChangeset,
 };
 use rust_eth_triedb::{get_global_triedb, triedb_manager::is_triedb_active};
+use rust_eth_triedb_common::DiffLayer;
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
@@ -87,6 +88,38 @@ use std::{
     time::Instant,
 };
 use tracing::{debug, instrument, trace};
+
+/// A precomputed `TrieDB` flush produced by [`DatabaseProvider::save_blocks`] and
+/// deferred so the caller can commit the MDBX transaction first.
+///
+/// System invariant: `pathdb_tip <= mdbx_tip`. If pathdb ever exceeds MDBX, the
+/// node cannot unwind (MDBX lacks the changeset for blocks pathdb still thinks
+/// are persisted) — this is the "Triedb pathdb gap" deadlock. To preserve the
+/// invariant on the forward path, the MDBX commit must precede [`Self::apply`].
+/// If a crash happens between the two, pathdb lags MDBX, which is recoverable
+/// via re-execution or P2P backfill.
+#[derive(Debug, Clone)]
+pub struct TriedbPendingFlush {
+    block_number: BlockNumber,
+    state_root: B256,
+    difflayer: Arc<DiffLayer>,
+}
+
+impl TriedbPendingFlush {
+    /// Flush the pending difflayer to the global `TrieDB`.
+    pub fn apply(self) -> ProviderResult<()> {
+        let mut triedb = get_global_triedb();
+        triedb
+            .flush(self.block_number, self.state_root, &Some(self.difflayer))
+            .map_err(ProviderError::other)?;
+        Ok(())
+    }
+
+    /// The block number this flush is associated with.
+    pub const fn block_number(&self) -> BlockNumber {
+        self.block_number
+    }
+}
 
 /// A [`DatabaseProvider`] that holds a read-only database transaction.
 pub type DatabaseProviderRO<DB, N> = DatabaseProvider<<DB as Database>::TX, N>;
@@ -448,15 +481,21 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     ///
     /// Use [`SaveBlocksMode::Full`] for production (includes receipts, state, trie).
     /// Use [`SaveBlocksMode::BlocksOnly`] for block structure only (used by `insert_block`).
+    ///
+    /// When `TrieDB` is active, precomputed-difflayer blocks are validated here but
+    /// their rocksdb flush is deferred and returned as [`TriedbPendingFlush`]. The
+    /// caller MUST call [`Self::commit`] on the MDBX transaction before applying
+    /// the returned flushes — see [`TriedbPendingFlush`] for the invariant. In
+    /// non-TrieDB mode the returned vector is always empty.
     #[instrument(level = "debug", target = "providers::db", skip_all, fields(block_count = blocks.len()))]
     pub fn save_blocks(
         &self,
         blocks: Vec<ExecutedBlock<N::Primitives>>,
         save_mode: SaveBlocksMode,
-    ) -> ProviderResult<()> {
+    ) -> ProviderResult<Vec<TriedbPendingFlush>> {
         if blocks.is_empty() {
             debug!(target: "providers::db", "Attempted to write empty block range");
-            return Ok(())
+            return Ok(Vec::new())
         }
 
         let total_start = Instant::now();
@@ -553,6 +592,11 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             let triedb_active = is_triedb_active();
             let mut triedb_opt = triedb_active.then(get_global_triedb);
 
+            // Deferred TrieDB flushes: precomputed-difflayer blocks are validated
+            // here but their rocksdb flush is deferred to the caller so MDBX can
+            // commit first. Keeps pathdb_tip <= mdbx_tip across any crash window.
+            let mut pending_flushes: Vec<TriedbPendingFlush> = Vec::new();
+
             for (i, block) in blocks.iter().enumerate() {
                 let recovered_block = block.recovered_block();
                 let block_number = recovered_block.number();
@@ -590,18 +634,36 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
 
                         if let Some(ref difflayer) = block.difflayer {
                             // The difflayer was precomputed during validation (newPayload).
-                            // Root was already verified there, so just flush to disk.
+                            // Root was already verified there, so defer the flush until the
+                            // caller has committed MDBX.
                             debug!(
                                 target: "providers::db",
                                 block_number,
                                 state_root = ?state_root,
-                                "Flushing precomputed triedb difflayer in save_blocks",
+                                "Deferring precomputed triedb difflayer flush until after MDBX commit",
                             );
-                            triedb
-                                .flush(block_number, state_root, &Some(difflayer.clone()))
-                                .map_err(ProviderError::other)?;
+                            pending_flushes.push(TriedbPendingFlush {
+                                block_number,
+                                state_root,
+                                difflayer: difflayer.clone(),
+                            });
                         } else {
-                            // No precomputed difflayer; compute and commit from hashed state.
+                            // Compute-path: this needs pathdb at block_number - 1 for
+                            // parent_root, so it must flush inline. Mixing compute-path
+                            // with pending precomputed flushes would require draining
+                            // pending to pathdb BEFORE MDBX commit, which opens a
+                            // pathdb > mdbx crash window. The precomputed path covers
+                            // every validator flow — reject the mix instead of silently
+                            // risking the invariant.
+                            if !pending_flushes.is_empty() {
+                                return Err(ProviderError::Database(DatabaseError::Other(format!(
+                                    "triedb save_blocks batch mixes precomputed and compute-path blocks \
+                                     (block_number={block_number}, {} pending precomputed flushes); \
+                                     refuse to flush pathdb before MDBX commit",
+                                    pending_flushes.len()
+                                ))));
+                            }
+
                             let (latest_block_number, latest_state_root) =
                                 triedb.latest_persist_state().map_err(ProviderError::other)?;
 
@@ -734,7 +796,7 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
             self.metrics.record_save_blocks(&timings);
             debug!(target: "providers::db", range = ?first_number..=last_block_number, "Appended block data");
 
-            Ok(())
+            Ok(pending_flushes)
         })
     }
 
@@ -3337,8 +3399,10 @@ impl<TX: DbTxMut + DbTx + 'static, N: NodeTypesForProvider> BlockWriter
             ComputedTrieData::default(),
         );
 
-        // Delegate to save_blocks with BlocksOnly mode (skips receipts/state/trie)
-        self.save_blocks(vec![executed_block], SaveBlocksMode::BlocksOnly)?;
+        // Delegate to save_blocks with BlocksOnly mode (skips receipts/state/trie).
+        // BlocksOnly never touches triedb, so the returned vec is always empty.
+        let _pending = self.save_blocks(vec![executed_block], SaveBlocksMode::BlocksOnly)?;
+        debug_assert!(_pending.is_empty());
 
         // Return the body indices
         self.block_body_indices(block_number)?

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -483,9 +483,9 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
     /// Use [`SaveBlocksMode::BlocksOnly`] for block structure only (used by `insert_block`).
     ///
     /// When `TrieDB` is active, precomputed-difflayer blocks are validated here but
-    /// their rocksdb flush is deferred and returned as [`TriedbPendingFlush`]. The
+    /// their rocksdb flush is deferred and returned as `TriedbPendingFlush`. The
     /// caller MUST call [`Self::commit`] on the MDBX transaction before applying
-    /// the returned flushes — see [`TriedbPendingFlush`] for the invariant. In
+    /// the returned flushes — see `TriedbPendingFlush` for the invariant. In
     /// non-TrieDB mode the returned vector is always empty.
     #[instrument(level = "debug", target = "providers::db", skip_all, fields(block_count = blocks.len()))]
     pub fn save_blocks(

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -43,8 +43,10 @@ impl DiskFileBlobStore {
         let DiskFileBlobStoreConfig { max_cached_entries, .. } = opts;
         let inner = DiskFileBlobStoreInner::new(blob_dir, max_cached_entries);
 
-        // initialize the blob store
-        inner.delete_all()?;
+        // Do NOT wipe existing sidecars on startup. Peers may request bodies for
+        // recently-finalized blocks (EIP-4844 keeps sidecars around for the blob
+        // retention window); the pool maintenance task handles delayed deletion
+        // via FINALIZED_BLOCK_OFFSET once blocks age out.
         inner.create_blob_dir()?;
 
         Ok(Self { inner: Arc::new(inner) })
@@ -338,18 +340,6 @@ impl DiskFileBlobStoreInner {
         debug!(target:"txpool::blob", blob_dir = ?self.blob_dir, "Creating blob store");
         fs::create_dir_all(&self.blob_dir)
             .map_err(|e| DiskFileBlobStoreError::Open(self.blob_dir.clone(), e))
-    }
-
-    /// Deletes the entire blob store.
-    fn delete_all(&self) -> Result<(), DiskFileBlobStoreError> {
-        match fs::remove_dir_all(&self.blob_dir) {
-            Ok(_) => {
-                debug!(target:"txpool::blob", blob_dir = ?self.blob_dir, "Removed blob store directory");
-            }
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-            Err(err) => return Err(DiskFileBlobStoreError::Open(self.blob_dir.clone(), err)),
-        }
-        Ok(())
     }
 
     /// Ensures blob is in the blob cache and written to the disk.


### PR DESCRIPTION
### Description

Fixes for cross-region multi-validator test failures, makes reth-bsc more stable. Paired with bnb-chain/reth-bsc#334.

### Rationale

- Peers tagged us `UselessPeer` and we banned them, starving the peer pool.
- BSC's Status message advertised TD=0, so remote peers filtered us out.
- Unclean shutdown left pathdb ahead of MDBX, causing a startup livelock.
- SIGTERM dropped in-memory blocks, so every restart lost recent progress.

### Example

N/A.

### Changes

- **UselessPeer no longer fatal** — remote UselessPeer is recoverable, so stop removing+banning to keep the peer pool healthy across regions.
- **Status TD falls back to provider** — when Paris is inactive (BSC), look up the real TD instead of advertising 0.
- **Blob sidecars survive restart** — don't wipe the blob dir on startup; pool maintenance already handles deletion after the retention window.
- **Fork-chain TD final lookup** — when a fork attaches exactly at the canonical tip, do one canonical lookup instead of returning `None`.
- **MDBX commits before pathdb flush on save** — `save_blocks` returns pending flushes and the caller applies them after `commit()`, so a crash leaves pathdb lagging (recoverable) instead of ahead (deadlock).
- **Pathdb rewinds before MDBX commit on reorg** — reverse diff flushes to pathdb first, so a crash during reorg still leaves pathdb ≤ MDBX.
- **Pathdb-gap blocks buffered as Disconnected** — if parent state root diverges from pathdb disk layer, refuse to execute and let P2P walk ancestors.
- **Startup alignment of MDBX to pathdb** — unwind MDBX to pathdb tip before engine/pipeline start; hard-fail on pathdb-ahead, gap > 1024, or root mismatch.
- **Graceful shutdown flushes the engine** — SIGTERM now awaits `persist_until_complete` before exit; default timeout raised 5s → 60s.
- **Peer lifecycle visibility** — warn/info logs on reject, ban, reputation transition, and fatal-protocol removal for post-incident forensics.

### Potential Impacts

- Peer table retains more peers across a node's lifetime (intended).
- BSC peers now see a non-zero TD from us and may re-evaluate us as a sync source (intended).
- Blob directory size no longer resets on boot; steady-state unchanged.
- `DatabaseProvider::save_blocks` now returns `Vec<TriedbPendingFlush>`; callers must commit MDBX before applying. In non-TrieDB mode the vec is always empty.
- Misconfigured pathdb directories now fail fast at startup instead of livelocking.
- Graceful shutdown budget raised to 60s — operators with tighter SIGTERM deadlines should re-check.
- New early-exit `Disconnected` branch in `insert_block_or_payload` triggers only under the pathdb-gap condition.
- `RethError` size unchanged (56 bytes); alignment errors use `ProviderError::other(io::Error)`.