### PR TITLE
chore: bump rustls-webpki to 0.103.13 (fixes RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2977,7 +2977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -11254,9 +11254,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -19,8 +19,6 @@ ignore = [
     "RUSTSEC-2026-0097",
     # https://rustsec.org/advisories/RUSTSEC-2026-0105 core2 is unmaintained
     "RUSTSEC-2026-0105",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0104 rustls-webpki vulnerability, no fix available yet
-    "RUSTSEC-2026-0104",
 ]
 
 # This section is considered when running `cargo deny check bans`.


### PR DESCRIPTION
Ported from bnb-chain/reth@9dc62131acdd83c4adc343e83157ebb1305e957a.

Bumps `rustls-webpki` 0.103.12 → 0.103.13, which fixes [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) (reachable panic in CRL parsing). Removes the advisory ignore from `deny.toml` now that the fix is in place.

The error-propagation part of the source commit (propagating `MultiProofTask` worker errors to the sparse trie) is already covered in `develop-v2` by the `SparseTrieCacheTask` architecture: proof worker errors are sent as `Err(ParallelStateRootError)` through the `ProofResultMessage` channel and propagated via `result.result?` in the event loop.