### PR TITLE
fix: do not cache internal block execution errors in invalid_headers

### DIFF
--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -3192,30 +3192,54 @@ where
 
         // if invalid block, we check the validation error. Otherwise return the fatal
         // error.
-        let validation_err = error.ensure_validation_error()?;
+        match error.ensure_validation_error() {
+            Ok(validation_err) => {
+                // Permanent validation error: cache in invalid_headers so that
+                // descendants are immediately rejected without re-execution.
+                warn!(
+                    target: "engine::tree",
+                    invalid_hash=%block.hash(),
+                    invalid_number=block.number(),
+                    %validation_err,
+                    "Invalid block error on new payload",
+                );
+                let latest_valid_hash =
+                    self.latest_valid_hash_for_invalid_payload(block.parent_hash())?;
 
-        // If the error was due to an invalid payload, the payload is added to the
-        // invalid headers cache and `Ok` with [PayloadStatusEnum::Invalid] is
-        // returned.
-        warn!(
-            target: "engine::tree",
-            invalid_hash=%block.hash(),
-            invalid_number=block.number(),
-            %validation_err,
-            "Invalid block error on new payload",
-        );
-        let latest_valid_hash = self.latest_valid_hash_for_invalid_payload(block.parent_hash())?;
+                // keep track of the invalid header
+                self.state.invalid_headers.insert(block.block_with_parent());
+                self.emit_event(EngineApiEvent::BeaconConsensus(
+                    ConsensusEngineEvent::InvalidBlock(Box::new(block)),
+                ));
 
-        // keep track of the invalid header
-        self.state.invalid_headers.insert(block.block_with_parent());
-        self.emit_event(EngineApiEvent::BeaconConsensus(ConsensusEngineEvent::InvalidBlock(
-            Box::new(block),
-        )));
+                Ok(PayloadStatus::new(
+                    PayloadStatusEnum::Invalid { validation_error: validation_err.to_string() },
+                    latest_valid_hash,
+                ))
+            }
+            Err(fatal) => match fatal {
+                // Internal block execution error (e.g., BSC transient FutureBlock).
+                // Reject the block but do NOT cache in invalid_headers — the error
+                // may be transient and the block (or its descendants) could become
+                // processable later.
+                InsertBlockFatalError::BlockExecutionError(err) => {
+                    warn!(
+                        target: "engine::tree",
+                        block_hash=%block.hash(),
+                        block_number=block.number(),
+                        %err,
+                        "Internal block execution error on new payload (not caching as invalid)",
+                    );
 
-        Ok(PayloadStatus::new(
-            PayloadStatusEnum::Invalid { validation_error: validation_err.to_string() },
-            latest_valid_hash,
-        ))
+                    Ok(PayloadStatus::new(
+                        PayloadStatusEnum::Invalid { validation_error: err.to_string() },
+                        None,
+                    ))
+                }
+                // Provider errors are truly fatal — propagate to shut down the engine.
+                fatal @ InsertBlockFatalError::Provider(_) => Err(fatal),
+            },
+        }
     }
 
     /// Handles a [`NewPayloadError`] by converting it to a [`PayloadStatus`].


### PR DESCRIPTION
Ported from bnb-chain/reth@083931863c422f982cea49446cc65261ea080bc1.

When a block execution fails with an internal error (e.g., BSC's transient `FutureBlock` during a backoff period), the engine previously propagated it as a fatal error, shutting down the node.

This change distinguishes between two non-validation error cases in `on_insert_block_error`:

- **`BlockExecutionError` (internal/transient):** reject the block via `PayloadStatusEnum::Invalid` but do **not** insert into `invalid_headers`. This prevents a transient error from permanently poisoning all descendant blocks (closes bnb-chain/reth-bsc#313).
- **`Provider` errors:** remain truly fatal and are propagated as before.