### PR TITLE
feat(net): expose per-kind reputation-change and ban counters

### DIFF
--- a/crates/net/network/src/metrics.rs
+++ b/crates/net/network/src/metrics.rs
@@ -5,6 +5,7 @@ use reth_metrics::{
     metrics::{Counter, Gauge},
     Metrics,
 };
+use reth_network_types::peers::reputation::ReputationChangeKind;
 
 /// Scope for monitoring transactions sent from the manager to the tx manager
 pub(crate) const NETWORK_POOL_TRANSACTIONS_SCOPE: &str = "network.pool.transactions";
@@ -308,6 +309,81 @@ impl DisconnectMetrics {
             DisconnectReason::ConnectedToSelf => self.connected_to_self.increment(1),
             DisconnectReason::PingTimeout => self.ping_timeout.increment(1),
             DisconnectReason::SubprotocolSpecific => self.subprotocol_specific.increment(1),
+        }
+    }
+}
+
+/// Metrics for reputation-driven peer-management actions, broken out by
+/// [`ReputationChangeKind`] (the reason a change was applied) and by outcome
+/// (whether the change crossed a banning threshold).
+///
+/// Without these counters, a peer-pool drain induced by reputation bans is
+/// invisible at the metrics layer: ban events go to the `ban_list`, which is
+/// not exposed as a gauge, and the `DisconnectMetrics` counters cannot tell
+/// whether a `DisconnectRequested` was a graceful close or a rep-driven kick.
+/// Tracking change-kind frequency and ban outcomes makes it possible to
+/// correlate peer-count drops with their root cause (e.g. a flood of
+/// `BadBlock` penalties from a network-layer issue).
+#[derive(Metrics)]
+#[metrics(scope = "network")]
+pub struct ReputationMetrics {
+    /// Reputation change applied due to an unspecific bad message.
+    pub(crate) reputation_changes_bad_message: Counter,
+    /// Reputation change applied due to a bad block (pre-merge / `PoW` only).
+    pub(crate) reputation_changes_bad_block: Counter,
+    /// Reputation change applied due to a bad transaction.
+    pub(crate) reputation_changes_bad_transactions: Counter,
+    /// Reputation change applied due to a bad announcement.
+    pub(crate) reputation_changes_bad_announcement: Counter,
+    /// Reputation change applied due to a peer re-announcing a hash/tx already
+    /// known to be seen by that peer.
+    pub(crate) reputation_changes_already_seen_transaction: Counter,
+    /// Reputation change applied due to a peer response timeout.
+    pub(crate) reputation_changes_timeout: Counter,
+    /// Reputation change applied due to a peer protocol violation.
+    pub(crate) reputation_changes_bad_protocol: Counter,
+    /// Reputation change applied due to a failed connection attempt.
+    pub(crate) reputation_changes_failed_to_connect: Counter,
+    /// Reputation change applied due to the peer dropping the connection.
+    pub(crate) reputation_changes_dropped: Counter,
+    /// Reputation reset (back to the default value).
+    pub(crate) reputation_changes_reset: Counter,
+    /// Custom reputation change applied via [`ReputationChangeKind::Other`].
+    pub(crate) reputation_changes_other: Counter,
+
+    /// Reputation changes that crossed the banning threshold and resulted in
+    /// the peer being added to the ban list (without an explicit disconnect).
+    pub(crate) bans_total: Counter,
+    /// Reputation changes that resulted in both an enqueued `Disconnect` and
+    /// a ban — the dominant ban path in practice.
+    pub(crate) disconnect_and_bans_total: Counter,
+    /// Reputation resets that crossed the un-ban threshold.
+    pub(crate) unbans_total: Counter,
+}
+
+impl ReputationMetrics {
+    /// Increments the per-`ReputationChangeKind` counter.
+    pub(crate) fn increment_kind(&self, kind: ReputationChangeKind) {
+        match kind {
+            ReputationChangeKind::BadMessage => self.reputation_changes_bad_message.increment(1),
+            ReputationChangeKind::BadBlock => self.reputation_changes_bad_block.increment(1),
+            ReputationChangeKind::BadTransactions => {
+                self.reputation_changes_bad_transactions.increment(1)
+            }
+            ReputationChangeKind::BadAnnouncement => {
+                self.reputation_changes_bad_announcement.increment(1)
+            }
+            ReputationChangeKind::AlreadySeenTransaction => {
+                self.reputation_changes_already_seen_transaction.increment(1)
+            }
+            ReputationChangeKind::Timeout => self.reputation_changes_timeout.increment(1),
+            ReputationChangeKind::BadProtocol => self.reputation_changes_bad_protocol.increment(1),
+            ReputationChangeKind::FailedToConnect => {
+                self.reputation_changes_failed_to_connect.increment(1)
+            }
+            ReputationChangeKind::Dropped => self.reputation_changes_dropped.increment(1),
+            ReputationChangeKind::Reset => self.reputation_changes_reset.increment(1),
+            ReputationChangeKind::Other(_) => self.reputation_changes_other.increment(1),
         }
     }
 }

--- a/crates/net/network/src/peers.rs
+++ b/crates/net/network/src/peers.rs
@@ -95,6 +95,10 @@ pub struct PeersManager {
     ip_filter: IpFilter,
     /// The map of proxied node ids.
     proxied_node_ids_map: Arc<RwLock<HashSet<PeerId>>>,
+    /// Counters for reputation-driven peer-management actions, broken out by
+    /// change kind and ban outcome. Lets observers correlate peer-pool drains
+    /// with their reputation-layer cause.
+    metrics: crate::metrics::ReputationMetrics,
 }
 
 impl PeersManager {
@@ -181,6 +185,7 @@ impl PeersManager {
             incoming_ip_throttle_duration,
             ip_filter,
             proxied_node_ids_map,
+            metrics: Default::default(),
         }
     }
 
@@ -505,6 +510,11 @@ impl PeersManager {
     /// reputation changes that can be attributed to network conditions. If the peer is a
     /// trusted peer, it will also be less strict with the reputation slashing.
     pub(crate) fn apply_reputation_change(&mut self, peer_id: &PeerId, rep: ReputationChangeKind) {
+        // Count every change kind, including ones we ultimately ignore (trusted
+        // peers, unknown peers). The kind-counter answers "what's hitting us"
+        // — outcome counters below answer "did we punish for it".
+        self.metrics.increment_kind(rep);
+
         let (outcome, new_reputation) = if let Some(peer) = self.peers.get_mut(peer_id) {
             // First check if we should reset the reputation
             let outcome = if rep.is_reset() {
@@ -555,10 +565,15 @@ impl PeersManager {
         match outcome {
             ReputationChangeOutcome::None => {}
             ReputationChangeOutcome::Ban => {
+                self.metrics.bans_total.increment(1);
                 self.ban_peer(*peer_id);
             }
-            ReputationChangeOutcome::Unban => self.unban_peer(*peer_id),
+            ReputationChangeOutcome::Unban => {
+                self.metrics.unbans_total.increment(1);
+                self.unban_peer(*peer_id);
+            }
             ReputationChangeOutcome::DisconnectAndBan => {
+                self.metrics.disconnect_and_bans_total.increment(1);
                 self.queued_actions.push_back(PeerAction::Disconnect {
                     peer_id: *peer_id,
                     reason: Some(DisconnectReason::DisconnectRequested),


### PR DESCRIPTION
## Summary

Adds per-\`ReputationChangeKind\` and per-outcome counters to the network's \`PeersManager\`, so reputation-driven peer drops are visible at the Prometheus layer.

## Why

Today, a peer-pool drain induced by reputation bans is invisible at the metrics layer:

- Banned peers go into the \`ban_list\`, which has no exposed gauge or counter.
- The existing \`DisconnectMetrics\` counters cannot tell a graceful close apart from a rep-driven kick — both increment \`network_disconnect_requested\`.
- \`apply_reputation_change\` only emits a \`debug\`/\`info\` log line per call (since #175), which is fine for forensics but useless for Grafana.

Concretely this affects BSC node operators investigating the *peers drop to zero after sync* pattern (bnb-chain/reth-bsc#320). Without these counters, distinguishing **"we are banning peers because of repeated \`BadBlock\` penalties"** from **"peers are leaving us for unrelated reasons"** requires log inspection. With them, a single PromQL \`rate(network_reputation_changes_bad_block[5m])\` correlated against \`network_connected_peers\` makes the diagnosis a panel.

## New metrics

\`\`\`
network_reputation_changes_bad_message
network_reputation_changes_bad_block
network_reputation_changes_bad_transactions
network_reputation_changes_bad_announcement
network_reputation_changes_already_seen_transaction
network_reputation_changes_timeout
network_reputation_changes_bad_protocol
network_reputation_changes_failed_to_connect
network_reputation_changes_dropped
network_reputation_changes_reset
network_reputation_changes_other
network_bans_total
network_disconnect_and_bans_total
network_unbans_total
\`\`\`

## Behaviour

- The kind-counter increments **before** the trusted-peer / unknown-peer guards — it answers "what's hitting us." Outcome counters answer "did we punish for it."
- Trusted-peer exemption is preserved.
- No behaviour change beyond the new counters.

## Test plan

- [x] \`cargo check -p reth-network\` — pass
- [x] \`cargo +nightly clippy -p reth-network --tests --all-features\` — no new warnings
- [x] \`cargo +nightly fmt --check\` — clean
- [x] \`cargo nextest run -p reth-network\` — **177 passed, 4 skipped**

Refs bnb-chain/reth-bsc#320.