### PR TITLE
chore: cherry-pick precompile cache memory limit fix from paradigmxyz/reth v1.11.4

### DIFF
--- a/crates/engine/tree/src/tree/precompile_cache.rs
+++ b/crates/engine/tree/src/tree/precompile_cache.rs
@@ -9,7 +9,7 @@ use revm_primitives::Address;
 use std::{hash::Hash, sync::Arc};
 
 /// Default max cache size for [`PrecompileCache`]
-const MAX_CACHE_SIZE: u32 = 10_000;
+const MAX_CACHE_SIZE: u32 = 1024 * 1024;
 
 /// Stores caches for each precompile.
 #[derive(Debug, Clone, Default)]
@@ -51,6 +51,9 @@ where
             moka::sync::CacheBuilder::new(MAX_CACHE_SIZE as u64)
                 .initial_capacity(MAX_CACHE_SIZE as usize)
                 .eviction_policy(EvictionPolicy::lru())
+                .weigher(|key: &Bytes, value: &CacheEntry<S>| {
+                    (key.len() + value.output.bytes.len()) as u32
+                })
                 .build_with_hasher(Default::default()),
         )
     }


### PR DESCRIPTION
## Summary

Cherry-picks upstream commit [`2ac58a2`](https://github.com/paradigmxyz/reth/commit/2ac58a25f561827e2b816a3c1ed972194f3b2915) (tagged as `v1.11.4` in `paradigmxyz/reth`) which bounds the precompile cache by **actual byte usage** instead of entry count.

## Motivation

Before this change, `PrecompileCache` was configured with `MAX_CACHE_SIZE = 10_000` interpreted by `moka` as a max **entry count** (default weigher = 1 per entry). Because the cache stores precompile inputs/outputs whose sizes are attacker-controllable (e.g. `IDENTITY`, `MODEXP`), an adversary could fill the cache with large entries and balloon node memory well into the hundreds of MB range with only 10,000 cached results.

## Change

`crates/engine/tree/src/tree/precompile_cache.rs`:

- Add `.weigher(|key, value| (key.len() + value.output.bytes.len()) as u32)` so each entry's weight equals the bytes it actually holds.
- Raise the capacity constant to `1024 * 1024`, which under the new weigher means **≈1 MiB total bytes** instead of 10,000 entries.

Net effect: precompile cache memory is now hard-bounded at ~1 MiB regardless of per-entry size, eliminating the unbounded-growth surface.

## Test plan

- [x] `cargo check -p reth-engine-tree` passes
- [ ] CI green
- [ ] Optional targeted test run: `cargo test -p reth-engine-tree precompile_cache`

## Upstream reference

- Tag: https://github.com/paradigmxyz/reth/releases/tag/v1.11.4
- Commit: https://github.com/paradigmxyz/reth/commit/2ac58a25f561827e2b816a3c1ed972194f3b2915

🤖 Generated with [Claude Code](https://claude.com/claude-code)