### PR TITLE
perf(metrics): prevent multi-second engine stalls from scrape hooks

### DIFF
--- a/crates/node/builder/src/launch/common.rs
+++ b/crates/node/builder/src/launch/common.rs
@@ -1628,23 +1628,32 @@ where
 }
 
 /// Returns the metrics hooks for the node.
+///
+/// The DB and static-file metric-reporting hooks walk all tables/segments and
+/// can be expensive on large databases. Set `RETH_DISABLE_HEAVY_METRICS` to
+/// any value to skip registering them; the metrics server still serves the
+/// rest of the registry.
 pub fn metrics_hooks<N: NodeTypesWithDB>(provider_factory: &ProviderFactory<N>) -> Hooks {
-    Hooks::builder()
-        .with_hook({
-            let db = provider_factory.db_ref().clone();
-            move || throttle!(Duration::from_secs(5 * 60), || db.report_metrics())
-        })
-        .with_hook({
-            let sfp = provider_factory.static_file_provider();
-            move || {
-                throttle!(Duration::from_secs(5 * 60), || {
-                    if let Err(error) = sfp.report_metrics() {
-                        error!(%error, "Failed to report metrics from static file provider");
-                    }
-                })
-            }
-        })
-        .build()
+    let mut builder = Hooks::builder();
+    // Heavy hooks: opt out via env var when their cost is unacceptable.
+    if std::env::var_os("RETH_DISABLE_HEAVY_METRICS").is_none() {
+        builder = builder
+            .with_hook({
+                let db = provider_factory.db_ref().clone();
+                move || throttle!(Duration::from_secs(5 * 60), || db.report_metrics())
+            })
+            .with_hook({
+                let sfp = provider_factory.static_file_provider();
+                move || {
+                    throttle!(Duration::from_secs(5 * 60), || {
+                        if let Err(error) = sfp.report_metrics() {
+                            error!(%error, "Failed to report metrics from static file provider");
+                        }
+                    })
+                }
+            });
+    }
+    builder.build()
 }
 
 #[cfg(test)]

--- a/crates/node/metrics/src/server.rs
+++ b/crates/node/metrics/src/server.rs
@@ -149,9 +149,24 @@ impl MetricServer {
                     let hook = hook.clone();
                     let pprof_dump_dir = pprof_dump_dir.clone();
                     let service = tower::service_fn(move |req: Request<_>| {
-                        let response =
-                            handle_request(req.uri().path(), &*hook, handle, &pprof_dump_dir);
-                        async move { Ok::<_, Infallible>(response) }
+                        let path = req.uri().path().to_owned();
+                        let hook = hook.clone();
+                        let pprof_dump_dir = pprof_dump_dir.clone();
+                        async move {
+                            let response = tokio::task::spawn_blocking(move || {
+                                handle_request(&path, &*hook, handle, &pprof_dump_dir)
+                            })
+                            .await
+                            .unwrap_or_else(|err| {
+                                tracing::error!(%err, "metrics handler task failed");
+                                let mut response = Response::new(Full::new(Bytes::from_static(
+                                    b"metrics handler error",
+                                )));
+                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                response
+                            });
+                            Ok::<_, Infallible>(response)
+                        }
                     });
 
                     let mut shutdown = signal.clone().ignore_guard();
@@ -193,8 +208,19 @@ impl MetricServer {
                             break;
                         }
                         _ = tokio::time::sleep(interval) => {
-                            hooks.iter().for_each(|hook| hook());
-                            let metrics = handle.handle().render();
+                            let hooks_clone = hooks.clone();
+                            let metrics = match tokio::task::spawn_blocking(move || {
+                                hooks_clone.iter().for_each(|hook| hook());
+                                handle.handle().render()
+                            })
+                            .await
+                            {
+                                Ok(m) => m,
+                                Err(err) => {
+                                    tracing::warn!(%err, "metrics gather failed; skipping push");
+                                    continue;
+                                }
+                            };
                             match client.put(&url).header("Content-Type", "text/plain").body(metrics).send().await {
                                 Ok(response) => {
                                     if !response.status().is_success() {


### PR DESCRIPTION
Addresses bnb-chain/reth-bsc#353 (the *engine-tree handler is slow* stalls observed on BSC full nodes have their root cause here in the metrics scrape path).

### Description

The Prometheus metrics endpoint and push-gateway loop currently run the full hook chain + exporter `render()` synchronously on a tokio worker. On large databases the two heavy hooks (`Database::report_metrics` and `StaticFileProvider::report_metrics`) walk MDBX page metadata, the freelist DB, and every static-file jar header on every scrape, which can take seconds and stall the runtime. In practice this surfaces as multi-second *engine-tree handler is slow* events on a cadence matching the hook throttle, observed on a BSC full node (bnb-chain/reth-bsc#353).

This PR makes two independent changes:

1. Adds a `RETH_DISABLE_HEAVY_METRICS` env-var escape hatch so operators can drop those two hooks without rebuilding.
2. Offloads the synchronous scrape work (`render()` + hooks) to `spawn_blocking` for both the HTTP endpoint and the push-gateway loop, so even when the hooks are enabled they no longer block the tokio worker that accepted the request.

### Rationale

The heavy hooks above already produce real multi-second engine stalls today; the env-var escape hatch makes those stop without losing the rest of the metrics. Beyond that, even after gating the two heavy hooks out, `render()` itself is O(total time-series) and grows over the lifetime of the node. A multi-millisecond synchronous block on a tokio worker is enough to add tail latency to anything else scheduled on that worker (engine API, RPC, networking). Moving the rendering to the blocking pool makes the metrics path a non-actor for runtime jitter regardless of how the registry grows.

### Example

Opt out of heavy DB / static-file hooks at startup:

```bash
RETH_DISABLE_HEAVY_METRICS=1 reth node ...
```

The metrics endpoint still serves the rest of the registry (process, jemalloc, io, chain spec, version). Default behavior (no env var set) is unchanged.

### Changes

Notable changes:
* `crates/node/builder/src/launch/common.rs`: `metrics_hooks` skips registering the DB and static-file `report_metrics` hooks when `RETH_DISABLE_HEAVY_METRICS` is set. Doc comment on the function documents the escape hatch.
* `crates/node/metrics/src/server.rs`: HTTP request handler offloads `handle_request` (hooks + render or pprof dump) onto `spawn_blocking`; returns 500 on join error.
* `crates/node/metrics/src/server.rs`: Push-gateway loop offloads the per-tick hooks + render onto `spawn_blocking`; on join error logs a warning and skips the tick rather than killing the loop. HTTP put remains async.

### Potential Impacts

* Scrape latency: a single extra `spawn_blocking` hop per request. Negligible compared to the synchronous `render()` cost it removes.
* Hook ordering / thread-locals: hooks now execute on a blocking-pool thread instead of a tokio worker. Existing hooks use atomics / cheap procfs reads and don't depend on thread-locals, so this is safe today, but worth keeping in mind for future hook additions.
* `RETH_DISABLE_HEAVY_METRICS`: new env var. Operators who haven't set it see identical behavior.

Related: bnb-chain/reth-bsc#353