### PR TITLE
fix(fastnode): skip trie-state unwind when trie tables are not maintained

### DIFF
--- a/crates/chain-state/src/fastnode.rs
+++ b/crates/chain-state/src/fastnode.rs
@@ -1,0 +1,27 @@
+//! Global fastnode-mode flag.
+//!
+//! Lives in `reth-chain-state` (rather than `reth-engine-primitives`, where it is
+//! re-exported from) so that storage-layer crates such as `reth-provider` can
+//! consult it without depending on engine crates.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Global flag indicating whether the node is running in fastnode mode
+/// (i.e., `--engine.skip-state-root-validation` is enabled).
+///
+/// When active, trie-dependent RPC methods such as `eth_getProof` and `eth_getAccount`
+/// are unavailable because the hashing stages and state root computation are skipped,
+/// meaning the trie tables in the database are not kept up to date.
+static FASTNODE_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// Activate fastnode mode globally.
+///
+/// This should be called once during node startup when `skip_state_root_validation` is enabled.
+pub fn activate_fastnode() {
+    FASTNODE_ACTIVE.store(true, Ordering::SeqCst);
+}
+
+/// Returns `true` if the node is running in fastnode mode.
+pub fn is_fastnode_active() -> bool {
+    FASTNODE_ACTIVE.load(Ordering::SeqCst)
+}

--- a/crates/chain-state/src/lib.rs
+++ b/crates/chain-state/src/lib.rs
@@ -11,6 +11,9 @@
 mod execution_stats;
 pub use execution_stats::ExecutionTimingStats;
 
+mod fastnode;
+pub use fastnode::{activate_fastnode, is_fastnode_active};
+
 mod in_memory;
 pub use in_memory::*;
 

--- a/crates/engine/primitives/src/config.rs
+++ b/crates/engine/primitives/src/config.rs
@@ -1,30 +1,14 @@
 //! Engine tree configuration.
 
 use alloy_eips::merge::EPOCH_SLOTS;
-use core::{
-    sync::atomic::{AtomicBool, Ordering},
-    time::Duration,
-};
+use core::time::Duration;
 
-/// Global flag indicating whether the node is running in fastnode mode
-/// (i.e., `--engine.skip-state-root-validation` is enabled).
-///
-/// When active, trie-dependent RPC methods such as `eth_getProof` and `eth_getAccount`
-/// are unavailable because the hashing stages and state root computation are skipped,
-/// meaning the trie tables in the database are not kept up to date.
-static FASTNODE_ACTIVE: AtomicBool = AtomicBool::new(false);
-
-/// Activate fastnode mode globally.
-///
-/// This should be called once during node startup when `skip_state_root_validation` is enabled.
-pub fn activate_fastnode() {
-    FASTNODE_ACTIVE.store(true, Ordering::SeqCst);
-}
-
-/// Returns `true` if the node is running in fastnode mode.
-pub fn is_fastnode_active() -> bool {
-    FASTNODE_ACTIVE.load(Ordering::SeqCst)
-}
+// The fastnode flag lives in `reth-chain-state` so storage-layer crates (e.g.
+// `reth-provider`, which must skip trie-state unwinds in fastnode mode) can
+// consult it without depending on engine crates. Re-exported here to keep the
+// established `reth_engine_primitives::{activate_fastnode, is_fastnode_active}`
+// paths working.
+pub use reth_chain_state::{activate_fastnode, is_fastnode_active};
 
 /// Triggers persistence when the number of canonical blocks in memory exceeds this threshold.
 pub const DEFAULT_PERSISTENCE_THRESHOLD: u64 = 2;

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -881,6 +881,22 @@ impl<TX: DbTx + DbTxMut + 'static, N: NodeTypesForProvider> DatabaseProvider<TX,
         // Unwind storage history indices.
         self.unwind_storage_history_indices(changed_storages.iter().copied())?;
 
+        // In fastnode mode the trie tables (`AccountsTrie`/`StoragesTrie`) are not
+        // maintained: live-sync persists empty `TrieUpdates` and the hashing/Merkle
+        // stages are disabled. Computing a trie revert here would walk changesets
+        // against (near-)empty trie tables — expensive, and the resulting "revert"
+        // would write garbage nodes into tables that are intentionally unmaintained.
+        // The hashed-state and history unwinds above still run: hashed tables are the
+        // canonical state representation under storage v2.
+        if reth_chain_state::is_fastnode_active() {
+            debug!(
+                target: "providers::db",
+                from,
+                "Fastnode mode: skipping trie-state unwind (trie tables are not maintained)"
+            );
+            return Ok(())
+        }
+
         // Unwind accounts/storages trie tables using the revert.
         // Get the database tip block number
         let db_tip_block = self


### PR DESCRIPTION
### Description

Companion to the downstream trie removal in reth-bsc-zerosim ([reth-bsc#423](https://github.com/bnb-chain/reth-bsc/pull/423)). Closes the one remaining place where fastnode mode (`--engine.skip-state-root-validation`) still touches the trie machinery: **deep reorg / unwind**.

### Problem

In fastnode mode the trie tables (`AccountsTrie`/`StoragesTrie`) are intentionally unmaintained — live-sync persists empty `TrieUpdates` and the hashing/Merkle pipeline stages are disabled. But `DatabaseProvider::unwind_trie_state_from` (called from `take_block_and_execution_above` / `remove_block_and_execution_above` on every deep reorg and pipeline unwind) still unconditionally computes a changeset-derived trie revert via `changeset_cache.get_or_compute_range` and writes it with `write_trie_updates_sorted`. On a trie-less datadir that walk runs against (near-)empty trie tables — expensive, and the resulting "revert" writes garbage nodes into tables nothing reads.

### Changes

- **Move the fastnode global from `reth-engine-primitives` to `reth-chain-state`** (new `fastnode.rs`), so storage-layer crates can consult it without depending on engine crates. Both `reth-provider` and `reth-engine-primitives` already depend on `reth-chain-state`, so no new dependency edges. The flag is re-exported from `reth_engine_primitives::config`, keeping the existing `activate_fastnode()` / `is_fastnode_active()` call sites (`node-builder` launch, `rpc-eth-api` `eth_getProof`/`eth_getAccount` gates) unchanged.
- **`unwind_trie_state_from`: early-return before the trie-revert step under fastnode** (with a debug log). The hashed-state and history-index unwinds above it still run — hashed tables are the canonical state representation under storage v2 and are written during live sync regardless of fastnode.

### Not changed (deliberately)

- **Block persistence**: `write_trie_updates_sorted` in `save_blocks` is already guarded by `merged_trie.is_empty()`, which always holds under fastnode (payload validator attaches `TrieUpdates::default()`). No change needed.
- **Genesis init**: still computes the state root and writes genesis trie nodes once — the root is required for the genesis hash, and the one-time cost is negligible. Dropping/never-creating the trie tables plus a datadir migration is left as follow-up.

### Verification

- `cargo check -p reth-chain-state -p reth-engine-primitives -p reth-provider`: clean
- `cargo check -p reth-rpc-eth-api -p reth-node-builder` (re-export consumers): clean

Suggested integration test before merging into `remove_triedb`: multi-block reorg + `reth stage unwind` on a fastnode datadir, asserting `AccountsTrie`/`StoragesTrie` stay empty and hashed state matches a control node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)