### PR TITLE
fix: stream finalization-appended receipts to receipt-root task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -5823,9 +5823,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/crates/cli/commands/src/download/progress.rs
+++ b/crates/cli/commands/src/download/progress.rs
@@ -322,6 +322,8 @@ impl SharedProgress {
     }
 }
 
+// `try_update` (the suggested replacement) is still unstable (atomic_try_update, rust#135894).
+#[allow(deprecated)]
 fn sub_bytes(counter: &AtomicU64, bytes: u64) {
     let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
         Some(current.saturating_sub(bytes))

--- a/crates/cli/commands/src/download/tui.rs
+++ b/crates/cli/commands/src/download/tui.rs
@@ -199,9 +199,7 @@ impl SelectorApp {
     }
 
     fn select_all(&mut self) {
-        for sel in &mut self.selections {
-            *sel = ComponentSelection::All;
-        }
+        self.selections.fill(ComponentSelection::All);
         self.preset = Some(SelectionPreset::Archive);
     }
 

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1287,21 +1287,32 @@ where
         let execution_start = Instant::now();
 
         // Execute all transactions and finalize
-        let (executor, senders) = self.execute_transactions(
+        let (executor, senders, last_sent_len) = self.execute_transactions(
             executor,
             transaction_count,
             handle.iter_transactions(),
             &receipt_tx,
             &executed_tx_index,
         )?;
-        drop(receipt_tx);
 
-        // Finish execution and get the result
+        // Finish execution and get the result. `receipt_tx` is kept alive across this
+        // call: some executors (e.g. BSC) append additional receipts here (a system
+        // transaction's receipt) that were never streamed by the main loop above.
         let post_exec_start = Instant::now();
         let (_evm, result) = debug_span!(target: "engine::tree", "BlockExecutor::finish")
             .in_scope(|| executor.finish())
             .map(|(evm, result)| (evm.into_db(), result))?;
         self.metrics.record_post_execution(post_exec_start.elapsed());
+
+        // Stream any receipts that were only appended during finalization, so the
+        // receipt-root task still receives the complete set instead of always
+        // finalizing short.
+        if result.receipts.len() > last_sent_len {
+            for (tx_index, receipt) in result.receipts.iter().enumerate().skip(last_sent_len) {
+                let _ = receipt_tx.send(IndexedReceipt::new(tx_index, receipt.clone()));
+            }
+        }
+        drop(receipt_tx);
 
         // Merge transitions into bundle state
         debug_span!(target: "engine::tree", "merge_transitions")
@@ -1333,7 +1344,7 @@ where
         transactions: impl Iterator<Item = Result<Tx, Err>>,
         receipt_tx: &crossbeam_channel::Sender<IndexedReceipt<N::Receipt>>,
         executed_tx_index: &AtomicUsize,
-    ) -> Result<(E, Vec<Address>), BlockExecutionError>
+    ) -> Result<(E, Vec<Address>, usize), BlockExecutionError>
     where
         E: BlockExecutor<Receipt = N::Receipt>,
         Tx: alloy_evm::block::ExecutableTx<E> + alloy_evm::RecoveredTx<InnerTx>,
@@ -1395,7 +1406,7 @@ where
         }
         drop(exec_span);
 
-        Ok((executor, senders))
+        Ok((executor, senders, last_sent_len))
     }
 
     /// Compute state root for the given hashed post state in parallel.

--- a/crates/era/src/era1/types/execution.rs
+++ b/crates/era/src/era1/types/execution.rs
@@ -530,7 +530,7 @@ impl Accumulator {
         // Binary Merkle tree bottom-up (capacity is always a power of two)
         while leaves.len() > 1 {
             let mut next_level = Vec::with_capacity(leaves.len() / 2);
-            for pair in leaves.chunks_exact(2) {
+            for pair in leaves.as_chunks::<2>().0 {
                 let mut data = [0u8; 64];
                 data[..32].copy_from_slice(&pair[0]);
                 data[32..].copy_from_slice(&pair[1]);

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -65,7 +65,7 @@ impl<HttpMiddleware, RpcMiddleware> IpcServer<HttpMiddleware, RpcMiddleware> {
 
 impl<HttpMiddleware, RpcMiddleware> IpcServer<HttpMiddleware, RpcMiddleware>
 where
-    RpcMiddleware: for<'a> Layer<RpcService, Service: RpcServiceT> + Clone + Send + 'static,
+    RpcMiddleware: Layer<RpcService, Service: RpcServiceT> + Clone + Send + 'static,
     HttpMiddleware: Layer<
             TowerServiceNoHttp<RpcMiddleware>,
             Service: Service<
@@ -368,7 +368,7 @@ pub struct TowerServiceNoHttp<L> {
 
 impl<RpcMiddleware> Service<String> for TowerServiceNoHttp<RpcMiddleware>
 where
-    RpcMiddleware: for<'a> Layer<RpcService>,
+    RpcMiddleware: Layer<RpcService>,
     for<'a> <RpcMiddleware as Layer<RpcService>>::Service:
         Send + Sync + 'static + RpcServiceT<MethodResponse = MethodResponse>,
 {

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -155,6 +155,8 @@ impl BlobStoreSize {
     }
 
     #[inline]
+    // `try_update` (the suggested replacement) is still unstable (atomic_try_update, rust#135894).
+    #[allow(deprecated)]
     pub(crate) fn sub_size(&self, sub: usize) {
         let _ = self.data_size.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(current.saturating_sub(sub))
@@ -172,6 +174,8 @@ impl BlobStoreSize {
     }
 
     #[inline]
+    // `try_update` (the suggested replacement) is still unstable (atomic_try_update, rust#135894).
+    #[allow(deprecated)]
     pub(crate) fn sub_len(&self, sub: usize) {
         let _ = self.num_blobs.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(current.saturating_sub(sub))

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -2116,7 +2116,7 @@ impl ParallelSparseTrie {
         size += self.upper_subtrie.memory_size();
 
         // Lower subtries (both Revealed and Blind with allocation)
-        for subtrie in self.lower_subtries.iter() {
+        for subtrie in self.lower_subtries.as_ref() {
             size += subtrie.memory_size();
         }
 

--- a/deny.toml
+++ b/deny.toml
@@ -10,16 +10,10 @@ ignore = [
     "RUSTSEC-2025-0141",
     # https://rustsec.org/advisories/RUSTSEC-2023-0089 atomic-polyfill is unmaintained, transitive dep via test-fuzz
     "RUSTSEC-2023-0089",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0104 rustls-webpki CRL panic, fixed in 0.103.13
-    "RUSTSEC-2026-0104",
     # https://rustsec.org/advisories/RUSTSEC-2026-0118 hickory-proto NSEC3 unbounded loop
     "RUSTSEC-2026-0118",
     # https://rustsec.org/advisories/RUSTSEC-2026-0119 hickory-proto O(n²) name compression
     "RUSTSEC-2026-0119",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0105 core2 unmaintained, all versions yanked (no replacement)
-    "RUSTSEC-2026-0105",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand unsound only with custom trace-level logger; not reachable in reth
-    "RUSTSEC-2026-0097",
     # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 unmaintained, transitive dep via aquamarine (build-time only)
     "RUSTSEC-2026-0173",
 ]


### PR DESCRIPTION
## Summary
- The receipt-root streaming task's channel (`receipt_tx`) was dropped right after the per-tx execution loop returned, *before* `BlockExecutor::finish()` ran — so any receipt an executor appends only during finalization (e.g. a downstream chain's system transaction) could never reach the streaming task.
- The task always finalized short by exactly that count, logging `"Receipt root task received incomplete receipts, execution likely aborted"` / `"Receipt root task dropped sender without result, receipt root calculation likely aborted"` on every affected block, even though the block executes and validates correctly via the existing full-receipts-vector fallback.
- Fix: keep `receipt_tx` alive across `executor.finish()`, and stream the delta between what the main loop already sent and the final `result.receipts` before dropping the channel, so the streaming task receives the complete set instead of always falling back.

## Test plan
- [x] `cargo check -p reth-engine-tree`
- [x] Live-verified downstream on a local 10-validator BSC devnet (bnb-chain/reth-bsc, path-patched to this branch): positive control confirmed the errors occurred pre-fix; post-fix, 128–394 blocks produced across 4 nodes with zero "Receipt root task" errors and zero ERROR-level log lines of any kind, blocks advancing normally on canonical chain.