### PR TITLE
fix: stream finalization-appended receipts to receipt-root task (#206)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1080,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -2712,9 +2712,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -5823,9 +5823,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -163,10 +163,10 @@ impl Command {
     /// Execute `benchmark new-payload-fcu` command
     pub async fn execute(self, _ctx: CliContext) -> eyre::Result<()> {
         if self.reorg.is_some() && self.benchmark.rlp_blocks {
-            bail!("--reorg cannot be combined with --rlp-blocks")
+            bail!("--reorg cannot be combined with --rlp-blocks");
         }
         if self.reorg.is_some() && self.enable_bal {
-            bail!("--reorg cannot be combined with --enable-bal")
+            bail!("--reorg cannot be combined with --enable-bal");
         }
 
         // Log mode configuration

--- a/crates/cli/commands/src/config_cmd.rs
+++ b/crates/cli/commands/src/config_cmd.rs
@@ -24,7 +24,9 @@ impl Command {
         } else {
             let path = match self.config.as_ref() {
                 Some(path) => path,
-                None => bail!("No config file provided. Use --config <FILE> or pass --default"),
+                None => {
+                    bail!("No config file provided. Use --config <FILE> or pass --default");
+                }
             };
             if !path.exists() {
                 bail!("Config file does not exist: {}", path.display());

--- a/crates/cli/commands/src/download/archive.rs
+++ b/crates/cli/commands/src/download/archive.rs
@@ -203,7 +203,7 @@ impl ArchiveProcessor {
                         "Failed integrity validation after {} attempts for {}",
                         MAX_DOWNLOAD_RETRIES,
                         archive.file_name
-                    )
+                    );
                 }
             }
         }

--- a/crates/cli/commands/src/download/manifest.rs
+++ b/crates/cli/commands/src/download/manifest.rs
@@ -742,7 +742,7 @@ fn state_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {
         return collect_files_recursive(source_datadir, Path::new("db"));
     }
 
-    eyre::bail!("Could not find source state DB directory under {}", source_datadir.display())
+    eyre::bail!("Could not find source state DB directory under {}", source_datadir.display());
 }
 
 fn rocksdb_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {

--- a/crates/cli/commands/src/download/manifest_cmd.rs
+++ b/crates/cli/commands/src/download/manifest_cmd.rs
@@ -126,7 +126,7 @@ fn infer_snapshot_block_from_db(source_datadir: &std::path::Path) -> Result<u64>
 
     eyre::bail!(
         "Could not infer --block from source DB (Finish checkpoint missing); pass --block manually"
-    )
+    );
 }
 
 /// Infers the snapshot block from the highest header static-file range.

--- a/crates/cli/commands/src/download/progress.rs
+++ b/crates/cli/commands/src/download/progress.rs
@@ -322,6 +322,8 @@ impl SharedProgress {
     }
 }
 
+// `try_update` (the suggested replacement) is still unstable (atomic_try_update, rust#135894).
+#[allow(deprecated)]
 fn sub_bytes(counter: &AtomicU64, bytes: u64) {
     let _ = counter.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
         Some(current.saturating_sub(bytes))

--- a/crates/cli/commands/src/download/tui.rs
+++ b/crates/cli/commands/src/download/tui.rs
@@ -199,9 +199,7 @@ impl SelectorApp {
     }
 
     fn select_all(&mut self) {
-        for sel in &mut self.selections {
-            *sel = ComponentSelection::All;
-        }
+        self.selections.fill(ComponentSelection::All);
         self.preset = Some(SelectionPreset::Archive);
     }
 

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -76,7 +76,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     eyre::bail!(
                         "Invalid number of bodies received. Expected: 1. Received: {}",
                         result.len()
-                    )
+                    );
                 }
                 let body = result.into_iter().next().unwrap();
                 tracing::info!(target: "reth::cli", ?body, "Successfully downloaded body")
@@ -185,7 +185,7 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
         if config.peers.trusted_nodes.is_empty() && self.network.trusted_only {
             eyre::bail!(
                 "No trusted nodes. Set trusted peer with `--trusted-peer <enode record>` or set `--trusted-only` to `false`"
-            )
+            );
         }
 
         config.peers.trusted_nodes_only |= self.network.trusted_only;

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -237,7 +237,7 @@ impl Subcommands {
         if target > last {
             eyre::bail!(
                 "Target block number {target} is higher than the latest block number {last}"
-            )
+            );
         }
         Ok(target)
     }

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -227,7 +227,7 @@ where
         let res = self.to_engine.fork_choice_updated(state, None).await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid fork choice update {state:?}: {res:?}")
+            eyre::bail!("Invalid fork choice update {state:?}: {res:?}");
         }
 
         Ok(())
@@ -245,7 +245,7 @@ where
             .await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid payload status")
+            eyre::bail!("Invalid payload status");
         }
 
         let payload_id = res.payload_id.ok_or_eyre("No payload id")?;
@@ -257,7 +257,7 @@ where
         let Some(Ok(payload)) =
             self.payload_builder.resolve_kind(payload_id, PayloadKind::WaitForPending).await
         else {
-            eyre::bail!("No payload")
+            eyre::bail!("No payload");
         };
 
         let header = payload.block().sealed_header().clone();
@@ -265,7 +265,7 @@ where
         let res = self.to_engine.new_payload(payload).await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid payload")
+            eyre::bail!("Invalid payload");
         }
 
         self.last_block_hashes.push_back(header.hash());

--- a/crates/engine/tree/src/tree/payload_validator.rs
+++ b/crates/engine/tree/src/tree/payload_validator.rs
@@ -1287,21 +1287,32 @@ where
         let execution_start = Instant::now();
 
         // Execute all transactions and finalize
-        let (executor, senders) = self.execute_transactions(
+        let (executor, senders, last_sent_len) = self.execute_transactions(
             executor,
             transaction_count,
             handle.iter_transactions(),
             &receipt_tx,
             &executed_tx_index,
         )?;
-        drop(receipt_tx);
 
-        // Finish execution and get the result
+        // Finish execution and get the result. `receipt_tx` is kept alive across this
+        // call: some executors (e.g. BSC) append additional receipts here (a system
+        // transaction's receipt) that were never streamed by the main loop above.
         let post_exec_start = Instant::now();
         let (_evm, result) = debug_span!(target: "engine::tree", "BlockExecutor::finish")
             .in_scope(|| executor.finish())
             .map(|(evm, result)| (evm.into_db(), result))?;
         self.metrics.record_post_execution(post_exec_start.elapsed());
+
+        // Stream any receipts that were only appended during finalization, so the
+        // receipt-root task still receives the complete set instead of always
+        // finalizing short.
+        if result.receipts.len() > last_sent_len {
+            for (tx_index, receipt) in result.receipts.iter().enumerate().skip(last_sent_len) {
+                let _ = receipt_tx.send(IndexedReceipt::new(tx_index, receipt.clone()));
+            }
+        }
+        drop(receipt_tx);
 
         // Merge transitions into bundle state
         debug_span!(target: "engine::tree", "merge_transitions")
@@ -1333,7 +1344,7 @@ where
         transactions: impl Iterator<Item = Result<Tx, Err>>,
         receipt_tx: &crossbeam_channel::Sender<IndexedReceipt<N::Receipt>>,
         executed_tx_index: &AtomicUsize,
-    ) -> Result<(E, Vec<Address>), BlockExecutionError>
+    ) -> Result<(E, Vec<Address>, usize), BlockExecutionError>
     where
         E: BlockExecutor<Receipt = N::Receipt>,
         Tx: alloy_evm::block::ExecutableTx<E> + alloy_evm::RecoveredTx<InnerTx>,
@@ -1395,7 +1406,7 @@ where
         }
         drop(exec_span);
 
-        Ok((executor, senders))
+        Ok((executor, senders, last_sent_len))
     }
 
     /// Compute state root for the given hashed post state in parallel.

--- a/crates/era/src/era1/types/execution.rs
+++ b/crates/era/src/era1/types/execution.rs
@@ -530,7 +530,7 @@ impl Accumulator {
         // Binary Merkle tree bottom-up (capacity is always a power of two)
         while leaves.len() > 1 {
             let mut next_level = Vec::with_capacity(leaves.len() / 2);
-            for pair in leaves.chunks_exact(2) {
+            for pair in leaves.as_chunks::<2>().0 {
                 let mut data = [0u8; 64];
                 data[..32].copy_from_slice(&pair[0]);
                 data[32..].copy_from_slice(&pair[1]);

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -5,7 +5,7 @@
 //!  - The network implementation.
 //!  - The payload builder service.
 //!
-//! Components depend on a fully type configured node: [FullNodeTypes](crate::node::FullNodeTypes).
+//! Components depend on a fully type configured node: [`FullNodeTypes`].
 
 mod builder;
 mod consensus;

--- a/crates/node/builder/src/launch/invalid_block_hook.rs
+++ b/crates/node/builder/src/launch/invalid_block_hook.rs
@@ -105,7 +105,7 @@ where
                     healthy_node_rpc_client.clone(),
                 )),
                 InvalidBlockHookType::PreState | InvalidBlockHookType::Opcode => {
-                    eyre::bail!("invalid block hook {hook:?} is not implemented yet")
+                    eyre::bail!("invalid block hook {hook:?} is not implemented yet");
                 }
             } as Box<dyn InvalidBlockHook<_>>)
         })

--- a/crates/node/core/src/utils.rs
+++ b/crates/node/core/src/utils.rs
@@ -41,7 +41,7 @@ where
 
     let Some(header) = response else {
         client.report_bad_message(peer_id);
-        eyre::bail!("Invalid number of headers received. Expected: 1. Received: 0")
+        eyre::bail!("Invalid number of headers received. Expected: 1. Received: 0");
     };
 
     let header = SealedHeader::seal_slow(header);
@@ -77,7 +77,7 @@ where
 
     let Some(body) = response else {
         client.report_bad_message(peer_id);
-        eyre::bail!("Invalid number of bodies received. Expected: 1. Received: 0")
+        eyre::bail!("Invalid number of bodies received. Expected: 1. Received: 0");
     };
 
     let block = SealedBlock::from_sealed_parts(header, body);

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -65,7 +65,7 @@ impl<HttpMiddleware, RpcMiddleware> IpcServer<HttpMiddleware, RpcMiddleware> {
 
 impl<HttpMiddleware, RpcMiddleware> IpcServer<HttpMiddleware, RpcMiddleware>
 where
-    RpcMiddleware: for<'a> Layer<RpcService, Service: RpcServiceT> + Clone + Send + 'static,
+    RpcMiddleware: Layer<RpcService, Service: RpcServiceT> + Clone + Send + 'static,
     HttpMiddleware: Layer<
             TowerServiceNoHttp<RpcMiddleware>,
             Service: Service<
@@ -368,7 +368,7 @@ pub struct TowerServiceNoHttp<L> {
 
 impl<RpcMiddleware> Service<String> for TowerServiceNoHttp<RpcMiddleware>
 where
-    RpcMiddleware: for<'a> Layer<RpcService>,
+    RpcMiddleware: Layer<RpcService>,
     for<'a> <RpcMiddleware as Layer<RpcService>>::Service:
         Send + Sync + 'static + RpcServiceT<MethodResponse = MethodResponse>,
 {

--- a/crates/storage/db-common/src/db_tool/mod.rs
+++ b/crates/storage/db-common/src/db_tool/mod.rs
@@ -36,7 +36,7 @@ impl<N: NodeTypesWithDB> DbTool<N> {
     pub fn list<T: Table>(&self, filter: &ListFilter) -> Result<(Vec<TableRow<T>>, usize)> {
         let bmb = Rc::new(BMByte::from(&filter.search));
         if bmb.is_none() && filter.has_search() {
-            eyre::bail!("Invalid search.")
+            eyre::bail!("Invalid search.");
         }
 
         let mut hits = 0;

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -155,6 +155,8 @@ impl BlobStoreSize {
     }
 
     #[inline]
+    // `try_update` (the suggested replacement) is still unstable (atomic_try_update, rust#135894).
+    #[allow(deprecated)]
     pub(crate) fn sub_size(&self, sub: usize) {
         let _ = self.data_size.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(current.saturating_sub(sub))
@@ -172,6 +174,8 @@ impl BlobStoreSize {
     }
 
     #[inline]
+    // `try_update` (the suggested replacement) is still unstable (atomic_try_update, rust#135894).
+    #[allow(deprecated)]
     pub(crate) fn sub_len(&self, sub: usize) {
         let _ = self.num_blobs.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(current.saturating_sub(sub))

--- a/crates/trie/sparse/src/parallel.rs
+++ b/crates/trie/sparse/src/parallel.rs
@@ -2116,7 +2116,7 @@ impl ParallelSparseTrie {
         size += self.upper_subtrie.memory_size();
 
         // Lower subtries (both Revealed and Blind with allocation)
-        for subtrie in self.lower_subtries.iter() {
+        for subtrie in self.lower_subtries.as_ref() {
             size += subtrie.memory_size();
         }
 

--- a/deny.toml
+++ b/deny.toml
@@ -10,16 +10,10 @@ ignore = [
     "RUSTSEC-2025-0141",
     # https://rustsec.org/advisories/RUSTSEC-2023-0089 atomic-polyfill is unmaintained, transitive dep via test-fuzz
     "RUSTSEC-2023-0089",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0104 rustls-webpki CRL panic, fixed in 0.103.13
-    "RUSTSEC-2026-0104",
     # https://rustsec.org/advisories/RUSTSEC-2026-0118 hickory-proto NSEC3 unbounded loop
     "RUSTSEC-2026-0118",
     # https://rustsec.org/advisories/RUSTSEC-2026-0119 hickory-proto O(n²) name compression
     "RUSTSEC-2026-0119",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0105 core2 unmaintained, all versions yanked (no replacement)
-    "RUSTSEC-2026-0105",
-    # https://rustsec.org/advisories/RUSTSEC-2026-0097 rand unsound only with custom trace-level logger; not reachable in reth
-    "RUSTSEC-2026-0097",
     # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 unmaintained, transitive dep via aquamarine (build-time only)
     "RUSTSEC-2026-0173",
 ]


### PR DESCRIPTION
* fix: stream finalization-appended receipts to receipt-root task

Some executors (e.g. BSC) append a receipt during BlockExecutor::finish() (a system transaction's receipt) rather than during the main per-tx execution loop. The receipt-root streaming task's sending channel was dropped immediately after the loop returned and before finish() ran, so any such receipt could never reach it — the task always finalized short by exactly that count, logging spurious "incomplete receipts" / "dropped sender" errors on every block despite the block executing correctly via the existing full-recompute fallback.

Keep the channel open across finish() and stream the delta between what the loop already sent and the final receipts vector before dropping it, so the streaming task actually receives the complete set.

* chore: drop stale RUSTSEC ignores no longer matched by the dependency tree

cargo-deny's advisory-not-detected check flags RUSTSEC-2026-0097, RUSTSEC-2026-0104, and RUSTSEC-2026-0105 as ignored but no longer present in any crate in the tree (dependency versions have since moved past the affected ranges / the crate was replaced), which cargo-deny treats as a failure to keep the ignore list from accumulating stale entries.

* chore: bump anyhow, crossbeam-epoch, memmap2 for RUSTSEC advisories

Patch-level bumps with no API changes, fixing newly-published advisories flagged by cargo-deny:
- anyhow 1.0.102 -> 1.0.103 (RUSTSEC-2026-0190, downcast_mut unsoundness)
- crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204, invalid pointer deref)
- memmap2 0.9.10 -> 0.9.11 (RUSTSEC-2026-0186, unchecked pointer offset)

* fix: unrelated CI drift on develop (clippy + deprecated API)

Pre-existing breakage on develop from nightly toolchain/clippy drift since its last green CI run, blocking this PR's checks:
- trie/sparse: clippy's explicit_iter_loop autofix (&self.field) doesn't compile for a Box<[T; N]> field; use .as_ref() instead.
- transaction-pool: Atomic::fetch_update is deprecated in favor of try_update, but try_update is still unstable (atomic_try_update, rust-lang/rust#135894) — allow(deprecated) instead of switching to an API that isn't usable yet.

Verified against CI's exact clippy invocations (nightly, --all-features, -D warnings) for both the `clippy` and `clippy-binaries` jobs: zero errors.

* fix: more unrelated CI drift on develop (nightly clippy lints)

Continuation of the develop bit-rot cleanup needed to get this PR's CI green:
- cli/commands/download: same fetch_update/try_update situation as transaction-pool (allow(deprecated), try_update still unstable); manual_slice_fill in select_all -> Vec::fill.
- era/execution: chunks_exact(2) -> as_chunks::<2>().0 (clippy::chunks_exact_to_as_chunks).
- rpc/ipc server: drop two genuinely-unused for<'a> HRTBs flagged by clippy::extra_unused_lifetimes.

Verified against CI's exact clippy invocations for both the `clippy` and `clippy-binaries` jobs (nightly 1.99.0 2026-07-07, matching -D warnings --all-features flags): zero errors workspace-wide.

### Description

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
