### PR TITLE
fix: add trailing semicolons to block-end bail! macros (nightly hard error)

### DIFF
--- a/bin/reth-bench/src/bench/new_payload_fcu.rs
+++ b/bin/reth-bench/src/bench/new_payload_fcu.rs
@@ -163,10 +163,10 @@ impl Command {
     /// Execute `benchmark new-payload-fcu` command
     pub async fn execute(self, _ctx: CliContext) -> eyre::Result<()> {
         if self.reorg.is_some() && self.benchmark.rlp_blocks {
-            bail!("--reorg cannot be combined with --rlp-blocks")
+            bail!("--reorg cannot be combined with --rlp-blocks");
         }
         if self.reorg.is_some() && self.enable_bal {
-            bail!("--reorg cannot be combined with --enable-bal")
+            bail!("--reorg cannot be combined with --enable-bal");
         }
 
         // Log mode configuration

--- a/crates/cli/commands/src/config_cmd.rs
+++ b/crates/cli/commands/src/config_cmd.rs
@@ -24,7 +24,9 @@ impl Command {
         } else {
             let path = match self.config.as_ref() {
                 Some(path) => path,
-                None => bail!("No config file provided. Use --config <FILE> or pass --default"),
+                None => {
+                    bail!("No config file provided. Use --config <FILE> or pass --default");
+                }
             };
             if !path.exists() {
                 bail!("Config file does not exist: {}", path.display());

--- a/crates/cli/commands/src/download/archive.rs
+++ b/crates/cli/commands/src/download/archive.rs
@@ -203,7 +203,7 @@ impl ArchiveProcessor {
                         "Failed integrity validation after {} attempts for {}",
                         MAX_DOWNLOAD_RETRIES,
                         archive.file_name
-                    )
+                    );
                 }
             }
         }

--- a/crates/cli/commands/src/download/manifest.rs
+++ b/crates/cli/commands/src/download/manifest.rs
@@ -742,7 +742,7 @@ fn state_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {
         return collect_files_recursive(source_datadir, Path::new("db"));
     }
 
-    eyre::bail!("Could not find source state DB directory under {}", source_datadir.display())
+    eyre::bail!("Could not find source state DB directory under {}", source_datadir.display());
 }
 
 fn rocksdb_source_files(source_datadir: &Path) -> Result<Vec<PlannedFile>> {

--- a/crates/cli/commands/src/download/manifest_cmd.rs
+++ b/crates/cli/commands/src/download/manifest_cmd.rs
@@ -126,7 +126,7 @@ fn infer_snapshot_block_from_db(source_datadir: &std::path::Path) -> Result<u64>
 
     eyre::bail!(
         "Could not infer --block from source DB (Finish checkpoint missing); pass --block manually"
-    )
+    );
 }
 
 /// Infers the snapshot block from the highest header static-file range.

--- a/crates/cli/commands/src/p2p/mod.rs
+++ b/crates/cli/commands/src/p2p/mod.rs
@@ -76,7 +76,7 @@ impl<C: ChainSpecParser<ChainSpec: EthChainSpec + Hardforks + EthereumHardforks>
                     eyre::bail!(
                         "Invalid number of bodies received. Expected: 1. Received: {}",
                         result.len()
-                    )
+                    );
                 }
                 let body = result.into_iter().next().unwrap();
                 tracing::info!(target: "reth::cli", ?body, "Successfully downloaded body")
@@ -185,7 +185,7 @@ impl<C: ChainSpecParser> DownloadArgs<C> {
         if config.peers.trusted_nodes.is_empty() && self.network.trusted_only {
             eyre::bail!(
                 "No trusted nodes. Set trusted peer with `--trusted-peer <enode record>` or set `--trusted-only` to `false`"
-            )
+            );
         }
 
         config.peers.trusted_nodes_only |= self.network.trusted_only;

--- a/crates/cli/commands/src/stage/unwind.rs
+++ b/crates/cli/commands/src/stage/unwind.rs
@@ -237,7 +237,7 @@ impl Subcommands {
         if target > last {
             eyre::bail!(
                 "Target block number {target} is higher than the latest block number {last}"
-            )
+            );
         }
         Ok(target)
     }

--- a/crates/engine/local/src/miner.rs
+++ b/crates/engine/local/src/miner.rs
@@ -227,7 +227,7 @@ where
         let res = self.to_engine.fork_choice_updated(state, None).await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid fork choice update {state:?}: {res:?}")
+            eyre::bail!("Invalid fork choice update {state:?}: {res:?}");
         }
 
         Ok(())
@@ -245,7 +245,7 @@ where
             .await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid payload status")
+            eyre::bail!("Invalid payload status");
         }
 
         let payload_id = res.payload_id.ok_or_eyre("No payload id")?;
@@ -257,7 +257,7 @@ where
         let Some(Ok(payload)) =
             self.payload_builder.resolve_kind(payload_id, PayloadKind::WaitForPending).await
         else {
-            eyre::bail!("No payload")
+            eyre::bail!("No payload");
         };
 
         let header = payload.block().sealed_header().clone();
@@ -265,7 +265,7 @@ where
         let res = self.to_engine.new_payload(payload).await?;
 
         if !res.is_valid() {
-            eyre::bail!("Invalid payload")
+            eyre::bail!("Invalid payload");
         }
 
         self.last_block_hashes.push_back(header.hash());

--- a/crates/node/builder/src/components/mod.rs
+++ b/crates/node/builder/src/components/mod.rs
@@ -5,7 +5,7 @@
 //!  - The network implementation.
 //!  - The payload builder service.
 //!
-//! Components depend on a fully type configured node: [FullNodeTypes](crate::node::FullNodeTypes).
+//! Components depend on a fully type configured node: [`FullNodeTypes`].
 
 mod builder;
 mod consensus;

--- a/crates/node/builder/src/launch/invalid_block_hook.rs
+++ b/crates/node/builder/src/launch/invalid_block_hook.rs
@@ -105,7 +105,7 @@ where
                     healthy_node_rpc_client.clone(),
                 )),
                 InvalidBlockHookType::PreState | InvalidBlockHookType::Opcode => {
-                    eyre::bail!("invalid block hook {hook:?} is not implemented yet")
+                    eyre::bail!("invalid block hook {hook:?} is not implemented yet");
                 }
             } as Box<dyn InvalidBlockHook<_>>)
         })

--- a/crates/node/core/src/utils.rs
+++ b/crates/node/core/src/utils.rs
@@ -41,7 +41,7 @@ where
 
     let Some(header) = response else {
         client.report_bad_message(peer_id);
-        eyre::bail!("Invalid number of headers received. Expected: 1. Received: 0")
+        eyre::bail!("Invalid number of headers received. Expected: 1. Received: 0");
     };
 
     let header = SealedHeader::seal_slow(header);
@@ -77,7 +77,7 @@ where
 
     let Some(body) = response else {
         client.report_bad_message(peer_id);
-        eyre::bail!("Invalid number of bodies received. Expected: 1. Received: 0")
+        eyre::bail!("Invalid number of bodies received. Expected: 1. Received: 0");
     };
 
     let block = SealedBlock::from_sealed_parts(header, body);

--- a/crates/storage/db-common/src/db_tool/mod.rs
+++ b/crates/storage/db-common/src/db_tool/mod.rs
@@ -36,7 +36,7 @@ impl<N: NodeTypesWithDB> DbTool<N> {
     pub fn list<T: Table>(&self, filter: &ListFilter) -> Result<(Vec<TableRow<T>>, usize)> {
         let bmb = Rc::new(BMByte::from(&filter.search));
         if bmb.is_none() && filter.has_search() {
-            eyre::bail!("Invalid search.")
+            eyre::bail!("Invalid search.");
         }
 
         let mut hits = 0;


### PR DESCRIPTION
## Summary

Newer nightly toolchains promote `semicolon_in_expressions_from_macros` (part of `future_incompatible`, deny-by-default) from a warning to a **hard error**. `eyre::bail!`/`bail!` expand to a statement ending in `;`, so when such a call is the trailing expression of a block (expression position) without its own trailing semicolon, it now fails to compile:

```
error: trailing semicolon in macro used in expression position
   --> crates/engine/local/src/miner.rs:230:13
    = note: this error originates in the macro `eyre::bail`
```

This broke CI on the current `develop`: the nightly-toolchain jobs (`clippy`, `clippy binaries / ethereum`, `docs`, `udeps`, `book`) and the stable `test / ethereum` build.

Fix: add a trailing `;` to every block-end `bail!` invocation across the workspace. No behavioral change — `bail!` diverges regardless.

## Files touched

- `crates/engine/local/src/miner.rs` (4)
- `crates/node/core/src/utils.rs` (2)
- `crates/storage/db-common/src/db_tool/mod.rs`
- `crates/node/builder/src/launch/invalid_block_hook.rs`
- `crates/cli/commands/src/{download/archive.rs, download/manifest.rs, download/manifest_cmd.rs, p2p/mod.rs, stage/unwind.rs}`
- `bin/reth-bench/src/bench/new_payload_fcu.rs` (2)

## Testing

`cargo +nightly check --workspace --all-features` — clean (exit 0, zero trailing-semicolon errors).

Note: the `test / ethereum` **test** failure (`blobs::blob_conversion_at_osaka`) seen on the same `develop` run is an unrelated, timing-flaky upstream e2e test and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)