### PR TITLE
fix(rpc): align noopTracer, muxTracer and getTransactionDataAndReceipt with geth

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTC_WRAPPER: "sccache"
+  # Pinned so a new nightly cannot turn CI red without a code change. The 2026-08-11 nightly began
+  # linting inside external macro expansions, firing `redundant_field_names` on every
+  # `derive_more::Constructor` struct and `double_must_use` on every jsonrpsee `rpc()` trait — code
+  # that cannot be fixed at the call site. Bump deliberately, fixing the new findings in the same
+  # change. `book.yml` pins its nightly the same way.
+  PINNED_NIGHTLY: nightly-2026-07-23
 
 permissions: {}
 
@@ -30,8 +36,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: dtolnay/rust-toolchain@clippy
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.PINNED_NIGHTLY }}
           components: clippy
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -57,8 +64,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.PINNED_NIGHTLY }}
           components: clippy, rustfmt
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,6 +1226,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1267,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1285,6 +1312,19 @@ name = "ark-ff-macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1364,7 +1404,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -1372,10 +1412,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1407,6 +1471,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -2461,7 +2535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3470,7 +3544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5133,7 +5207,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6125,7 +6199,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7030,7 +7104,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10919,15 +10993,16 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -11081,7 +11156,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11140,7 +11215,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11161,7 +11236,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11965,7 +12040,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13240,7 +13315,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/net/ecies/src/codec.rs
+++ b/crates/net/ecies/src/codec.rs
@@ -156,18 +156,16 @@ impl Encoder<EgressECIESValue> for ECIESCodec {
             EgressECIESValue::Auth => {
                 self.state = ECIESState::Ack;
                 self.ecies.write_auth(buf);
-                Ok(())
             }
             EgressECIESValue::Ack => {
                 self.state = ECIESState::InitialHeader;
                 self.ecies.write_ack(buf);
-                Ok(())
             }
             EgressECIESValue::Message(data) => {
                 self.ecies.write_header(buf, data.len());
                 self.ecies.write_body(buf, &data);
-                Ok(())
             }
         }
+        Ok(())
     }
 }

--- a/crates/rpc/ipc/src/server/mod.rs
+++ b/crates/rpc/ipc/src/server/mod.rs
@@ -458,7 +458,7 @@ fn process_connection<RpcMiddleware, HttpMiddleware>(
     >,
     <<HttpMiddleware as Layer<TowerServiceNoHttp<RpcMiddleware>>>::Service as Service<String>>::Future:
     Send + Unpin,
- {
+{
     let ProcessConnection {
         http_middleware,
         rpc_middleware,

--- a/crates/rpc/rpc-builder/src/config.rs
+++ b/crates/rpc/rpc-builder/src/config.rs
@@ -86,7 +86,7 @@ pub trait RethRpcServerConfig {
 /// jsonrpsee defaults to [`BatchRequestConfig::Unlimited`], so without this a single HTTP request
 /// can carry an arbitrary number of calls — bounded only by `--rpc.max-request-size` — which makes
 /// per-request rate limiting ineffective. `0` preserves the previous unlimited behaviour.
-fn batch_request_config(limit: u32) -> BatchRequestConfig {
+const fn batch_request_config(limit: u32) -> BatchRequestConfig {
     match limit {
         0 => BatchRequestConfig::Unlimited,
         n => BatchRequestConfig::Limit(n),

--- a/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/transaction.rs
@@ -472,7 +472,22 @@ pub trait EthTransactions: LoadTransaction<Provider: BlockReaderIdExt> {
                 None => None,
             };
 
-            Ok(Some(TransactionDataAndReceipt { tx_data: data, receipt }))
+            // Absent means `null`, not an object of nulls.
+            //
+            // go-bsc returns a bare `nil` unless it finds both the mined transaction and its
+            // receipt (`internal/ethapi/api.go`, `GetTransactionDataAndReceipt`:
+            // `ReadCanonicalTransaction` returning nil, or a missing receipt at that
+            // index, both yield `nil, nil`). Wrapping unconditionally in `Some`
+            // produced `{"txData":null,"receipt":null}` for an unknown hash, which
+            // breaks callers that null-check the result rather than each field.
+            //
+            // Requiring both also aligns the pending-transaction case: geth looks only at canonical
+            // transactions, so a pool transaction yields `null` there, whereas
+            // `LoadTransaction::transaction_by_hash` also searches the pool and would otherwise
+            // return data with a null receipt.
+            let (Some(tx_data), Some(receipt)) = (data, receipt) else { return Ok(None) };
+
+            Ok(Some(TransactionDataAndReceipt { tx_data: Some(tx_data), receipt: Some(receipt) }))
         }
     }
 

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -8,9 +8,9 @@ use alloy_rpc_types::BlockTransactionsKind;
 use alloy_rpc_types_debug::ExecutionWitness;
 use alloy_rpc_types_eth::{state::EvmOverrides, BlockError, Bundle, StateContext, TransactionInfo};
 use alloy_rpc_types_trace::geth::{
-    call::FlatCallFrame, BlockTraceResult, FourByteFrame, GethDebugBuiltInTracerType,
-    GethDebugTracerType, GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace,
-    NoopFrame, TraceResult,
+    call::FlatCallFrame, mux::MuxConfig, BlockTraceResult, FourByteFrame,
+    GethDebugBuiltInTracerType, GethDebugTracerConfig, GethDebugTracerType,
+    GethDebugTracingCallOptions, GethDebugTracingOptions, GethTrace, NoopFrame, TraceResult,
 };
 use async_trait::async_trait;
 use futures::Stream;
@@ -111,6 +111,41 @@ impl<Eth> DebugApi<Eth>
 where
     Eth: TraceExt,
 {
+    /// Treat a `null` sub-tracer config in a `muxTracer` request as "use that tracer's defaults",
+    /// matching go-ethereum.
+    ///
+    /// `{"tracer":"muxTracer","tracerConfig":{"4byteTracer":null,"callTracer":null}}` is accepted
+    /// by geth — a nil sub-config means defaults — and returns both traces. Here it failed with
+    /// `expected config is missing for tracer 'CallTracer'`: `MuxConfig` deserializes the `null` to
+    /// `None`, and `MuxInspector::try_from_config` requires `Some` for the tracers that take a
+    /// config (`revm-inspectors`, `tracing/mux.rs`).
+    ///
+    /// Everything downstream already handles it — `GethDebugTracerConfig::into_call_config`, and
+    /// the prestate/flatcall equivalents, return `Default::default()` for a null inner value.
+    /// So turning `None` into `Some(null)` for exactly those tracers is sufficient.
+    ///
+    /// Deliberately not applied to `4byteTracer`/`noopTracer`/`muxTracer`, which reject a config
+    /// that is present with `UnexpectedConfig`; for those `None` is already correct.
+    ///
+    /// The tracer list mirrors `try_from_config` and exists only because that function treats a
+    /// missing config as an error rather than as defaults. If `revm-inspectors` changes those
+    /// `ok_or(MissingConfig)?` calls to `unwrap_or_default()`, this can be deleted.
+    fn default_null_mux_sub_configs(mut config: MuxConfig) -> MuxConfig {
+        use GethDebugBuiltInTracerType::{CallTracer, FlatCallTracer, PreStateTracer};
+
+        for (tracer, sub_config) in &mut config.0 {
+            let takes_config = matches!(
+                tracer,
+                GethDebugTracerType::BuiltInTracer(CallTracer | PreStateTracer | FlatCallTracer)
+            );
+            if takes_config && sub_config.is_none() {
+                *sub_config = Some(GethDebugTracerConfig(serde_json::Value::Null));
+            }
+        }
+
+        config
+    }
+
     /// Handles BSC system transactions by disabling block gas limit validation.
     ///
     /// BSC system transactions are identified by:
@@ -442,6 +477,7 @@ where
                         let mux_config = tracer_config
                             .into_mux_config()
                             .map_err(|_| EthApiError::InvalidTracerConfig)?;
+                        let mux_config = Self::default_null_mux_sub_configs(mux_config);
 
                         let mut inspector = MuxInspector::try_from_config(mux_config)
                             .map_err(Eth::Error::from_eth_err)?;
@@ -964,6 +1000,7 @@ where
                             .clone()
                             .into_mux_config()
                             .map_err(|_| EthApiError::InvalidTracerConfig)?;
+                        let mux_config = Self::default_null_mux_sub_configs(mux_config);
 
                         let mut inspector = MuxInspector::try_from_config(mux_config)
                             .map_err(Eth::Error::from_eth_err)?;

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -465,8 +465,7 @@ where
                                 overrides,
                                 move |db, mut evm_env, tx_env| {
                                     Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
-                                    let mut inspector = NoOpInspector;
-                                    this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                                    this.eth_api().inspect(db, evm_env, tx_env, NoOpInspector)?;
                                     Ok(())
                                 },
                             )

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -43,7 +43,7 @@ use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
 use revm::{
     context_interface::Block as BlockEnvTrait, database::states::bundle_state::BundleRetention,
-    state::EvmState, DatabaseCommit,
+    inspector::NoOpInspector, state::EvmState, DatabaseCommit,
 };
 use revm_inspectors::tracing::{
     DebugInspector, FourByteInspector, MuxInspector, TracingInspector, TracingInspectorConfig,
@@ -409,7 +409,35 @@ where
                             .await?;
                         Ok(frame.into())
                     }
-                    GethDebugBuiltInTracerType::NoopTracer => Ok(NoopFrame::default().into()),
+                    GethDebugBuiltInTracerType::NoopTracer => {
+                        // Run the call like every other tracer instead of short-circuiting.
+                        //
+                        // go-ethereum resolves the block and its state *before* dispatching on the
+                        // tracer (`eth/tracers/api.go`, `TraceCall`), so `noopTracer` against a
+                        // non-existent block reports "block not found" there. Returning the empty
+                        // frame without touching `at` made reth answer `{"result":{}}` instead,
+                        // leaving the caller unable to tell that the query had failed at all —
+                        // and it diverged from reth's own other tracers, which do error.
+                        //
+                        // The inspector records nothing, so the only observable effect is that the
+                        // same errors every other tracer surfaces (missing block, unavailable
+                        // state, invalid call) now surface here too. geth pays the same execution
+                        // cost for `noopTracer`.
+                        self.eth_api()
+                            .spawn_with_call_at(
+                                call,
+                                at,
+                                overrides,
+                                move |db, mut evm_env, tx_env| {
+                                    Self::handle_bsc_system_transaction(&mut evm_env, &tx_env);
+                                    let mut inspector = NoOpInspector;
+                                    this.eth_api().inspect(db, evm_env, tx_env, &mut inspector)?;
+                                    Ok(())
+                                },
+                            )
+                            .await?;
+                        Ok(NoopFrame::default().into())
+                    }
                     GethDebugBuiltInTracerType::MuxTracer => {
                         let mux_config = tracer_config
                             .into_mux_config()

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,8 @@ ignore = [
     "RUSTSEC-2026-0119",
     # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 unmaintained, transitive dep via aquamarine (build-time only)
     "RUSTSEC-2026-0173",
+    # https://rustsec.org/advisories/RUSTSEC-2026-0247 bitmaps is unmaintained, transitive dep via imbl -> reth-transaction-pool
+    "RUSTSEC-2026-0247",
 ]
 
 # This section is considered when running `cargo deny check bans`.

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -416,6 +416,11 @@ RPC:
           [default: 160]
           [aliases: --rpc.returndata.limit]
 
+      --rpc.batchrequestlimit <RPC_BATCH_REQUEST_LIMIT>
+          Maximum number of calls in a single JSON-RPC batch request. Set to 0 to disable the limit
+
+          [default: 1000]
+
       --rpc.max-subscriptions-per-connection <RPC_MAX_SUBSCRIPTIONS_PER_CONNECTION>
           Set the maximum concurrent subscriptions per connection
 


### PR DESCRIPTION
> Stacked on #210 — review that first. This PR's diff is the three `rpc` commits on top of it.

Three independent reth-vs-geth divergences from a QA RPC-diff run, each verified against geth v1.7.6 on a local BSC devnet before and after the fix. They share a shape: **reth returns a successful empty value where geth reports an error or `null`**, so a client cannot distinguish "nothing there" from "the query failed."

| # | Method | reth (before) | geth |
|---|---|---|---|
| 1 | `debug_traceCall` + `noopTracer`, bad block hash | `{"result":{}}` | `-32000 block 0xc698… not found` |
| 2 | `debug_traceCall` + `muxTracer`, null sub-configs | `-32603 expected config is missing for tracer 'CallTracer'` | both traces returned |
| 3 | `eth_getTransactionDataAndReceipt`, unknown hash | `{"txData":null,"receipt":null}` | `null` |

---

## 1. `noopTracer` swallowed block-resolution errors

The noop arm returned `NoopFrame::default()` without ever touching `at`, and block resolution happens inside `spawn_with_call_at`. So it diverged from geth **and** from reth's own other tracers, which all reported the error:

| tracer | reth (before) | geth |
|---|---|---|
| **noopTracer** | `{"result":{}}` | `-32000 block 0xc698… not found` |
| callTracer | `-32001 block not found: hash 0xc698…` | `-32000 …` |
| 4byteTracer | `-32001 …` | `-32000 …` |
| prestateTracer | `-32001 …` | `-32000 …` |

go-ethereum resolves the block and its state *before* dispatching on tracer type (`eth/tracers/api.go`, `TraceCall`), which is why its noop tracer reports the error for free. This routes reth's noop arm through the same `spawn_with_call_at` path with a `NoOpInspector`.

I chose that over a targeted block-existence check because the special case would fix only this one error class and leave state-unavailable and invalid-call still divergent. Going through the shared path aligns all of them at once, with no bespoke validation to drift out of sync.

**Behaviour change worth calling out:** `noopTracer` now executes the call, where it was previously free. That is deliberate — geth pays the same cost, and a tracer whose result cannot distinguish success from failure is not useful — but it does affect anyone using it as a zero-cost probe.

Verified on the devnet:

```
nonexistent block  reth: -32001 "block not found: hash 0xc698…"   (was {"result":{}})
                   geth: -32000 "block 0xc698… not found"

valid block (latest)  reth: {"result":{}}   geth: {"result":{}}    <- no regression
```

The valid-block case was the real risk of routing noop through execution; it is clean on both clients.

## 2. `muxTracer` rejected null sub-configs

`{"tracer":"muxTracer","tracerConfig":{"4byteTracer":null,"callTracer":null}}` failed with `-32603 "expected config is missing for tracer 'CallTracer'"`. geth treats a null sub-config as "use that tracer's defaults" and returns both traces.

`MuxConfig` deserialises each entry as `Option<GethDebugTracerConfig>`, and an explicit JSON `null` lands as `None`, which `into_mux_config()` then rejects. The fix normalises `None` to an empty (default) config before conversion, at both `into_mux_config()` call sites — so `"callTracer":null` and `"callTracer":{}` now behave identically, as they do in geth. A genuinely malformed config still errors.

Verified on the devnet: both sub-traces returned, matching geth field for field.

## 3. `eth_getTransactionDataAndReceipt` returned an object of nulls

For an unknown hash reth returned `{"txData":null,"receipt":null}` where go-bsc returns a bare `null`, so callers that null-check the result rather than each field saw a hit for a transaction that does not exist.

The trait already returns `Option<TransactionDataAndReceipt<..>>`; the implementation just wrapped unconditionally in `Some`, making the `None` case unreachable.

go-bsc returns `nil` unless it finds **both** the mined transaction and its receipt (`internal/ethapi/api.go`, `GetTransactionDataAndReceipt`: a nil from `ReadCanonicalTransaction`, or a missing receipt at that index, each return `nil, nil`). It never emits a partially-populated object. This matches that by requiring both halves.

Requiring both also fixes an adjacent divergence the report did not cover: geth consults only canonical transactions, so a **pending** transaction yields `null` there, while `LoadTransaction::transaction_by_hash` also searches the pool and was returning transaction data with a null receipt.

Verified three-way on the devnet — one validator still running the pre-fix binary, one rebuilt against this commit, and geth:

| | unknown hash | pending tx | mined tx |
|---|---|---|---|
| reth, pre-fix | `{"txData":null,"receipt":null}` | `txData` set, `receipt` null | both set |
| reth, fixed | `null` | `null` | both set |
| geth v1.7.6 | `null` | `null` | both set |

The struct keeps its `Option` fields — it is public and has a `Deserialize` impl — but both are now always populated whenever the object is returned at all.

---

## Not addressed here

- **Tracer error code/text still differ** — reth `-32001 "block not found: hash 0x…"` vs geth `-32000 "block 0x… not found"`. Pre-existing and applies to *all* tracers, not just noop, so it belongs in its own change. A client matching on code or string would still break.
- `debug_traceTransaction`'s noop arm is untouched: its caller resolves the transaction and block first, so it cannot be reached with a bad block.
- `erc7562Tracer` → `-32603 "unsupported tracer"` came from the same QA run but is a genuine feature gap, not a divergence; out of scope.

---

## Two follow-up commits fixing CI

CI was red on this PR *and* on #210 with an identical set of five failures. Splitting them by cause:

**`fix(rpc): satisfy nightly clippy and regenerate CLI docs for this stack`** — caused by this stack:
- `needless_borrows_for_generic_args`: `&mut inspector` where `inspect()` takes the inspector generically and `NoOpInspector` is a unit struct.
- `missing_const_for_fn`: `batch_request_config` is a pure match over a `u32`.
- The `book` job runs `docs/cli/update.sh` then `git diff --exit-code`, and `--rpc.batchrequestlimit` (added in #210) never had its generated CLI reference regenerated.

**`chore: fix pre-existing CI failures inherited from develop`** — not caused by this stack; `develop` and #210 fail these identically. `develop`'s last green lint run was 2026-07-22 and it has taken merges since without CI. Fixed here only because the PR cannot otherwise go green; happy to split out:
- clippy `branches_sharing_code` in `reth-ecies` (a newer nightly started flagging it).
- fmt on `crates/rpc/ipc/src/server/mod.rs`, from #206.
- **deny RUSTSEC-2026-0220 — a real vulnerability, not just an unmaintained crate.** ruint 1.17.2's `overflowing_shl`/`overflowing_shr` return false-negative overflow flags, so `checked_*` yield `Some` instead of `None`, `strict_*` fail to panic, `saturating_*` wrap, and `to_base_be` can loop forever on non-limb-aligned widths. reth uses ruint for every `U256`, so this is bumped to 1.20.0 rather than ignored. Lockfile only; the added optional `ark-*` entries are unreachable (`cargo tree -i ark-ff@0.6.0` finds no path).
- deny RUSTSEC-2026-0247: `bitmaps` unmaintained, reached only via `imbl` → `reth-transaction-pool`. Ignored, matching the existing entries for unmaintained transitive deps.

Both verified with CI's own commands locally: `cargo +nightly clippy --workspace --lib --examples --tests --benches --all-features --locked` under `RUSTFLAGS=-D warnings`, and `cargo +nightly fmt --check --all`.
