### PR TITLE
fix(rpc): honour topic-position count in eth_getLogs, and attach totalDifficulty to header responses

### DIFF
--- a/crates/rpc/rpc-api/src/engine.rs
+++ b/crates/rpc/rpc-api/src/engine.rs
@@ -16,11 +16,12 @@ use alloy_rpc_types_engine::{
     PayloadId, PayloadStatus,
 };
 use alloy_rpc_types_eth::{
-    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Filter, Log, SyncStatus,
+    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Log, SyncStatus,
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc, RpcModule};
 use reth_engine_primitives::EngineTypes;
+use reth_rpc_eth_api::LogFilter;
 use serde_json::Value;
 
 /// Helper trait for the engine api server.
@@ -396,7 +397,7 @@ pub trait EngineEthApi<TxReq: RpcObject, B: RpcObject, R: RpcObject> {
 
     /// Returns logs matching given filter object.
     #[method(name = "getLogs")]
-    async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
+    async fn logs(&self, filter: LogFilter) -> RpcResult<Vec<Log>>;
 
     /// Returns the account and storage values of the specified account including the Merkle-proof.
     /// This call can be used to verify that the data you are pulling from is not tampered with.

--- a/crates/rpc/rpc-builder/tests/it/http.rs
+++ b/crates/rpc/rpc-builder/tests/it/http.rs
@@ -117,7 +117,7 @@ async fn test_filter_calls<C>(client: &C)
 where
     C: ClientT + SubscriptionClientT + Sync,
 {
-    EthFilterApiClient::<Transaction>::new_filter(client, Filter::default()).await.unwrap();
+    EthFilterApiClient::<Transaction>::new_filter(client, Filter::default().into()).await.unwrap();
     EthFilterApiClient::<Transaction>::new_pending_transaction_filter(client, None).await.unwrap();
     EthFilterApiClient::<Transaction>::new_pending_transaction_filter(
         client,
@@ -127,9 +127,10 @@ where
     .unwrap();
     let id = EthFilterApiClient::<Transaction>::new_block_filter(client).await.unwrap();
     EthFilterApiClient::<Transaction>::filter_changes(client, id.clone()).await.unwrap();
-    EthFilterApiClient::<Transaction>::logs(client, Filter::default()).await.unwrap();
-    let id =
-        EthFilterApiClient::<Transaction>::new_filter(client, Filter::default()).await.unwrap();
+    EthFilterApiClient::<Transaction>::logs(client, Filter::default().into()).await.unwrap();
+    let id = EthFilterApiClient::<Transaction>::new_filter(client, Filter::default().into())
+        .await
+        .unwrap();
     EthFilterApiClient::<Transaction>::filter_logs(client, id.clone()).await.unwrap();
     EthFilterApiClient::<Transaction>::uninstall_filter(client, id).await.unwrap();
 }

--- a/crates/rpc/rpc-eth-api/src/filter.rs
+++ b/crates/rpc/rpc-eth-api/src/filter.rs
@@ -1,8 +1,9 @@
 //! `eth_` RPC API for filtering.
 
 use alloy_json_rpc::RpcObject;
-use alloy_rpc_types_eth::{Filter, FilterChanges, FilterId, Log, PendingTransactionFilterKind};
+use alloy_rpc_types_eth::{FilterChanges, FilterId, Log, PendingTransactionFilterKind};
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use reth_rpc_eth_types::LogFilter;
 use std::future::Future;
 
 /// Rpc Interface for poll-based ethereum filter API.
@@ -11,7 +12,7 @@ use std::future::Future;
 pub trait EthFilterApi<T: RpcObject> {
     /// Creates a new filter and returns its id.
     #[method(name = "newFilter")]
-    async fn new_filter(&self, filter: Filter) -> RpcResult<FilterId>;
+    async fn new_filter(&self, filter: LogFilter) -> RpcResult<FilterId>;
 
     /// Creates a new block filter and returns its id.
     #[method(name = "newBlockFilter")]
@@ -38,7 +39,7 @@ pub trait EthFilterApi<T: RpcObject> {
 
     /// Returns logs matching given filter object.
     #[method(name = "getLogs")]
-    async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>>;
+    async fn logs(&self, filter: LogFilter) -> RpcResult<Vec<Log>>;
 }
 
 /// Limits for logs queries
@@ -63,7 +64,7 @@ pub trait EngineEthFilter: Send + Sync + 'static {
     /// Returns logs matching given filter object.
     fn logs(
         &self,
-        filter: Filter,
+        filter: LogFilter,
         limits: QueryLimits,
     ) -> impl Future<Output = RpcResult<Vec<Log>>> + Send;
 }

--- a/crates/rpc/rpc-eth-api/src/helpers/block.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/block.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use alloy_consensus::{transaction::TxHashRef, TxReceipt};
 use alloy_eips::{BlockId, BlockNumberOrTag};
+use alloy_primitives::U256;
 use alloy_rlp::Encodable;
 use alloy_rpc_types_eth::{Block, BlockTransactions, Index};
 use futures::Future;
@@ -75,6 +76,60 @@ fn resolved_validators_threshold(
 /// Block related functions for the [`EthApiServer`](crate::EthApiServer) trait in the
 /// `eth_` namespace.
 pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primitives>> {
+    /// Returns the total difficulty at the given header, or `None` if it cannot be determined.
+    ///
+    /// Reads the stored total difficulty for the block, falling back to
+    /// `parent_td + header.difficulty` for blocks that are not in the database yet, such as the
+    /// pending block.
+    ///
+    /// `block_id` is only used for tracing context.
+    fn total_difficulty_for(
+        &self,
+        header: &SealedHeader<ProviderHeader<Self::Provider>>,
+        block_id: BlockId,
+    ) -> Option<U256> {
+        let block_number = header.number();
+        match self.provider().header_td_by_number(block_number) {
+            Ok(Some(td)) => Some(td),
+            Ok(None) | Err(_) => {
+                // Block not in database yet (e.g., pending block)
+                // Calculate TD = parent_td + current_difficulty
+                trace!(target: "rpc::eth", ?block_id, block_number, "Block not in DB, calculating TD from parent");
+
+                let parent_number = block_number.saturating_sub(1);
+                match self.provider().header_td_by_number(parent_number) {
+                    Ok(Some(parent_td)) => {
+                        let current_difficulty = header.difficulty();
+                        let calculated_td = parent_td.saturating_add(current_difficulty);
+
+                        trace!(
+                            target: "rpc::eth",
+                            ?block_id,
+                            block_number,
+                            parent_number,
+                            ?parent_td,
+                            ?current_difficulty,
+                            ?calculated_td,
+                            "Calculated TD from parent"
+                        );
+
+                        Some(calculated_td)
+                    }
+                    _ => {
+                        warn!(
+                            target: "rpc::eth",
+                            ?block_id,
+                            block_number,
+                            parent_number,
+                            "Parent TD not found, returning None"
+                        );
+                        None
+                    }
+                }
+            }
+        }
+    }
+
     /// Returns the block header for the given block id.
     fn rpc_block_header(
         &self,
@@ -85,11 +140,14 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
     {
         async move {
             let Some(block) = self.recovered_block(block_id).await? else { return Ok(None) };
-            let header = self.converter().convert_header(
-                block.clone_sealed_header(),
-                block.rlp_length(),
-                None,
-            )?;
+            let header = block.clone_sealed_header();
+            // go-bsc's `rpcMarshalHeader` always attaches the total difficulty, so every header
+            // response carries it — unlike `rpcMarshalBlock`, which only does so when transactions
+            // are included. Passing `None` here left `eth_getHeaderByHash`,
+            // `eth_getHeaderByNumber` and `eth_getFinalizedHeader` without the field while
+            // `eth_getBlockByHash` returned it for the very same block.
+            let td = self.total_difficulty_for(&header, block_id);
+            let header = self.converter().convert_header(header, block.rlp_length(), td)?;
             Ok(Some(header))
         }
     }
@@ -113,48 +171,7 @@ pub trait EthBlocks: LoadBlock<RpcConvert: RpcConvert<Primitives = Self::Primiti
                 full.into(),
                 |tx, tx_info| self.converter().fill(tx, tx_info),
                 |header, size| {
-                    let block_number = header.number();
-                    let td = match self.provider().header_td_by_number(block_number) {
-                        Ok(Some(td)) => {
-                            Some(td)
-                        }
-                        Ok(None) | Err(_) => {
-                            // Block not in database yet (e.g., pending block)
-                            // Calculate TD = parent_td + current_difficulty
-                            trace!(target: "rpc::eth", ?block_id, block_number, "Block not in DB, calculating TD from parent");
-
-                            let parent_number = block_number.saturating_sub(1);
-                            match self.provider().header_td_by_number(parent_number) {
-                                Ok(Some(parent_td)) => {
-                                    let current_difficulty = header.difficulty();
-                                    let calculated_td = parent_td.saturating_add(current_difficulty);
-
-                                    trace!(
-                                        target: "rpc::eth",
-                                        ?block_id,
-                                        block_number,
-                                        parent_number,
-                                        ?parent_td,
-                                        ?current_difficulty,
-                                        ?calculated_td,
-                                        "Calculated TD from parent"
-                                    );
-
-                                    Some(calculated_td)
-                                }
-                                _ => {
-                                    warn!(
-                                        target: "rpc::eth",
-                                        ?block_id,
-                                        block_number,
-                                        parent_number,
-                                        "Parent TD not found, returning None"
-                                    );
-                                    None
-                                }
-                            }
-                        }
-                    };
+                    let td = self.total_difficulty_for(&header, block_id);
                     self.converter().convert_header(header, size, td)
                 },
             )?;

--- a/crates/rpc/rpc-eth-api/src/lib.rs
+++ b/crates/rpc/rpc-eth-api/src/lib.rs
@@ -29,8 +29,9 @@ pub use helpers::config::EthConfigApiServer;
 pub use node::{RpcNodeCore, RpcNodeCoreExt};
 pub use pubsub::EthPubSubApiServer;
 pub use reth_rpc_convert::*;
-pub use reth_rpc_eth_types::error::{
-    AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError,
+pub use reth_rpc_eth_types::{
+    error::{AsEthApiError, FromEthApiError, FromEvmError, IntoEthApiError},
+    LogFilter,
 };
 pub use types::{EthApiTypes, FullEthApiTypes, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction};
 

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -63,8 +63,6 @@ schnellru.workspace = true
 rand.workspace = true
 tracing.workspace = true
 itertools.workspace = true
-
-[dev-dependencies]
 serde_json.workspace = true
 
 [features]

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -18,6 +18,7 @@ pub mod error;
 pub mod fee_history;
 pub mod gas_oracle;
 pub mod id_provider;
+pub mod log_filter;
 pub mod logs_utils;
 pub mod pending_block;
 pub mod receipt;
@@ -39,6 +40,7 @@ pub use gas_oracle::{
     GasCap, GasPriceOracle, GasPriceOracleConfig, GasPriceOracleResult, RPC_DEFAULT_GAS_CAP,
 };
 pub use id_provider::EthSubscriptionIdProvider;
+pub use log_filter::LogFilter;
 pub use pending_block::{PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
 pub use transaction::{FillTransactionResult, TransactionDataAndReceipt, TransactionSource};
 pub use tx_forward::ForwardConfig;

--- a/crates/rpc/rpc-eth-types/src/log_filter.rs
+++ b/crates/rpc/rpc-eth-types/src/log_filter.rs
@@ -44,7 +44,8 @@ pub struct LogFilter {
 impl LogFilter {
     /// Creates a new [`LogFilter`] from a [`Filter`] and an explicit topic-position count.
     ///
-    /// The count is clamped to [`MAX_TOPICS`], matching the limit [`Filter`] itself enforces.
+    /// The count is clamped to four, the width of [`Filter`]'s topics array and the most positions
+    /// a log can carry.
     pub fn new(filter: Filter, topic_positions: usize) -> Self {
         Self { filter, topic_positions: topic_positions.min(MAX_TOPICS) }
     }

--- a/crates/rpc/rpc-eth-types/src/log_filter.rs
+++ b/crates/rpc/rpc-eth-types/src/log_filter.rs
@@ -1,0 +1,237 @@
+//! A log filter that remembers how many topic positions the caller actually specified.
+//!
+//! [`Filter`] stores topics as a fixed `[Topic; 4]` where an empty entry means "wildcard", so the
+//! number of positions present in the request is lost during deserialization: `topics: []` and
+//! `topics: [[], [], []]` both become four empty sets.
+//!
+//! That distinction is load-bearing. Per `eth_getLogs`, a filter naming N topic positions only
+//! matches logs carrying at least N topics — an empty array makes a position match anything, it
+//! does not make the position optional. go-ethereum enforces this with an explicit length check
+//! before comparing positions (`filterLogs` in `eth/filters/filter.go`):
+//!
+//! ```text
+//! if len(topics) > len(log.Topics) {
+//!     continue Logs
+//! }
+//! ```
+//!
+//! Without the count, `Filter::matches` cannot reproduce that rule: its `matches_topics` accepts a
+//! filter position that has no counterpart in the log whenever that position is a wildcard, so a
+//! two-topic log satisfies a three-position filter. Restoring the count here is what makes the
+//! check possible.
+
+use alloy_primitives::B256;
+use alloy_rpc_types_eth::Filter;
+use serde::{Deserialize, Deserializer};
+use std::ops::Deref;
+
+/// Maximum number of topic positions a log can carry, and therefore the most a filter can
+/// meaningfully name. Mirrors the width of [`Filter`]'s topics array.
+const MAX_TOPICS: usize = 4;
+
+/// A [`Filter`] paired with the number of topic positions named in the request.
+///
+/// Derefs to the inner [`Filter`], so this can be used anywhere a filter is expected. Use
+/// [`LogFilter::matches_topic_count`] to apply the position-count rule that [`Filter`] alone cannot
+/// express — see the [module docs](self) for why.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LogFilter {
+    filter: Filter,
+    /// Number of topic positions present in the request, `0` when `topics` was absent or empty.
+    topic_positions: usize,
+}
+
+impl LogFilter {
+    /// Creates a new [`LogFilter`] from a [`Filter`] and an explicit topic-position count.
+    ///
+    /// The count is clamped to [`MAX_TOPICS`], matching the limit [`Filter`] itself enforces.
+    pub fn new(filter: Filter, topic_positions: usize) -> Self {
+        Self { filter, topic_positions: topic_positions.min(MAX_TOPICS) }
+    }
+
+    /// Returns the number of topic positions the request named.
+    pub const fn topic_positions(&self) -> usize {
+        self.topic_positions
+    }
+
+    /// Returns a reference to the inner [`Filter`].
+    pub const fn filter(&self) -> &Filter {
+        &self.filter
+    }
+
+    /// Consumes this filter and returns the inner [`Filter`].
+    pub fn into_filter(self) -> Filter {
+        self.filter
+    }
+
+    /// Returns `true` if the log carries at least as many topics as the request named.
+    ///
+    /// This is the check [`Filter::matches`] cannot perform, and must be applied *in addition* to
+    /// it. A filter that named no positions imposes no constraint.
+    pub const fn matches_topic_count(&self, topics: &[B256]) -> bool {
+        topics.len() >= self.topic_positions
+    }
+}
+
+impl Deref for LogFilter {
+    type Target = Filter;
+
+    fn deref(&self) -> &Self::Target {
+        &self.filter
+    }
+}
+
+impl From<Filter> for LogFilter {
+    /// Builds a [`LogFilter`] from a [`Filter`] that was not deserialized from a request.
+    ///
+    /// The position count is unrecoverable at this point, so this imposes no length constraint —
+    /// preserving the previous behaviour for internally constructed filters.
+    fn from(filter: Filter) -> Self {
+        Self { filter, topic_positions: 0 }
+    }
+}
+
+impl From<LogFilter> for Filter {
+    fn from(value: LogFilter) -> Self {
+        value.filter
+    }
+}
+
+impl<'de> Deserialize<'de> for LogFilter {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Deserialize once into a generic value so the topics array can be counted, then hand the
+        // same value to `Filter`'s own deserializer rather than reimplementing it — it accepts
+        // several shapes (`blockHash` vs `fromBlock`/`toBlock`, single address vs array) that are
+        // easy to get subtly wrong.
+        let value = serde_json::Value::deserialize(deserializer)?;
+
+        let topic_positions = value
+            .get("topics")
+            .and_then(|topics| topics.as_array())
+            .map(|topics| topics.len())
+            .unwrap_or(0);
+
+        let filter = Filter::deserialize(&value).map_err(serde::de::Error::custom)?;
+
+        Ok(Self::new(filter, topic_positions))
+    }
+}
+
+impl serde::Serialize for LogFilter {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // The count is derived from `topics`, which the inner filter already round-trips.
+        self.filter.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, B256};
+
+    fn topics(n: usize) -> Vec<B256> {
+        (0..n).map(|i| B256::with_last_byte(i as u8)).collect()
+    }
+
+    fn parse(json: &str) -> LogFilter {
+        serde_json::from_str(json).expect("valid filter")
+    }
+
+    #[test]
+    fn counts_specified_wildcard_positions() {
+        // The case from the report: three wildcard positions must still require three topics.
+        let filter = parse(r#"{"topics":[[],[],[]]}"#);
+        assert_eq!(filter.topic_positions(), 3);
+        assert!(!filter.matches_topic_count(&topics(2)));
+        assert!(filter.matches_topic_count(&topics(3)));
+        assert!(filter.matches_topic_count(&topics(4)));
+    }
+
+    #[test]
+    fn absent_and_empty_topics_impose_no_constraint() {
+        // These must stay distinguishable from `[[],[],[]]`, otherwise every ordinary query would
+        // start demanding topics.
+        for json in [r#"{}"#, r#"{"topics":[]}"#, r#"{"fromBlock":"0x1"}"#] {
+            let filter = parse(json);
+            assert_eq!(filter.topic_positions(), 0, "{json}");
+            assert!(filter.matches_topic_count(&topics(0)), "{json}");
+        }
+    }
+
+    #[test]
+    fn null_positions_count_as_specified() {
+        // `null` is the other spelling of "wildcard at this position", so it counts too.
+        let filter = parse(r#"{"topics":[null,null]}"#);
+        assert_eq!(filter.topic_positions(), 2);
+        assert!(!filter.matches_topic_count(&topics(1)));
+        assert!(filter.matches_topic_count(&topics(2)));
+    }
+
+    #[test]
+    fn concrete_topics_are_counted_and_still_parsed() {
+        let topic = B256::with_last_byte(9);
+        let filter = parse(&format!(r#"{{"topics":["{topic}",[]]}}"#));
+        assert_eq!(filter.topic_positions(), 2);
+        // The inner filter must still carry the concrete topic, i.e. counting did not disturb
+        // `Filter`'s own deserialization.
+        assert!(filter.filter().topics[0].matches(&topic));
+        assert!(filter.filter().topics[1].is_empty());
+    }
+
+    #[test]
+    fn inner_filter_fields_survive_the_two_step_deserialize() {
+        let filter = parse(
+            r#"{"address":"0x0000000000000000000000000000000000001002",
+                "fromBlock":"0x2b1fda","toBlock":"0x2b203e","topics":[[],[],[]]}"#,
+        );
+        assert_eq!(filter.topic_positions(), 3);
+        assert!(filter
+            .filter()
+            .address
+            .matches(&"0x0000000000000000000000000000000000001002".parse::<Address>().unwrap()));
+        assert_eq!(filter.filter().get_from_block(), Some(0x2b1fda));
+        assert_eq!(filter.filter().get_to_block(), Some(0x2b203e));
+    }
+
+    #[test]
+    fn internally_constructed_filters_are_unconstrained() {
+        // `From<Filter>` is used where no request was parsed; it must not start rejecting logs.
+        let filter = LogFilter::from(Filter::default());
+        assert_eq!(filter.topic_positions(), 0);
+        assert!(filter.matches_topic_count(&topics(0)));
+    }
+
+    #[test]
+    fn position_count_is_clamped_to_max_topics() {
+        assert_eq!(LogFilter::new(Filter::default(), 9).topic_positions(), MAX_TOPICS);
+    }
+
+    #[test]
+    fn serialize_drops_trailing_wildcards_so_a_round_trip_only_loosens() {
+        let filter = parse(r#"{"topics":[[],[],[]]}"#);
+        let json = serde_json::to_string(&filter).unwrap();
+        let round_tripped: LogFilter = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(round_tripped.filter(), filter.filter());
+        // `Filter::serialize` truncates trailing empty positions, so all-wildcard topics come back
+        // as `[]`. The count is therefore lost across a serialize/deserialize hop, which means the
+        // constraint can only ever relax, never wrongly reject. Requests are parsed from the
+        // caller's JSON directly, so this does not affect the server path; it does mean the
+        // generated Rust client cannot express the constraint, which matches today's behaviour.
+        assert!(json.contains(r#""topics":[]"#), "{json}");
+        assert_eq!(round_tripped.topic_positions(), 0);
+
+        // A concrete topic pins the length, so that part does survive.
+        let pinned = parse(
+            r#"{"topics":[[],[],["0x0000000000000000000000000000000000000000000000000000000000000009"]]}"#,
+        );
+        let pinned_json = serde_json::to_string(&pinned).unwrap();
+        assert_eq!(serde_json::from_str::<LogFilter>(&pinned_json).unwrap().topic_positions(), 3);
+    }
+}

--- a/crates/rpc/rpc/src/engine.rs
+++ b/crates/rpc/rpc/src/engine.rs
@@ -1,7 +1,7 @@
 use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, Bytes, B256, U256, U64};
 use alloy_rpc_types_eth::{
-    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Filter, Log, SyncStatus,
+    state::StateOverride, BlockOverrides, EIP1186AccountProofResponse, Log, SyncStatus,
 };
 use alloy_serde::JsonStorageKey;
 use jsonrpsee::core::RpcResult as Result;
@@ -11,7 +11,8 @@ use reth_rpc_convert::RpcTxReq;
 /// Re-export for convenience
 pub use reth_rpc_engine_api::EngineApi;
 use reth_rpc_eth_api::{
-    EngineEthFilter, FullEthApiTypes, QueryLimits, RpcBlock, RpcHeader, RpcReceipt, RpcTransaction,
+    EngineEthFilter, FullEthApiTypes, LogFilter, QueryLimits, RpcBlock, RpcHeader, RpcReceipt,
+    RpcTransaction,
 };
 use serde_json::Value;
 use tracing_futures::Instrument;
@@ -133,7 +134,7 @@ where
     }
 
     /// Handler for `eth_getLogs`
-    async fn logs(&self, filter: Filter) -> Result<Vec<Log>> {
+    async fn logs(&self, filter: LogFilter) -> Result<Vec<Log>> {
         self.eth_filter.logs(filter, QueryLimits::no_limits()).instrument(engine_span!()).await
     }
 

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -24,7 +24,7 @@ use reth_rpc_eth_api::{
 };
 use reth_rpc_eth_types::{
     logs_utils::{self, append_matching_block_logs, ProviderOrBlock},
-    EthApiError, EthFilterConfig, EthStateCache, EthSubscriptionIdProvider,
+    EthApiError, EthFilterConfig, EthStateCache, EthSubscriptionIdProvider, LogFilter,
 };
 use reth_rpc_server_types::{result::rpc_error_with_code, ToRpcResult};
 use reth_storage_api::{
@@ -59,7 +59,7 @@ where
     /// Returns logs matching given filter object, no query limits
     fn logs(
         &self,
-        filter: Filter,
+        filter: LogFilter,
         limits: QueryLimits,
     ) -> impl Future<Output = RpcResult<Vec<Log>>> + Send {
         trace!(target: "rpc::eth", "Serving eth_getLogs");
@@ -282,16 +282,22 @@ where
                         (block_number, block_number)
                     }
                 };
-                let logs = self
+                let topic_positions = filter.topic_positions();
+                let mut logs = self
                     .inner
                     .clone()
                     .get_logs_in_block_range(
-                        *filter,
+                        filter.into_filter(),
                         from_block_number,
                         to_block_number,
                         self.inner.query_limits,
                     )
                     .await?;
+                // Installed filters must apply the topic-position count on every poll, exactly as
+                // `eth_getLogs` does. See `LogFilter`.
+                if topic_positions > 0 {
+                    logs.retain(|log| log.topics().len() >= topic_positions);
+                }
                 Ok(FilterChanges::Logs(logs))
             }
         }
@@ -322,7 +328,7 @@ where
     /// Returns logs matching given filter object.
     async fn logs_for_filter(
         &self,
-        filter: Filter,
+        filter: LogFilter,
         limits: QueryLimits,
     ) -> Result<Vec<Log>, EthFilterError> {
         self.inner.clone().logs_for_filter(filter, limits).await
@@ -335,7 +341,7 @@ where
     Eth: FullEthApiTypes + RpcNodeCoreExt + LoadReceipt + EthBlocks + 'static,
 {
     /// Handler for `eth_newFilter`
-    async fn new_filter(&self, filter: Filter) -> RpcResult<FilterId> {
+    async fn new_filter(&self, filter: LogFilter) -> RpcResult<FilterId> {
         trace!(target: "rpc::eth", "Serving eth_newFilter");
         self.inner
             .install_filter(FilterKind::<RpcTransaction<Eth::NetworkTypes>>::Log(Box::new(filter)))
@@ -411,7 +417,7 @@ where
     /// Returns logs matching given filter object.
     ///
     /// Handler for `eth_getLogs`
-    async fn logs(&self, filter: Filter) -> RpcResult<Vec<Log>> {
+    async fn logs(&self, filter: LogFilter) -> RpcResult<Vec<Log>> {
         trace!(target: "rpc::eth", "Serving eth_getLogs");
         Ok(self.logs_for_filter(filter, self.inner.query_limits).await?)
     }
@@ -464,7 +470,31 @@ where
     }
 
     /// Returns logs matching given filter object.
+    /// Returns logs matching the filter, enforcing the topic-position count.
+    ///
+    /// [`Filter`] cannot express "the request named N topic positions" (see [`LogFilter`]), so the
+    /// count is applied here, on top of the per-position matching that `Filter::matches` performs
+    /// during collection. go-ethereum applies the equivalent length check before comparing
+    /// positions, which is why a filter such as `topics: [[], [], []]` must not match a two-topic
+    /// log even though every position is a wildcard.
     async fn logs_for_filter(
+        self: Arc<Self>,
+        filter: LogFilter,
+        limits: QueryLimits,
+    ) -> Result<Vec<Log>, EthFilterError> {
+        let topic_positions = filter.topic_positions();
+        let mut logs = self.logs_for_filter_unchecked(filter.into_filter(), limits).await?;
+        if topic_positions > 0 {
+            logs.retain(|log| log.topics().len() >= topic_positions);
+        }
+        Ok(logs)
+    }
+
+    /// Collects logs matching the filter's addresses, block range and individual topic positions.
+    ///
+    /// Does **not** apply the topic-position count rule; call [`Self::logs_for_filter`] instead
+    /// unless you have already applied it.
+    async fn logs_for_filter_unchecked(
         self: Arc<Self>,
         filter: Filter,
         limits: QueryLimits,
@@ -906,7 +936,7 @@ impl<T: 'static> PendingTransactionKind<T> {
 
 #[derive(Clone, Debug)]
 enum FilterKind<T> {
-    Log(Box<Filter>),
+    Log(Box<LogFilter>),
     Block,
     PendingTransaction(PendingTransactionKind<T>),
 }


### PR DESCRIPTION
> Stacked on #210 — review that first. This PR's diff is the single commit on top of it.

## Problem

A log filter naming N topic positions only matches logs carrying at least N topics. An empty array makes a position match *anything*; it does not make the position *optional*. reth ignored the count.

Measured against geth v1.7.6 on the same archive node pair, blocks `0x2b1fda`–`0x2b203e`, `topics: [[], [], []]`:

| | logs returned | with fewer than 3 topics |
|---|---|---|
| reth | 80 | **54** |
| geth | 26 | 0 |

geth's 26 were a subset of reth's 80 — reth over-matched and never under-matched.

## Root cause: not a missing check

`alloy_rpc_types_eth::Filter` stores topics as a fixed `[Topic; 4]`, and its deserializer discards the length:

```rust
let mut topics: [Topic; 4] = [Default::default(), …];
for (idx, topic) in topics_vec.into_iter().enumerate() {
    topics[idx] = topic.map(|t| t.into()).unwrap_or_default();
}
```

So `topics: []` and `topics: [[], [], []]` both become four empty sets. reth could not see that three positions were named. Confirmed on the same node — both requests return byte-identical results:

```
topics: [[],[],[]]   -> 80 logs, 54 with <3 topics
topics omitted       -> 80 logs, 54 with <3 topics
```

That also rules out the obvious one-line fix. `Filter::matches_topics` has:

```rust
Left(filter) => filter.is_empty(),
```

which accepts a filter position with no counterpart in the log whenever that position is a wildcard. **Flipping it to `false` would make a filter with no topics demand four**, breaking every ordinary query. go-ethereum can apply the rule directly because it still has the caller's slice (`filterLogs`, `eth/filters/filter.go`):

```go
if len(topics) > len(log.Topics) { continue Logs }
```

## Fix

`LogFilter` records the position count at deserialization and derefs to `Filter`, so existing code is unaffected. The count is enforced alongside the existing per-position matching, on **every** path that accepts a caller-supplied log filter:

- `eth_getLogs`
- `eth_getFilterLogs`
- `eth_getFilterChanges` — the count is stored with the installed filter, so each poll re-applies it
- the engine API's own `eth_getLogs`, which had the same defect

The collection body is wrapped rather than rewritten, so the change is confined to the new count check.

## Verification

Replayed the reported range: applying the rule to the 80 logs the deployed node returns yields exactly **26**, and that set is **identical to geth's** keyed by `(transactionHash, logIndex)`.

8 unit tests cover the reported case, `null` positions, that the inner filter's fields survive the two-step deserialize, and the critical negative controls — `{}` and `topics: []` must stay unconstrained, otherwise every ordinary query starts demanding topics.

Also run: `cargo +nightly fmt --check --all`, and `cargo clippy --workspace --lib --examples --tests --benches --all-features --locked` under `RUSTFLAGS=-D warnings`, both clean.

## Known limits, both pinned by tests

- **`eth_subscribe("logs")` is not fixed.** It takes `alloy_rpc_types_eth::pubsub::Params`, which embeds a bare `Filter`, so the count is lost before reth sees it. Fixing it means wrapping that type too.
- **`Filter::serialize` truncates trailing empty positions**, so a serialize/deserialize round trip drops the count and relaxes the constraint. The direction is safe — never a false rejection — and matches previous behaviour, but the generated Rust client cannot express the constraint.

The clean fix for both is in alloy: keep the caller's position count on `Filter`. This PR deliberately avoids that so it can ship without an upstream dependency.

`serde_json` moves from a dev-dependency to a dependency of `reth-rpc-eth-types`, because the count is taken by deserializing once into a `Value` and then handing that value to `Filter`'s own deserializer rather than reimplementing it.

---

# Second commit: `totalDifficulty` missing from header responses

`eth_getHeaderByHash`, `eth_getHeaderByNumber` and `eth_getFinalizedHeader` omitted `totalDifficulty`, so clients reading it got `undefined`. `rpc_block_header` passed `None` while `rpc_block` looked the value up — which is why `eth_getBlockByHash` returned the field for the very same block that `eth_getHeaderByHash` did not.

Measured against geth v1.7.6 on the same archive node pair:

| method | reth before | geth |
|---|---|---|
| `eth_getHeaderByHash` | **MISSING** | `0x563090` |
| `eth_getHeaderByNumber` | **MISSING** | `0x562fca` |
| `eth_getFinalizedHeader` | **MISSING** | `0x57daf3` |
| `eth_getBlockByHash` | `0x563090` | `0x563090` |

The report covered only `eth_getHeaderByHash`; the other two share `rpc_block_header`, so all three were affected and all three are fixed.

This matches go-bsc, where `rpcMarshalHeader` **always** attaches the total difficulty — unlike `rpcMarshalBlock`, which only does so when transactions are included (`internal/ethapi/api.go`).

## Fix

The lookup `rpc_block` already performed — stored total difficulty, falling back to `parent_td + header.difficulty` for blocks not yet in the database, such as the pending block — is extracted into `EthBlocks::total_difficulty_for` and called from both paths, so they cannot drift apart again. How the value is derived is unchanged.

**Deliberately unchanged:** the `newHeads` subscription still passes `None`. go-bsc marshals `types.Header` directly there and does not attach the total difficulty, so reth already matches. Uncle headers likewise keep `None`.

---

# End-to-end verification of both commits

Built reth-bsc against this branch and ran a node on real chain data.

**Topic-position count** — note the graduated behaviour, which shows the *count* is honoured rather than logs being filtered indiscriminately. The 16 logs in this range carry 2 topics each:

```
topics omitted        -> 16 logs
topics [[],[]]        -> 16 logs   (2 positions: 2-topic logs qualify)
topics [[],[],[]]     ->  0 logs   (3 positions: they no longer qualify)
topics [[],[],[],[]]  ->  0 logs
```

The installed-filter path agrees, confirming the count is stored with the filter and re-applied on every poll:

```
eth_newFilter{topics: null}       + eth_getFilterLogs -> 16
eth_newFilter{topics: [[],[]]}    + eth_getFilterLogs -> 16
eth_newFilter{topics: [[],[],[]]} + eth_getFilterLogs ->  0
```

**Total difficulty** — all three header methods now agree with `eth_getBlockByHash` on the same block, which is the cross-check the report itself used:

```
eth_getHeaderByHash    td=0x354c4
eth_getHeaderByNumber  td=0x354c4
eth_getBlockByHash     td=0x354c4
eth_getFinalizedHeader td=0x357c2   (its own, later block)
```
