### PR TITLE
fix(rpc): apply the topic-position count while selecting logs, not after

### DIFF
--- a/crates/rpc/rpc-eth-types/src/logs_utils.rs
+++ b/crates/rpc/rpc-eth-types/src/logs_utils.rs
@@ -2,6 +2,7 @@
 //!
 //! Log parsing for building filter.
 
+use crate::LogFilter;
 use alloy_consensus::TxReceipt;
 use alloy_eips::{eip2718::Encodable2718, BlockNumHash};
 use alloy_primitives::TxHash;
@@ -67,10 +68,14 @@ pub enum ProviderOrBlock<'a, P: BlockReader> {
 
 /// Appends all matching logs of a block's receipts.
 /// If the log matches, look up the corresponding transaction hash.
+///
+/// Takes a [`LogFilter`] rather than a [`Filter`] so the topic-position count is enforced here,
+/// where logs are selected. Applying it afterwards would let the caller's `max_logs_per_response`
+/// check count logs that do not actually match, and reject a query go-ethereum answers.
 pub fn append_matching_block_logs<P>(
     all_logs: &mut Vec<Log>,
     provider_or_block: ProviderOrBlock<'_, P>,
-    filter: &Filter,
+    filter: &LogFilter,
     block_num_hash: BlockNumHash,
     receipts: &[P::Receipt],
     removed: bool,
@@ -97,7 +102,7 @@ where
         let mut transaction_hash = None;
 
         for log in receipt.logs() {
-            if filter.matches(log) {
+            if filter.matches(log) && filter.matches_topic_count(log.topics()) {
                 // if this is the first match in the receipt's logs, look up the transaction hash
                 if transaction_hash.is_none() {
                     transaction_hash = match &provider_or_block {

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -4,8 +4,7 @@ use alloy_consensus::BlockHeader;
 use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::{Sealable, TxHash};
 use alloy_rpc_types_eth::{
-    BlockNumHash, Filter, FilterBlockOption, FilterChanges, FilterId, Log,
-    PendingTransactionFilterKind,
+    BlockNumHash, FilterBlockOption, FilterChanges, FilterId, Log, PendingTransactionFilterKind,
 };
 use async_trait::async_trait;
 use futures::{
@@ -282,22 +281,16 @@ where
                         (block_number, block_number)
                     }
                 };
-                let topic_positions = filter.topic_positions();
-                let mut logs = self
+                let logs = self
                     .inner
                     .clone()
                     .get_logs_in_block_range(
-                        filter.into_filter(),
+                        *filter,
                         from_block_number,
                         to_block_number,
                         self.inner.query_limits,
                     )
                     .await?;
-                // Installed filters must apply the topic-position count on every poll, exactly as
-                // `eth_getLogs` does. See `LogFilter`.
-                if topic_positions > 0 {
-                    logs.retain(|log| log.topics().len() >= topic_positions);
-                }
                 Ok(FilterChanges::Logs(logs))
             }
         }
@@ -470,33 +463,13 @@ where
     }
 
     /// Returns logs matching given filter object.
-    /// Returns logs matching the filter, enforcing the topic-position count.
+    /// Returns logs matching the filter.
     ///
-    /// [`Filter`] cannot express "the request named N topic positions" (see [`LogFilter`]), so the
-    /// count is applied here, on top of the per-position matching that `Filter::matches` performs
-    /// during collection. go-ethereum applies the equivalent length check before comparing
-    /// positions, which is why a filter such as `topics: [[], [], []]` must not match a two-topic
-    /// log even though every position is a wildcard.
+    /// The topic-position count is enforced by [`append_matching_block_logs`], i.e. while logs are
+    /// selected, so that `max_logs_per_response` counts only logs that actually match.
     async fn logs_for_filter(
         self: Arc<Self>,
         filter: LogFilter,
-        limits: QueryLimits,
-    ) -> Result<Vec<Log>, EthFilterError> {
-        let topic_positions = filter.topic_positions();
-        let mut logs = self.logs_for_filter_unchecked(filter.into_filter(), limits).await?;
-        if topic_positions > 0 {
-            logs.retain(|log| log.topics().len() >= topic_positions);
-        }
-        Ok(logs)
-    }
-
-    /// Collects logs matching the filter's addresses, block range and individual topic positions.
-    ///
-    /// Does **not** apply the topic-position count rule; call [`Self::logs_for_filter`] instead
-    /// unless you have already applied it.
-    async fn logs_for_filter_unchecked(
-        self: Arc<Self>,
-        filter: Filter,
         limits: QueryLimits,
     ) -> Result<Vec<Log>, EthFilterError> {
         match filter.block_option {
@@ -653,7 +626,7 @@ where
     ///  - amount of matches exceeds configured limit
     async fn get_logs_in_block_range(
         self: Arc<Self>,
-        filter: Filter,
+        filter: LogFilter,
         from_block: u64,
         to_block: u64,
         limits: QueryLimits,
@@ -692,7 +665,7 @@ where
     ///  - underlying database error
     async fn get_logs_in_block_range_inner(
         self: Arc<Self>,
-        filter: &Filter,
+        filter: &LogFilter,
         from_block: u64,
         to_block: u64,
         limits: QueryLimits,
@@ -1380,6 +1353,7 @@ mod tests {
     use crate::{eth::EthApi, EthApiBuilder};
     use alloy_network::Ethereum;
     use alloy_primitives::FixedBytes;
+    use alloy_rpc_types_eth::Filter;
     use rand::Rng;
     use reth_chainspec::{ChainSpec, ChainSpecProvider};
     use reth_ethereum_primitives::TxType;
@@ -1849,6 +1823,114 @@ mod tests {
         assert!(result.is_none());
     }
 
+    /// Seeds a provider with one bloom-matching block per number, each carrying a single log with
+    /// **zero topics**, so any filter naming a topic position must exclude every one of them.
+    fn seed_blocks_with_topicless_logs(blocks: std::ops::RangeInclusive<u64>) -> MockEthProvider {
+        use alloy_consensus::TxLegacy;
+        use reth_db_api::models::StoredBlockBodyIndices;
+        use reth_ethereum_primitives::{TransactionSigned, TxType};
+
+        let provider = MockEthProvider::default();
+
+        let tx_inner = TxLegacy {
+            chain_id: Some(1),
+            nonce: 0,
+            gas_price: 21_000,
+            gas_limit: 21_000,
+            to: alloy_primitives::TxKind::Call(alloy_primitives::Address::ZERO),
+            value: alloy_primitives::U256::ZERO,
+            input: alloy_primitives::Bytes::new(),
+        };
+        let tx = TransactionSigned::new_unhashed(
+            tx_inner.into(),
+            alloy_primitives::Signature::test_signature(),
+        );
+
+        let receipt = reth_ethereum_primitives::Receipt {
+            tx_type: TxType::Legacy,
+            cumulative_gas_used: 21_000,
+            logs: vec![alloy_primitives::Log {
+                address: alloy_primitives::Address::ZERO,
+                data: alloy_primitives::LogData::new_unchecked(
+                    vec![],
+                    alloy_primitives::Bytes::new(),
+                ),
+            }],
+            success: true,
+        };
+
+        let mut prev_hash = alloy_primitives::B256::default();
+        for (idx, block_number) in blocks.enumerate() {
+            let header = alloy_consensus::Header {
+                number: block_number,
+                parent_hash: prev_hash,
+                logs_bloom: alloy_primitives::Bloom::from([1u8; 256]),
+                ..Default::default()
+            };
+            let hash = header.hash_slow();
+            prev_hash = hash;
+
+            provider.add_block(
+                hash,
+                reth_ethereum_primitives::Block {
+                    header,
+                    body: reth_ethereum_primitives::BlockBody {
+                        transactions: vec![tx.clone()],
+                        ..Default::default()
+                    },
+                },
+            );
+            provider.add_receipts(block_number, vec![receipt.clone()]);
+            provider.add_block_body_indices(
+                block_number,
+                StoredBlockBodyIndices { first_tx_num: idx as u64, tx_count: 1 },
+            );
+        }
+
+        provider
+    }
+
+    /// The topic-position count must also hold on ranges wide enough to leave cached mode.
+    ///
+    /// `should_use_cached_mode` drops to `RangeMode::Range` past `CACHED_MODE_BLOCK_THRESHOLD`
+    /// (250, halved to 125 once bloom matches exceed 20), so a several-hundred-block query takes a
+    /// different path than the ~100-block one. Both feed the same `append_matching_block_logs`
+    /// call, and this pins that.
+    #[tokio::test]
+    async fn test_topic_position_count_holds_in_range_mode() {
+        let provider = seed_blocks_with_topicless_logs(100..=500);
+        let eth_api = build_test_eth_api(provider);
+        let eth_filter = EthFilter::new(eth_api, EthFilterConfig::default(), Runtime::test());
+        let limits = QueryLimits::no_limits();
+
+        // 401 blocks, every one bloom-matching, so this is well past the adjusted threshold.
+        let unconstrained = eth_filter
+            .inner
+            .clone()
+            .get_logs_in_block_range(Filter::default().into(), 100, 500, limits)
+            .await
+            .expect("unconstrained query should succeed");
+        assert_eq!(unconstrained.len(), 401, "each block contributes one zero-topic log");
+
+        for positions in 1..=4 {
+            let logs = eth_filter
+                .inner
+                .clone()
+                .get_logs_in_block_range(
+                    LogFilter::new(Filter::default(), positions),
+                    100,
+                    500,
+                    limits,
+                )
+                .await
+                .expect("constrained query should succeed");
+            assert!(
+                logs.is_empty(),
+                "zero-topic logs cannot match a {positions}-position filter: {logs:?}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn test_log_limit_retry_range_excludes_overflow_block() {
         let provider = MockEthProvider::default();
@@ -1913,7 +1995,7 @@ mod tests {
             .inner
             .clone()
             .get_logs_in_block_range(
-                Filter::default(),
+                Filter::default().into(),
                 100,
                 102,
                 QueryLimits { max_blocks_per_filter: None, max_logs_per_response: Some(2) },
@@ -1928,6 +2010,43 @@ mod tests {
         assert_eq!(max_logs, 2);
         assert_eq!(from_block, 100);
         assert_eq!(to_block, 101);
+    }
+
+    /// Logs excluded by the topic-position count must not count toward
+    /// `max_logs_per_response`.
+    ///
+    /// The count is enforced while logs are selected, not afterwards. If it were applied to the
+    /// finished vector, the limit check would already have tripped on logs that do not match, and
+    /// this query would fail where go-ethereum answers it.
+    #[tokio::test]
+    async fn test_topic_position_count_applies_before_the_log_limit() {
+        let provider = seed_blocks_with_topicless_logs(100..=102);
+        let eth_api = build_test_eth_api(provider);
+        let eth_filter = EthFilter::new(eth_api, EthFilterConfig::default(), Runtime::test());
+        let limits = QueryLimits { max_blocks_per_filter: None, max_logs_per_response: Some(2) };
+
+        // Control: with no topic positions named, the three logs exceed the limit of two. This is
+        // the behaviour `test_log_limit_retry_range_excludes_overflow_block` pins.
+        let err = eth_filter
+            .inner
+            .clone()
+            .get_logs_in_block_range(Filter::default().into(), 100, 102, limits)
+            .await
+            .expect_err("without a topic-position constraint the limit should trip");
+        assert!(
+            matches!(err, EthFilterError::QueryExceedsMaxResults { .. }),
+            "unexpected error: {err:?}"
+        );
+
+        // Naming three positions excludes every zero-topic log, so nothing is left to exceed the
+        // limit and the query succeeds with an empty result.
+        let logs = eth_filter
+            .inner
+            .clone()
+            .get_logs_in_block_range(LogFilter::new(Filter::default(), 3), 100, 102, limits)
+            .await
+            .expect("excluded logs must not count toward the limit");
+        assert!(logs.is_empty(), "zero-topic logs cannot match a three-position filter: {logs:?}");
     }
 
     #[tokio::test]
@@ -2020,7 +2139,7 @@ mod tests {
         let logs = eth_filter
             .inner
             .clone()
-            .get_logs_in_block_range(filter, 100, 103, QueryLimits::default())
+            .get_logs_in_block_range(filter.into(), 100, 103, QueryLimits::default())
             .await
             .expect("should succeed");
 


### PR DESCRIPTION
> Stacked on #210 — review that first. Follow-up to #212, which is already merged into that branch.

Auditing #212 against the two `eth_getLogs` cases in the report turned up two gaps.

## 1. The count ran *after* `max_logs_per_response`

That limit is enforced inside `get_logs_in_block_range_inner`, as logs accumulate:

```rust
if let Some(max_logs_per_response) = limits.max_logs_per_response &&
    is_multi_block_range &&
    all_logs.len() > max_logs_per_response
{
    return Err(EthFilterError::QueryExceedsMaxResults { .. });
}
```

#212 applied the topic-position count to the *finished* vector, so a query could fail with `QueryExceedsMaxResults` having counted logs that do not match the filter at all — where go-ethereum, which excludes them during collection, answers normally. On the reported data 54 of 80 logs were non-matching, so the inflation is substantial, and it is most likely to bite on wide ranges — exactly the `range_1000` case below.

## 2. Only the ~100-block path had been exercised

`should_use_cached_mode` switches from `RangeMode::Cached` to `RangeMode::Range` past `CACHED_MODE_BLOCK_THRESHOLD` (250, halved to 125 once bloom matches exceed 20). The two reported cases straddle that:

| case | range | mode |
|---|---|---|
| `Test_getLogs_block_range2/latest_block,_range_100` | 100 blocks | `Cached` — verified in #212 |
| `Test_getLogs_block_range3/latest_block,_range_1000` | 1000 blocks | **`Range` — not verified** |

## Fix

Move the check to where logs are selected, in `append_matching_block_logs`:

```rust
if filter.matches(log) && filter.matches_topic_count(log.topics()) {
```

So `max_logs_per_response` counts only logs that match, and cached and range mode are covered by construction — there is one selection point, not two. This also removes the post-hoc retains in `logs_for_filter` and the `eth_getFilterChanges` branch, and the `logs_for_filter_unchecked` split they required.

## Tests

- `test_topic_position_count_applies_before_the_log_limit` — with a limit of two and three zero-topic logs, an unconstrained filter still errors (the control, matching the existing `test_log_limit_retry_range_excludes_overflow_block`), while a three-position filter returns empty instead of erroring.
- `test_topic_position_count_holds_in_range_mode` — over 401 blocks, well past the adjusted threshold: 401 logs unconstrained, none for any position count `1..=4`.

Verified with the CI jobs' own commands and exit codes: clippy `--workspace --lib --examples --tests --benches --all-features --locked` under `-D warnings` → 0, `fmt --check --all` → 0, `cargo docs --document-private-items` with the CI `RUSTDOCFLAGS` → 0, and 95 tests across the three rpc crates.

## Unchanged

`matching_block_logs_with_tx_hashes` still takes a plain `Filter`: its only caller is the `eth_subscribe("logs")` path, which receives `alloy_rpc_types_eth::pubsub::Params` and so cannot know the count. Same limitation #212 documented.
