### PR TITLE
perf(rpc): log storage read breakdown for block traces

### DIFF
--- a/crates/rpc/rpc-eth-api/Cargo.toml
+++ b/crates/rpc/rpc-eth-api/Cargo.toml
@@ -19,7 +19,7 @@ revm-inspectors.workspace = true
 reth-primitives-traits = { workspace = true, features = ["rpc-compat"] }
 reth-errors.workspace = true
 reth-evm.workspace = true
-reth-storage-api.workspace = true
+reth-storage-api = { workspace = true, features = ["std"] }
 reth-revm.workspace = true
 reth-rpc-convert.workspace = true
 reth-tasks = { workspace = true, features = ["rayon"] }

--- a/crates/rpc/rpc-eth-api/src/helpers/trace.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/trace.rs
@@ -17,11 +17,13 @@ use reth_revm::{
     database::StateProviderDatabase,
     db::{bal::EvmDatabaseError, State},
 };
-use reth_rpc_eth_types::cache::db::StateCacheDb;
-use reth_storage_api::{ProviderBlock, ProviderTx};
+use reth_rpc_eth_types::{
+    cache::db::StateCacheDb, log_block_storage_timings, storage_timings_enabled,
+};
+use reth_storage_api::{ProviderBlock, ProviderTx, StorageTimingsScope};
 use revm::{context::Block, context_interface::result::ResultAndState};
 use revm_inspectors::tracing::{TracingInspector, TracingInspectorConfig};
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 /// Executes CPU heavy tasks.
 pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
@@ -287,6 +289,9 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                 let block_timestamp = evm_env.block_env.timestamp().saturating_to();
                 let base_fee = evm_env.block_env.basefee();
 
+                let started_at = Instant::now();
+                let storage_timings = StorageTimingsScope::new(storage_timings_enabled());
+
                 this.apply_pre_execution_changes(&block, &mut db, evm_env.clone())?;
 
                 // prepare transactions, we do everything upfront to reduce time spent with open
@@ -319,6 +324,16 @@ pub trait Trace: LoadState<Error: FromEvmError<Self::Evm>> + Call {
                         f(tx_info, ctx)
                     })
                     .collect::<Result<_, _>>()?;
+
+                if let Some(timings) = storage_timings.timings() {
+                    log_block_storage_timings(
+                        "trace_block",
+                        block_number,
+                        max_transactions.min(block.body().transaction_count()),
+                        started_at.elapsed(),
+                        &timings,
+                    );
+                }
 
                 Ok(Some(results))
             })

--- a/crates/rpc/rpc-eth-types/Cargo.toml
+++ b/crates/rpc/rpc-eth-types/Cargo.toml
@@ -20,7 +20,7 @@ reth-execution-types.workspace = true
 reth-metrics.workspace = true
 reth-ethereum-primitives = { workspace = true, features = ["rpc"] }
 reth-primitives-traits = { workspace = true, features = ["rpc-compat"] }
-reth-storage-api.workspace = true
+reth-storage-api = { workspace = true, features = ["std"] }
 reth-revm.workspace = true
 reth-rpc-server-types.workspace = true
 reth-rpc-convert.workspace = true

--- a/crates/rpc/rpc-eth-types/src/lib.rs
+++ b/crates/rpc/rpc-eth-types/src/lib.rs
@@ -22,6 +22,7 @@ pub mod logs_utils;
 pub mod pending_block;
 pub mod receipt;
 pub mod simulate;
+pub mod storage_timings;
 pub mod transaction;
 pub mod tx_forward;
 pub mod utils;
@@ -40,5 +41,6 @@ pub use gas_oracle::{
 };
 pub use id_provider::EthSubscriptionIdProvider;
 pub use pending_block::{PendingBlock, PendingBlockEnv, PendingBlockEnvOrigin};
+pub use storage_timings::{log_block_storage_timings, storage_timings_enabled};
 pub use transaction::{FillTransactionResult, TransactionDataAndReceipt, TransactionSource};
 pub use tx_forward::ForwardConfig;

--- a/crates/rpc/rpc-eth-types/src/storage_timings.rs
+++ b/crates/rpc/rpc-eth-types/src/storage_timings.rs
@@ -1,0 +1,98 @@
+//! Reporting for the storage read accounting collected by
+//! [`reth_storage_api::StorageTimingsScope`].
+//!
+//! Emitting is opt-in through the log filter, e.g. `RUST_LOG=storage::timings=debug`. Callers must
+//! ask [`storage_timings_enabled`] first and pass the answer to
+//! [`StorageTimingsScope::new`](reth_storage_api::StorageTimingsScope::new), so that a node running
+//! without the filter never reads the clock on a storage read.
+
+use reth_storage_api::{StorageBucket, StorageTimings};
+use std::time::Duration;
+use tracing::{Level, debug, enabled, info};
+
+/// Log target for the storage read breakdown.
+pub const STORAGE_TIMINGS_TARGET: &str = "storage::timings";
+
+/// Whether the storage read breakdown would be logged.
+pub fn storage_timings_enabled() -> bool {
+    enabled!(target: STORAGE_TIMINGS_TARGET, Level::DEBUG)
+}
+
+/// Logs the storage read breakdown of a single block trace as one event.
+///
+/// `total` is the wall time of the traced section, so `evm_ms` also covers inspector bookkeeping
+/// and trace construction, not just EVM execution.
+///
+/// Watch the `accounted` field: only the historical state provider is instrumented, so a block
+/// whose parent state is served by the latest-state provider reports zeroed buckets rather than
+/// cheap storage.
+pub fn log_block_storage_timings(
+    method: &'static str,
+    block_number: u64,
+    tx_count: usize,
+    total: Duration,
+    timings: &StorageTimings,
+) {
+    let account_calls = timings.calls(StorageBucket::Account);
+    let slot_calls = timings.calls(StorageBucket::Slot);
+    let history_calls = timings.calls(StorageBucket::History);
+
+    info!(
+        target: STORAGE_TIMINGS_TARGET,
+        method,
+        block = block_number,
+        txs = tx_count,
+        total_ms = total.as_millis(),
+        storage_ms = timings.total().as_millis(),
+        evm_ms = timings.non_storage(total).as_millis(),
+        // Buckets are in microseconds: bytecode and plain-state reads are routinely sub-millisecond
+        // and would otherwise all report zero.
+        acct_n = account_calls,
+        acct_us = timings.elapsed(StorageBucket::Account).as_micros(),
+        slot_n = slot_calls,
+        slot_us = timings.elapsed(StorageBucket::Slot).as_micros(),
+        code_n = timings.calls(StorageBucket::Bytecode),
+        code_us = timings.elapsed(StorageBucket::Bytecode).as_micros(),
+        hist_n = history_calls,
+        hist_us = timings.elapsed(StorageBucket::History).as_micros(),
+        cs_n = timings.calls(StorageBucket::Changeset),
+        cs_us = timings.elapsed(StorageBucket::Changeset).as_micros(),
+        plain_us = timings.plain().as_micros(),
+        cs_hit_pct = changeset_hit_rate(timings),
+        accounted = accounted(tx_count, timings),
+        "Block trace storage breakdown"
+    );
+}
+
+/// Whether the buckets can be trusted for this block.
+///
+/// False means the numbers are not a measurement of cheap storage, they are an absence of
+/// measurement. Two causes:
+///
+/// - The parent state was served by the latest-state provider instead of the historical one, which
+///   happens when the parent block is the persisted tip — so for any block still in the in-memory
+///   chain. Only the historical provider is instrumented.
+/// - A read path reached storage without going through the instrumented account or slot entry
+///   points, which would also break the nesting the derived fields rely on.
+///
+/// Detected via the invariant that every account and slot read performs exactly one history lookup,
+/// plus the fact that executing a transaction always reads at least the sender account.
+const fn accounted(tx_count: usize, timings: &StorageTimings) -> bool {
+    let reads = timings.calls(StorageBucket::Account) + timings.calls(StorageBucket::Slot);
+    if tx_count > 0 && reads == 0 {
+        return false
+    }
+    timings.calls(StorageBucket::History) == reads
+}
+
+/// Share of account and slot reads that had to fall back to a changeset, in whole percent.
+///
+/// High values mean the traced block is old enough that most of the state it touches was
+/// overwritten since, which is the inherent cost of tracing history.
+const fn changeset_hit_rate(timings: &StorageTimings) -> u64 {
+    let reads = timings.calls(StorageBucket::Account) + timings.calls(StorageBucket::Slot);
+    if reads == 0 {
+        return 0
+    }
+    timings.calls(StorageBucket::Changeset) * 100 / reads
+}

--- a/crates/rpc/rpc/Cargo.toml
+++ b/crates/rpc/rpc/Cargo.toml
@@ -20,7 +20,7 @@ reth-rpc-eth-api.workspace = true
 reth-engine-primitives.workspace = true
 reth-errors.workspace = true
 reth-metrics.workspace = true
-reth-storage-api.workspace = true
+reth-storage-api = { workspace = true, features = ["std"] }
 reth-execution-types = { workspace = true, features = ["serde"] }
 reth-chain-state.workspace = true
 reth-transaction-pool.workspace = true

--- a/crates/rpc/rpc/src/debug.rs
+++ b/crates/rpc/rpc/src/debug.rs
@@ -30,14 +30,17 @@ use reth_rpc_eth_api::{
     helpers::{EthTransactions, TraceExt},
     FromEthApiError, FromEvmError, RpcConvert, RpcNodeCore,
 };
-use reth_rpc_eth_types::{EthApiError, StateCacheDb};
+use reth_rpc_eth_types::{
+    log_block_storage_timings, storage_timings_enabled, EthApiError, StateCacheDb,
+};
 use reth_rpc_server_types::{
     result::{internal_rpc_err, rpc_error_with_code},
     ToRpcResult,
 };
 use reth_storage_api::{
     BlockIdReader, BlockReaderIdExt, HashedPostStateProvider, HeaderProvider, ProviderBlock,
-    ReceiptProviderIdExt, StateProviderFactory, StateRootProvider, TransactionVariant,
+    ReceiptProviderIdExt, StateProviderFactory, StateRootProvider, StorageTimingsScope,
+    TransactionVariant,
 };
 use reth_tasks::{pool::BlockingTaskGuard, Runtime};
 use reth_trie_common::{updates::TrieUpdates, ExecutionWitnessMode, HashedPostState};
@@ -51,7 +54,7 @@ use revm_inspectors::tracing::{
 };
 use rust_eth_triedb::triedb_manager::is_triedb_active;
 use serde::{Deserialize, Serialize};
-use std::{collections::VecDeque, sync::Arc};
+use std::{collections::VecDeque, sync::Arc, time::Instant};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
 use tokio_stream::StreamExt;
 
@@ -143,6 +146,9 @@ where
             .spawn_with_state_at_block(block.parent_hash(), move |eth_api, mut db| {
                 let mut results = Vec::with_capacity(block.body().transactions().len());
 
+                let started_at = Instant::now();
+                let storage_timings = StorageTimingsScope::new(storage_timings_enabled());
+
                 eth_api.apply_pre_execution_changes(&block, &mut db, evm_env.clone())?;
 
                 let mut transactions = block.transactions_recovered().enumerate().peekable();
@@ -172,6 +178,16 @@ where
                         // next transaction
                         db.commit(state_changes)
                     }
+                }
+
+                if let Some(timings) = storage_timings.timings() {
+                    log_block_storage_timings(
+                        "debug_traceBlock",
+                        block.number(),
+                        results.len(),
+                        started_at.elapsed(),
+                        &timings,
+                    );
                 }
 
                 Ok(results)

--- a/crates/storage/provider/src/providers/state/historical.rs
+++ b/crates/storage/provider/src/providers/state/historical.rs
@@ -14,9 +14,9 @@ use reth_db_api::{
 };
 use reth_primitives_traits::{Account, Bytecode, NodePrimitives};
 use reth_storage_api::{
-    BlockNumReader, BytecodeReader, DBProvider, NodePrimitivesProvider, PruneCheckpointReader,
-    StageCheckpointReader, StateProofProvider, StorageChangeSetReader, StorageRootProvider,
-    StorageSettingsCache,
+    record_storage_read, BlockNumReader, BytecodeReader, DBProvider, NodePrimitivesProvider,
+    PruneCheckpointReader, StageCheckpointReader, StateProofProvider, StorageBucket,
+    StorageChangeSetReader, StorageRootProvider, StorageSettingsCache,
 };
 use reth_storage_errors::provider::ProviderResult;
 use reth_trie::{
@@ -210,16 +210,18 @@ where
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        let visible_tip = self.provider.best_block_number()?;
+        record_storage_read(StorageBucket::History, || {
+            let visible_tip = self.provider.best_block_number()?;
 
-        self.provider.with_rocksdb_snapshot(|rocksdb_ref| {
-            let mut reader = EitherReader::new_accounts_history(self.provider, rocksdb_ref)?;
-            reader.account_history_info(
-                address,
-                self.block_number,
-                self.lowest_available_blocks.account_history_block_number,
-                visible_tip,
-            )
+            self.provider.with_rocksdb_snapshot(|rocksdb_ref| {
+                let mut reader = EitherReader::new_accounts_history(self.provider, rocksdb_ref)?;
+                reader.account_history_info(
+                    address,
+                    self.block_number,
+                    self.lowest_available_blocks.account_history_block_number,
+                    visible_tip,
+                )
+            })
         })
     }
 
@@ -238,17 +240,19 @@ where
             return Err(ProviderError::StateAtBlockPruned(self.block_number))
         }
 
-        let visible_tip = self.provider.best_block_number()?;
+        record_storage_read(StorageBucket::History, || {
+            let visible_tip = self.provider.best_block_number()?;
 
-        self.provider.with_rocksdb_snapshot(|rocksdb_ref| {
-            let mut reader = EitherReader::new_storages_history(self.provider, rocksdb_ref)?;
-            reader.storage_history_info(
-                address,
-                lookup_key,
-                self.block_number,
-                self.lowest_available_blocks.storage_history_block_number,
-                visible_tip,
-            )
+            self.provider.with_rocksdb_snapshot(|rocksdb_ref| {
+                let mut reader = EitherReader::new_storages_history(self.provider, rocksdb_ref)?;
+                reader.storage_history_info(
+                    address,
+                    lookup_key,
+                    self.block_number,
+                    self.lowest_available_blocks.storage_history_block_number,
+                    visible_tip,
+                )
+            })
         })
     }
 
@@ -266,16 +270,22 @@ where
     {
         match self.storage_history_lookup(address, lookup_key)? {
             HistoryInfo::NotYetWritten => Ok(None),
-            HistoryInfo::InChangeset(changeset_block_number) => self
-                .provider
-                .get_storage_before_block(changeset_block_number, address, lookup_key)?
+            HistoryInfo::InChangeset(changeset_block_number) => {
+                record_storage_read(StorageBucket::Changeset, || {
+                    self.provider.get_storage_before_block(
+                        changeset_block_number,
+                        address,
+                        lookup_key,
+                    )
+                })?
                 .ok_or_else(|| ProviderError::StorageChangesetNotFound {
                     block_number: changeset_block_number,
                     address,
                     storage_key: Box::new(lookup_key),
                 })
                 .map(|entry| entry.value)
-                .map(Some),
+                .map(Some)
+            }
             HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
                 if let Some((exec_tip, hist_tip)) =
                     self.pipeline_consistency.storage_inconsistency()
@@ -388,36 +398,41 @@ where
 {
     /// Get basic account information.
     fn basic_account(&self, address: &Address) -> ProviderResult<Option<Account>> {
-        match self.account_history_lookup(*address)? {
-            HistoryInfo::NotYetWritten => Ok(None),
-            HistoryInfo::InChangeset(changeset_block_number) => {
-                // Use ChangeSetReader trait method to get the account from changesets
-                self.provider
-                    .get_account_before_block(changeset_block_number, *address)?
+        record_storage_read(StorageBucket::Account, || {
+            match self.account_history_lookup(*address)? {
+                HistoryInfo::NotYetWritten => Ok(None),
+                HistoryInfo::InChangeset(changeset_block_number) => {
+                    // Use ChangeSetReader trait method to get the account from changesets
+                    record_storage_read(StorageBucket::Changeset, || {
+                        self.provider.get_account_before_block(changeset_block_number, *address)
+                    })?
                     .ok_or(ProviderError::AccountChangesetNotFound {
                         block_number: changeset_block_number,
                         address: *address,
                     })
                     .map(|account_before| account_before.info)
-            }
-            HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
-                if let Some((exec_tip, hist_tip)) =
-                    self.pipeline_consistency.account_inconsistency()
-                {
-                    return Err(ProviderError::HistoryStateInconsistent {
-                        block: self.block_number,
-                        execution_tip: exec_tip,
-                        history_tip: hist_tip,
-                    })
                 }
-                if self.provider.cached_storage_settings().use_hashed_state() {
-                    let hashed_address = alloy_primitives::keccak256(address);
-                    Ok(self.tx().get_by_encoded_key::<tables::HashedAccounts>(&hashed_address)?)
-                } else {
-                    Ok(self.tx().get_by_encoded_key::<tables::PlainAccountState>(address)?)
+                HistoryInfo::InPlainState | HistoryInfo::MaybeInPlainState => {
+                    if let Some((exec_tip, hist_tip)) =
+                        self.pipeline_consistency.account_inconsistency()
+                    {
+                        return Err(ProviderError::HistoryStateInconsistent {
+                            block: self.block_number,
+                            execution_tip: exec_tip,
+                            history_tip: hist_tip,
+                        })
+                    }
+                    if self.provider.cached_storage_settings().use_hashed_state() {
+                        let hashed_address = alloy_primitives::keccak256(address);
+                        Ok(self
+                            .tx()
+                            .get_by_encoded_key::<tables::HashedAccounts>(&hashed_address)?)
+                    } else {
+                        Ok(self.tx().get_by_encoded_key::<tables::PlainAccountState>(address)?)
+                    }
                 }
             }
-        }
+        })
     }
 }
 
@@ -706,7 +721,9 @@ where
         address: Address,
         storage_key: StorageKey,
     ) -> ProviderResult<Option<StorageValue>> {
-        self.storage_by_lookup_key(address, storage_key)
+        record_storage_read(StorageBucket::Slot, || {
+            self.storage_by_lookup_key(address, storage_key)
+        })
     }
 }
 
@@ -717,7 +734,9 @@ where
 {
     /// Get account code by its hash
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
-        self.tx().get_by_encoded_key::<tables::Bytecodes>(code_hash).map_err(Into::into)
+        record_storage_read(StorageBucket::Bytecode, || {
+            self.tx().get_by_encoded_key::<tables::Bytecodes>(code_hash).map_err(Into::into)
+        })
     }
 }
 

--- a/crates/storage/storage-api/src/lib.rs
+++ b/crates/storage/storage-api/src/lib.rs
@@ -96,6 +96,11 @@ pub use block_writer::*;
 mod state_writer;
 pub use state_writer::*;
 
+#[cfg(feature = "std")]
+mod storage_timings;
+#[cfg(feature = "std")]
+pub use storage_timings::*;
+
 mod header_sync_gap;
 pub use header_sync_gap::HeaderSyncGapProvider;
 

--- a/crates/storage/storage-api/src/storage_timings.rs
+++ b/crates/storage/storage-api/src/storage_timings.rs
@@ -1,0 +1,220 @@
+//! Per-request accounting of storage read latency.
+//!
+//! Historical state reads fan out into several backends (history index, changesets, plain state)
+//! that are reached through deeply nested provider calls. Threading an accumulator through those
+//! signatures would touch dozens of trait methods, so the counters live in thread-local storage
+//! instead: a caller opens a [`StorageTimingsScope`], runs synchronous work, and reads the totals
+//! back out.
+//!
+//! Accounting is off unless a scope is active, and [`record_storage_read`] checks that flag before
+//! reading the clock, so uninstrumented callers such as the executor pay nothing.
+
+use core::{cell::Cell, time::Duration};
+use std::{cell::RefCell, time::Instant};
+
+/// A storage read bucket.
+///
+/// [`Account`](Self::Account), [`Slot`](Self::Slot) and [`Bytecode`](Self::Bytecode) are the
+/// top-level reads issued by the EVM and never overlap each other. [`History`](Self::History) and
+/// [`Changeset`](Self::Changeset) are nested inside the first two, so summing all five would double
+/// count.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageBucket {
+    /// Account reads, including the history lookup and value fetch they trigger.
+    Account,
+    /// Storage slot reads, including the history lookup and value fetch they trigger.
+    Slot,
+    /// Bytecode reads.
+    Bytecode,
+    /// History index lookups, nested inside [`Account`](Self::Account) and [`Slot`](Self::Slot).
+    History,
+    /// Changeset reads, nested inside [`Account`](Self::Account) and [`Slot`](Self::Slot).
+    Changeset,
+}
+
+impl StorageBucket {
+    /// Number of buckets.
+    const COUNT: usize = 5;
+}
+
+/// Storage read latency accumulated by a [`StorageTimingsScope`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct StorageTimings {
+    buckets: [(Duration, u64); StorageBucket::COUNT],
+}
+
+impl StorageTimings {
+    /// Time spent in the given bucket.
+    pub const fn elapsed(&self, bucket: StorageBucket) -> Duration {
+        self.buckets[bucket as usize].0
+    }
+
+    /// Number of calls recorded for the given bucket.
+    pub const fn calls(&self, bucket: StorageBucket) -> u64 {
+        self.buckets[bucket as usize].1
+    }
+
+    /// Total time spent in storage reads.
+    ///
+    /// Only the top-level buckets are summed; see [`StorageBucket`] for the nesting.
+    pub fn total(&self) -> Duration {
+        self.elapsed(StorageBucket::Account) +
+            self.elapsed(StorageBucket::Slot) +
+            self.elapsed(StorageBucket::Bytecode)
+    }
+
+    /// Time spent resolving reads that fell through to plain state, derived as account + slot minus
+    /// the nested buckets.
+    ///
+    /// Also absorbs the per-read bookkeeping outside the nested buckets, such as key hashing.
+    /// Saturates at zero: the subtraction only holds while every history and changeset read happens
+    /// inside an account or slot read.
+    pub fn plain(&self) -> Duration {
+        (self.elapsed(StorageBucket::Account) + self.elapsed(StorageBucket::Slot))
+            .saturating_sub(self.elapsed(StorageBucket::History))
+            .saturating_sub(self.elapsed(StorageBucket::Changeset))
+    }
+
+    /// Share of `total_request_time` that was not spent in storage reads.
+    pub fn non_storage(&self, total_request_time: Duration) -> Duration {
+        total_request_time.saturating_sub(self.total())
+    }
+}
+
+thread_local! {
+    /// Whether a [`StorageTimingsScope`] is accounting on this thread.
+    static ENABLED: Cell<bool> = const { Cell::new(false) };
+    /// Counters for the active scope. Meaningless unless `ENABLED` is set.
+    static TIMINGS: RefCell<StorageTimings> = RefCell::new(StorageTimings::default());
+}
+
+/// Accounts storage reads on the current thread until dropped.
+///
+/// Only meaningful around synchronous code. The counters are thread-local, so a future that
+/// resumes on a different thread after an await point stops being accounted for.
+#[derive(Debug)]
+pub struct StorageTimingsScope {
+    /// Whether this scope owns the accounting. False when disabled, or when another scope on this
+    /// thread is already accounting.
+    owns_accounting: bool,
+}
+
+impl StorageTimingsScope {
+    /// Starts accounting, unless `enabled` is false or a scope is already active on this thread.
+    pub fn new(enabled: bool) -> Self {
+        let owns_accounting = enabled && !ENABLED.get();
+        if owns_accounting {
+            TIMINGS.with_borrow_mut(|timings| *timings = StorageTimings::default());
+            ENABLED.set(true);
+        }
+        Self { owns_accounting }
+    }
+
+    /// Returns the counters collected so far, or `None` if this scope isn't accounting.
+    pub fn timings(&self) -> Option<StorageTimings> {
+        self.owns_accounting.then(|| TIMINGS.with_borrow(|timings| *timings))
+    }
+}
+
+impl Drop for StorageTimingsScope {
+    fn drop(&mut self) {
+        // Cleared on drop rather than in an explicit finish, so an early return can't leak
+        // accounting into the next task that reuses this pool thread.
+        if self.owns_accounting {
+            ENABLED.set(false);
+        }
+    }
+}
+
+/// Runs `f`, attributing its duration to `bucket` if a [`StorageTimingsScope`] is active.
+#[inline]
+pub fn record_storage_read<R>(bucket: StorageBucket, f: impl FnOnce() -> R) -> R {
+    if !ENABLED.get() {
+        return f();
+    }
+
+    let started_at = Instant::now();
+    let result = f();
+    let elapsed = started_at.elapsed();
+
+    TIMINGS.with_borrow_mut(|timings| {
+        let bucket = &mut timings.buckets[bucket as usize];
+        bucket.0 += elapsed;
+        bucket.1 += 1;
+    });
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disabled_scope_records_nothing() {
+        let scope = StorageTimingsScope::new(false);
+        record_storage_read(StorageBucket::Account, || ());
+        assert_eq!(scope.timings(), None);
+    }
+
+    #[test]
+    fn records_calls_and_nesting() {
+        let scope = StorageTimingsScope::new(true);
+        record_storage_read(StorageBucket::Account, || {
+            record_storage_read(StorageBucket::History, || ())
+        });
+        record_storage_read(StorageBucket::Slot, || ());
+
+        let timings = scope.timings().unwrap();
+        assert_eq!(timings.calls(StorageBucket::Account), 1);
+        assert_eq!(timings.calls(StorageBucket::Slot), 1);
+        assert_eq!(timings.calls(StorageBucket::History), 1);
+        assert_eq!(timings.calls(StorageBucket::Changeset), 0);
+        // account + slot, with bytecode unused
+        assert_eq!(
+            timings.total(),
+            timings.elapsed(StorageBucket::Account) + timings.elapsed(StorageBucket::Slot)
+        );
+    }
+
+    #[test]
+    fn nested_scope_does_not_reset_outer() {
+        let outer = StorageTimingsScope::new(true);
+        record_storage_read(StorageBucket::Account, || ());
+        {
+            let inner = StorageTimingsScope::new(true);
+            assert_eq!(inner.timings(), None);
+            record_storage_read(StorageBucket::Account, || ());
+        }
+        assert_eq!(outer.timings().unwrap().calls(StorageBucket::Account), 2);
+    }
+
+    #[test]
+    fn accounting_stops_after_drop() {
+        drop(StorageTimingsScope::new(true));
+        assert!(!ENABLED.get());
+    }
+
+    /// Guards `StorageBucket::COUNT` against a variant being added without widening the array,
+    /// which would otherwise only surface as an out-of-bounds panic at runtime.
+    #[test]
+    fn every_bucket_is_indexable() {
+        let buckets = [
+            StorageBucket::Account,
+            StorageBucket::Slot,
+            StorageBucket::Bytecode,
+            StorageBucket::History,
+            StorageBucket::Changeset,
+        ];
+        assert_eq!(buckets.len(), StorageBucket::COUNT);
+
+        let scope = StorageTimingsScope::new(true);
+        for bucket in buckets {
+            record_storage_read(bucket, || ());
+        }
+        let timings = scope.timings().unwrap();
+        for bucket in buckets {
+            assert_eq!(timings.calls(bucket), 1);
+        }
+    }
+}


### PR DESCRIPTION
Adds thread-local accounting of historical state reads so trace_block and debug_traceBlock* emit a single event splitting wall time into history index lookups, changeset reads, plain state and the EVM. This makes it possible to tell which storage backend dominates a slow block trace.

Accounting is off unless storage::timings=debug is in the log filter, so uninstrumented callers such as the executor never read the clock.

### Description

add a description of your changes here...

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...

### Potential Impacts
* add potential impacts for other components here
* ...
