### PR TITLE
deps: bump h2 to 0.4.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4467,9 +4467,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
Fixes the `cargo deny check advisories` failure on #216.

`h2` before 0.4.16 accepts and queues empty DATA frames without limit, which can lead to unbounded memory growth or an overflow panic if streams are not drained ([GHSA-q83h-524g-xf6h](https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h)).

Lockfile-only change: version and checksum, no other resolution churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)