### PR TITLE
fix(rpc): fix rpc blocking-task deadlock

### DIFF
--- a/crates/rpc/rpc-engine-api/src/engine_api.rs
+++ b/crates/rpc/rpc-engine-api/src/engine_api.rs
@@ -638,6 +638,10 @@ where
             // Check if the requested range starts before the earliest available block due to pruning/expiry
             let earliest_block = inner.provider.earliest_block_number().unwrap_or(0);
             for num in start..=end {
+                if tx.is_closed() {
+                    return;
+                }
+
                 if num < earliest_block {
                     result.push(None);
                     continue;

--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -152,10 +152,14 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         guard.clone().acquire_many_owned(permits_to_acquire)
     }
 
-    /// Executes the future on a new blocking task.
+    /// Executes the closure on a new blocking task.
     ///
-    /// Note: This is expected for futures that are dominated by blocking IO operations, for tracing
-    /// or CPU bound operations in general use [`spawn_tracing`](Self::spawn_tracing).
+    /// `f` must be self-contained: it runs on a thread from the blocking pool and must not wait
+    /// for another task, or the pool can deadlock with every thread parked on work that needs a
+    /// thread. Resolve anything that needs awaiting before calling this.
+    ///
+    /// Note: This is expected for operations that are dominated by blocking IO, for tracing or
+    /// CPU bound operations in general use [`spawn_tracing`](Self::spawn_tracing).
     fn spawn_blocking_io<F, R>(&self, f: F) -> impl Future<Output = Result<R, Self::Error>> + Send
     where
         F: FnOnce(Self) -> Result<R, Self::Error> + Send + 'static,
@@ -165,29 +169,6 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         let this = self.clone();
         self.io_task_spawner().spawn_blocking_task(async move {
             let res = f(this);
-            let _ = tx.send(res);
-        });
-
-        async move { rx.await.map_err(|_| EthApiError::InternalEthError)? }
-    }
-
-    /// Executes the future on a new blocking task.
-    ///
-    /// Note: This is expected for futures that are dominated by blocking IO operations, for tracing
-    /// or CPU bound operations in general use [`spawn_tracing`](Self::spawn_tracing).
-    fn spawn_blocking_io_fut<F, R, Fut>(
-        &self,
-        f: F,
-    ) -> impl Future<Output = Result<R, Self::Error>> + Send
-    where
-        Fut: Future<Output = Result<R, Self::Error>> + Send + 'static,
-        F: FnOnce(Self) -> Fut + Send + 'static,
-        R: Send + 'static,
-    {
-        let (tx, rx) = oneshot::channel();
-        let this = self.clone();
-        self.io_task_spawner().spawn_blocking_task(async move {
-            let res = f(this).await;
             let _ = tx.send(res);
         });
 

--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -168,6 +168,12 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
         self.io_task_spawner().spawn_blocking_task(async move {
+            // This task only starts once it is assigned a blocking thread, which can be long
+            // after it was queued. If the caller gave up in the meantime, running `f` would
+            // hold that thread for a result nobody can receive.
+            if tx.is_closed() {
+                return
+            }
             let res = f(this);
             let _ = tx.send(res);
         });

--- a/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/blocking_task.rs
@@ -152,14 +152,11 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         guard.clone().acquire_many_owned(permits_to_acquire)
     }
 
-    /// Executes the closure on a new blocking task.
+    /// Executes `f` on the blocking pool.
     ///
-    /// `f` must be self-contained: it runs on a thread from the blocking pool and must not wait
-    /// for another task, or the pool can deadlock with every thread parked on work that needs a
-    /// thread. Resolve anything that needs awaiting before calling this.
+    /// `f` must be self-contained and must not depend on other queued work.
     ///
-    /// Note: This is expected for operations that are dominated by blocking IO, for tracing or
-    /// CPU bound operations in general use [`spawn_tracing`](Self::spawn_tracing).
+    /// For CPU-bound work use [`spawn_tracing`](Self::spawn_tracing).
     fn spawn_blocking_io<F, R>(&self, f: F) -> impl Future<Output = Result<R, Self::Error>> + Send
     where
         F: FnOnce(Self) -> Result<R, Self::Error> + Send + 'static,
@@ -168,9 +165,7 @@ pub trait SpawnBlocking: EthApiTypes + Clone + Send + Sync + 'static {
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
         self.io_task_spawner().spawn_blocking_task(async move {
-            // This task only starts once it is assigned a blocking thread, which can be long
-            // after it was queued. If the caller gave up in the meantime, running `f` would
-            // hold that thread for a result nobody can receive.
+            // Skip work if the caller already went away.
             if tx.is_closed() {
                 return
             }

--- a/crates/rpc/rpc-eth-api/src/helpers/call.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/call.rs
@@ -451,10 +451,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
             let block_id = block_number.unwrap_or_default();
             let (evm_env, at) = self.evm_env_at(block_id).await?;
 
-            self.spawn_blocking_io_fut(async move |this| {
-                this.create_access_list_with(evm_env, at, request, state_override).await
-            })
-            .await
+            self.create_access_list_with(evm_env, at, request, state_override).await
         }
     }
 
@@ -470,8 +467,7 @@ pub trait EthCall: EstimateCall + Call + LoadPendingBlock + LoadBlock + FullEthA
     where
         Self: Trace,
     {
-        self.spawn_blocking_io_fut(async move |this| {
-            let state = this.state_at_block_id(at).await?;
+        self.spawn_with_state(Some(at), move |this, state| {
             let mut db = State::builder().with_database(StateProviderDatabase::new(state)).build();
 
             if let Some(state_overrides) = state_override {
@@ -577,10 +573,7 @@ pub trait Call:
         R: Send + 'static,
         F: FnOnce(Self, StateProviderBox) -> Result<R, Self::Error> + Send + 'static,
     {
-        self.spawn_blocking_io_fut(async move |this| {
-            let state = this.state_at_block_id(at).await?;
-            f(this, state)
-        })
+        self.spawn_with_state(Some(at), f)
     }
 
     /// Executes the `TxEnv` against the given [Database] without committing state
@@ -663,9 +656,7 @@ pub trait Call:
         F: FnOnce(Self, StateCacheDb) -> Result<R, Self::Error> + Send + 'static,
         R: Send + 'static,
     {
-        let at = at.into();
-        self.spawn_blocking_io_fut(async move |this| {
-            let state = this.state_at_block_id(at).await?;
+        self.spawn_with_state(Some(at.into()), move |this, state| {
             let db = State::builder()
                 .with_database(StateProviderDatabase::new(StateProviderTraitObjWrapper(state)))
                 .build();

--- a/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/estimate.rs
@@ -306,8 +306,7 @@ pub trait EstimateCall: Call {
         async move {
             let (evm_env, at) = self.evm_env_at(at).await?;
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let state = this.state_at_block_id(at).await?;
+            self.spawn_with_state(Some(at), move |this, state| {
                 EstimateCall::estimate_gas_with(&this, evm_env, request, state, state_override)
             })
             .await

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -78,10 +78,8 @@ pub trait EthState: LoadState + SpawnBlocking {
         address: Address,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<U256, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(async move |this| {
-            Ok(this
-                .state_at_block_id_or_latest(block_id)
-                .await?
+        self.spawn_with_state(block_id, move |_, state| {
+            Ok(state
                 .account_balance(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default())
@@ -95,10 +93,9 @@ pub trait EthState: LoadState + SpawnBlocking {
         index: JsonStorageKey,
         block_id: Option<BlockId>,
     ) -> impl Future<Output = Result<B256, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(async move |this| {
+        self.spawn_with_state(block_id, move |_, state| {
             Ok(B256::new(
-                this.state_at_block_id_or_latest(block_id)
-                    .await?
+                state
                     .storage(address, index.as_b256())
                     .map_err(Self::Error::from_eth_err)?
                     .unwrap_or_default()
@@ -131,9 +128,7 @@ pub trait EthState: LoadState + SpawnBlocking {
                 )));
             }
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let state = this.state_at_block_id_or_latest(block_id).await?;
-
+            self.spawn_with_state(block_id, move |_, state| {
                 let mut result = HashMap::with_capacity(requests.len());
                 for (address, slots) in requests {
                     let mut values = Vec::with_capacity(slots.len());
@@ -186,8 +181,7 @@ pub trait EthState: LoadState + SpawnBlocking {
             let block_id = block_id.unwrap_or_default();
             self.ensure_within_proof_window(block_id)?;
 
-            self.spawn_blocking_io_fut(async move |this| {
-                let state = this.state_at_block_id(block_id).await?;
+            self.spawn_with_state(Some(block_id), move |_, state| {
                 let storage_keys = keys.iter().map(|key| key.as_b256()).collect::<Vec<_>>();
                 let proof = state
                     .proof(Default::default(), address, &storage_keys)
@@ -204,7 +198,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         address: Address,
         block_id: BlockId,
     ) -> impl Future<Output = Result<Option<Account>, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(move |this| async move {
+        async move {
             // Check if TrieDB is active, return error if so
             if is_triedb_active() {
                 return Err(EthApiError::MethodNotAvailable("eth_getAccount".to_string()).into())
@@ -215,22 +209,24 @@ pub trait EthState: LoadState + SpawnBlocking {
                 return Err(EthApiError::MethodNotAvailable("eth_getAccount".to_string()).into())
             }
 
-            let state = this.state_at_block_id(block_id).await?;
-            let account = state.basic_account(&address).map_err(Self::Error::from_eth_err)?;
-            let Some(account) = account else { return Ok(None) };
+            self.spawn_with_state(Some(block_id), move |_, state| {
+                let account = state.basic_account(&address).map_err(Self::Error::from_eth_err)?;
+                let Some(account) = account else { return Ok(None) };
 
-            let balance = account.balance;
-            let nonce = account.nonce;
-            let code_hash = account.bytecode_hash.unwrap_or(KECCAK_EMPTY);
+                let balance = account.balance;
+                let nonce = account.nonce;
+                let code_hash = account.bytecode_hash.unwrap_or(KECCAK_EMPTY);
 
-            // Provide a default `HashedStorage` value in order to
-            // get the storage root hash of the current state.
-            let storage_root = state
-                .storage_root(address, Default::default())
-                .map_err(Self::Error::from_eth_err)?;
+                // Provide a default `HashedStorage` value in order to
+                // get the storage root hash of the current state.
+                let storage_root = state
+                    .storage_root(address, Default::default())
+                    .map_err(Self::Error::from_eth_err)?;
 
-            Ok(Some(Account { balance, nonce, code_hash, storage_root }))
-        })
+                Ok(Some(Account { balance, nonce, code_hash, storage_root }))
+            })
+            .await
+        }
     }
 
     /// Retrieves the account's balance, nonce, and code for a given address.
@@ -239,8 +235,7 @@ pub trait EthState: LoadState + SpawnBlocking {
         address: Address,
         block_id: BlockId,
     ) -> impl Future<Output = Result<AccountInfo, Self::Error>> + Send {
-        self.spawn_blocking_io_fut(async move |this| {
-            let state = this.state_at_block_id(block_id).await?;
+        self.spawn_with_state(Some(block_id), move |_, state| {
             let account = state
                 .basic_account(&address)
                 .map_err(Self::Error::from_eth_err)?
@@ -321,6 +316,28 @@ pub trait LoadState:
             } else {
                 Ok(self.latest_state()?)
             }
+        }
+    }
+
+    /// Resolves the state for `block_id` (`None` meaning latest) and runs `f` with it on a
+    /// blocking task.
+    ///
+    /// Resolving the state stays on the calling async task on purpose: a `pending` block id
+    /// awaits, and a task that occupies a blocking thread while it awaits can exhaust the
+    /// blocking pool. Only `f`, which is synchronous, is offloaded.
+    fn spawn_with_state<F, R>(
+        &self,
+        block_id: Option<BlockId>,
+        f: F,
+    ) -> impl Future<Output = Result<R, Self::Error>> + Send
+    where
+        Self: SpawnBlocking,
+        F: FnOnce(Self, StateProviderBox) -> Result<R, Self::Error> + Send + 'static,
+        R: Send + 'static,
+    {
+        async move {
+            let state = self.state_at_block_id_or_latest(block_id).await?;
+            self.spawn_blocking_io(move |this| f(this, state)).await
         }
     }
 
@@ -421,11 +438,9 @@ pub trait LoadState:
     where
         Self: SpawnBlocking,
     {
-        self.spawn_blocking_io_fut(async move |this| {
+        self.spawn_with_state(block_id, move |this, state| {
             // first fetch the on chain nonce of the account
-            let on_chain_account_nonce = this
-                .state_at_block_id_or_latest(block_id)
-                .await?
+            let on_chain_account_nonce = state
                 .account_nonce(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default();
@@ -467,10 +482,8 @@ pub trait LoadState:
     where
         Self: SpawnBlocking,
     {
-        self.spawn_blocking_io_fut(async move |this| {
-            Ok(this
-                .state_at_block_id_or_latest(block_id)
-                .await?
+        self.spawn_with_state(block_id, move |_, state| {
+            Ok(state
                 .account_code(&address)
                 .map_err(Self::Error::from_eth_err)?
                 .unwrap_or_default()

--- a/crates/rpc/rpc-eth-api/src/helpers/state.rs
+++ b/crates/rpc/rpc-eth-api/src/helpers/state.rs
@@ -319,12 +319,9 @@ pub trait LoadState:
         }
     }
 
-    /// Resolves the state for `block_id` (`None` meaning latest) and runs `f` with it on a
-    /// blocking task.
+    /// Resolves `block_id` state on the async runtime, then runs `f` on the blocking pool.
     ///
-    /// Resolving the state stays on the calling async task on purpose: a `pending` block id
-    /// awaits, and a task that occupies a blocking thread while it awaits can exhaust the
-    /// blocking pool. Only `f`, which is synchronous, is offloaded.
+    /// This avoids holding a blocking thread across state resolution.
     fn spawn_with_state<F, R>(
         &self,
         block_id: Option<BlockId>,

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -335,6 +335,27 @@ impl<Provider> EthStateCacheService<Provider, Runtime>
 where
     Provider: BlockReader + Clone + Unpin + 'static,
 {
+    /// Runs a database read on the blocking pool once a rate limiter permit is available.
+    ///
+    /// The permit is awaited on the async runtime and only handed over once held, so a queued
+    /// read never occupies a blocking thread while it waits for one.
+    ///
+    /// Note the read itself is dispatched as a plain closure rather than a task, so it is not
+    /// counted by the `executor.spawn.*_blocking_tasks_*` metrics. That is deliberate: handing
+    /// a future to the blocking pool is what allowed a waiter to hold a thread in the first
+    /// place, and only the permit wait is a task here.
+    fn spawn_rate_limited(&self, f: impl FnOnce() + Send + 'static) {
+        let executor = self.action_task_spawner.clone();
+        let rate_limiter = self.rate_limiter.clone();
+        self.action_task_spawner.spawn_task(async move {
+            let permit = rate_limiter.acquire_owned().await;
+            executor.spawn_blocking(move || {
+                let _permit = permit;
+                f();
+            });
+        });
+    }
+
     /// Indexes all transactions in a block by transaction hash.
     fn index_block_transactions(&mut self, block: &RecoveredBlock<Provider::Block>) {
         let block_hash = block.hash();
@@ -478,12 +499,9 @@ where
                             if this.full_block_cache.queue(block_hash, response_tx) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
-                                let rate_limiter = this.rate_limiter.clone();
                                 let mut action_sender =
                                     ActionSender::new(CacheKind::Block, block_hash, action_tx);
-                                this.action_task_spawner.spawn_blocking_task(async move {
-                                    // Acquire permit
-                                    let _permit = rate_limiter.acquire().await;
+                                this.spawn_rate_limited(move || {
                                     // Only look in the database to prevent situations where we
                                     // looking up the tree is blocking
                                     let block_sender = provider
@@ -507,12 +525,9 @@ where
                             if this.receipts_cache.queue(block_hash, response_tx) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
-                                let rate_limiter = this.rate_limiter.clone();
                                 let mut action_sender =
                                     ActionSender::new(CacheKind::Receipt, block_hash, action_tx);
-                                this.action_task_spawner.spawn_blocking_task(async move {
-                                    // Acquire permit
-                                    let _permit = rate_limiter.acquire().await;
+                                this.spawn_rate_limited(move || {
                                     let res = provider
                                         .receipts_by_block(block_hash.into())
                                         .map(|maybe_receipts| maybe_receipts.map(Arc::new));
@@ -539,12 +554,9 @@ where
                             if this.headers_cache.queue(block_hash, response_tx) {
                                 let provider = this.provider.clone();
                                 let action_tx = this.action_tx.clone();
-                                let rate_limiter = this.rate_limiter.clone();
                                 let mut action_sender =
                                     ActionSender::new(CacheKind::Header, block_hash, action_tx);
-                                this.action_task_spawner.spawn_blocking_task(async move {
-                                    // Acquire permit
-                                    let _permit = rate_limiter.acquire().await;
+                                this.spawn_rate_limited(move || {
                                     let header = provider.header(block_hash).and_then(|header| {
                                         header.ok_or_else(|| {
                                             ProviderError::HeaderNotFound(block_hash.into())

--- a/crates/rpc/rpc-eth-types/src/cache/mod.rs
+++ b/crates/rpc/rpc-eth-types/src/cache/mod.rs
@@ -335,15 +335,10 @@ impl<Provider> EthStateCacheService<Provider, Runtime>
 where
     Provider: BlockReader + Clone + Unpin + 'static,
 {
-    /// Runs a database read on the blocking pool once a rate limiter permit is available.
+    /// Waits for a rate-limit permit on the async runtime, then runs the read on the blocking
+    /// pool.
     ///
-    /// The permit is awaited on the async runtime and only handed over once held, so a queued
-    /// read never occupies a blocking thread while it waits for one.
-    ///
-    /// Note the read itself is dispatched as a plain closure rather than a task, so it is not
-    /// counted by the `executor.spawn.*_blocking_tasks_*` metrics. That is deliberate: handing
-    /// a future to the blocking pool is what allowed a waiter to hold a thread in the first
-    /// place, and only the permit wait is a task here.
+    /// This avoids holding a blocking thread while queued on the limiter.
     fn spawn_rate_limited(&self, f: impl FnOnce() + Send + 'static) {
         let executor = self.action_task_spawner.clone();
         let rate_limiter = self.rate_limiter.clone();

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -43,7 +43,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::{
-    sync::{mpsc::Receiver, oneshot, Mutex},
+    sync::{mpsc::Receiver, Mutex},
     time::MissedTickBehavior,
 };
 use tracing::{debug, error, trace};
@@ -648,39 +648,20 @@ where
             return Err(EthFilterError::QueryExceedsMaxBlocks(max_blocks_per_filter))
         }
 
-        let (tx, rx) = oneshot::channel();
-        let this = self.clone();
-        self.task_spawner.spawn_blocking_task(async move {
-            let res =
-                this.get_logs_in_block_range_inner(&filter, from_block, to_block, limits).await;
-            let _ = tx.send(res);
-        });
-
-        rx.await.map_err(|_| EthFilterError::InternalError)?
+        let filter = Arc::new(filter);
+        self.collect_logs_in_block_range(filter, from_block, to_block, limits).await
     }
 
-    /// Returns all logs in the given _inclusive_ range that match the filter
+    /// Returns every header in the given _inclusive_ range whose bloom matches the filter.
     ///
-    /// Note: This function uses a mix of blocking db operations for fetching indices and header
-    /// ranges and utilizes the rpc cache for optimistically fetching receipts and blocks.
-    /// This function is considered blocking and should thus be spawned on a blocking task.
-    ///
-    /// Returns an error if:
-    ///  - underlying database error
-    async fn get_logs_in_block_range_inner(
-        self: Arc<Self>,
+    /// Fully synchronous; intended to be offloaded to the blocking pool.
+    fn scan_matching_headers(
+        &self,
         filter: &LogFilter,
         from_block: u64,
         to_block: u64,
-        limits: QueryLimits,
-    ) -> Result<Vec<Log>, EthFilterError> {
-        let mut all_logs = Vec::new();
+    ) -> Result<Vec<SealedHeader<<Eth::Provider as HeaderProvider>::Header>>, EthFilterError> {
         let mut matching_headers = Vec::new();
-
-        // get current chain tip to determine processing mode
-        let chain_tip = self.provider().best_block_number()?;
-
-        // first collect all headers that match the bloom filter for cached mode decision
         for (from, to) in
             BlockRangeInclusiveIter::new(from_block..=to_block, self.max_headers_range)
         {
@@ -710,6 +691,34 @@ where
             }
         }
 
+        Ok(matching_headers)
+    }
+
+    /// Collects the logs matching `filter` in the given _inclusive_ range.
+    ///
+    /// Drives the rpc cache to fetch receipts and blocks, so it must run on the async runtime;
+    /// the synchronous parts are offloaded via [`offload`].
+    async fn collect_logs_in_block_range(
+        self: Arc<Self>,
+        filter: Arc<LogFilter>,
+        from_block: u64,
+        to_block: u64,
+        limits: QueryLimits,
+    ) -> Result<Vec<Log>, EthFilterError> {
+        let mut all_logs = Vec::new();
+
+        // get current chain tip to determine processing mode
+        let chain_tip = self.provider().best_block_number()?;
+
+        // the bloom scan is synchronous, so it is offloaded
+        let matching_headers = {
+            let (this, filter) = (self.clone(), filter.clone());
+            offload(&self.task_spawner, move || {
+                this.scan_matching_headers(&filter, from_block, to_block)
+            })
+            .await?
+        };
+
         // initialize the appropriate range mode based on collected headers
         let mut range_mode = RangeMode::new(
             self.clone(),
@@ -725,17 +734,28 @@ where
             range_mode.next().await?
         {
             let num_hash = header.num_hash();
-            append_matching_block_logs(
-                &mut all_logs,
-                recovered_block
-                    .map(ProviderOrBlock::Block)
-                    .unwrap_or_else(|| ProviderOrBlock::Provider(self.provider())),
-                filter,
-                num_hash,
-                &receipts,
-                false,
-                header.timestamp(),
-            )?;
+            // Resolving tx hashes reads the db when the block is not in hand, and matching a
+            // wide-open filter is thousands of keccaks either way, so this stays off the
+            // reactor unconditionally.
+            let (this, filter, timestamp) = (self.clone(), filter.clone(), header.timestamp());
+            all_logs.extend(
+                offload(&self.task_spawner, move || {
+                    let mut logs = Vec::new();
+                    append_matching_block_logs(
+                        &mut logs,
+                        recovered_block
+                            .map(ProviderOrBlock::Block)
+                            .unwrap_or_else(|| ProviderOrBlock::Provider(this.provider())),
+                        &filter,
+                        num_hash,
+                        &receipts,
+                        false,
+                        timestamp,
+                    )?;
+                    Ok(logs)
+                })
+                .await?,
+            );
 
             // size check but only if range is multiple blocks, so we always return all
             // logs of a single block
@@ -1184,6 +1204,28 @@ impl<
     }
 }
 
+/// Runs `f` on the blocking pool.
+///
+/// `f` must be self-contained: a task that holds a blocking thread must never wait for another
+/// task, or the pool can deadlock with every thread parked on work that needs a thread.
+async fn offload<F, R>(spawner: &Runtime, f: F) -> Result<R, EthFilterError>
+where
+    F: FnOnce() -> Result<R, EthFilterError> + Send + 'static,
+    R: Send + 'static,
+{
+    let span = tracing::Span::current();
+    spawner
+        .spawn_blocking(move || {
+            let _entered = span.enter();
+            f()
+        })
+        .await
+        .map_err(|error| {
+            trace!(target: "rpc::eth::filter", ?error, "Offloaded task join error");
+            EthFilterError::InternalError
+        })?
+}
+
 /// Type alias for parallel receipt fetching task futures used in `RangeBlockMode`
 type ReceiptFetchFuture<P> =
     Pin<Box<dyn Future<Output = Result<Vec<ReceiptBlockResult<P>>, EthFilterError>> + Send>>;
@@ -1290,8 +1332,13 @@ impl<
             let receipts = match maybe_receipts {
                 Some(receipts) => receipts,
                 None => {
-                    // Not cached - fetch directly from provider
-                    match self.filter_inner.provider().receipts_by_block(header.hash().into())? {
+                    // not cached - the provider read is synchronous, so it is offloaded
+                    let (this, hash) = (self.filter_inner.clone(), header.hash());
+                    let receipts = offload(&self.filter_inner.task_spawner, move || {
+                        Ok(this.provider().receipts_by_block(hash.into())?)
+                    })
+                    .await?;
+                    match receipts {
                         Some(receipts) => Arc::new(receipts),
                         None => continue, // No receipts found
                     }

--- a/crates/rpc/rpc/src/eth/filter.rs
+++ b/crates/rpc/rpc/src/eth/filter.rs
@@ -694,10 +694,9 @@ where
         Ok(matching_headers)
     }
 
-    /// Collects the logs matching `filter` in the given _inclusive_ range.
+    /// Collects logs for `filter` over the inclusive range.
     ///
-    /// Drives the rpc cache to fetch receipts and blocks, so it must run on the async runtime;
-    /// the synchronous parts are offloaded via [`offload`].
+    /// Cache orchestration stays async; synchronous scans are offloaded via [`offload`].
     async fn collect_logs_in_block_range(
         self: Arc<Self>,
         filter: Arc<LogFilter>,
@@ -710,7 +709,7 @@ where
         // get current chain tip to determine processing mode
         let chain_tip = self.provider().best_block_number()?;
 
-        // the bloom scan is synchronous, so it is offloaded
+        // Bloom scan is synchronous, so offload it.
         let matching_headers = {
             let (this, filter) = (self.clone(), filter.clone());
             offload(&self.task_spawner, move || {
@@ -1206,8 +1205,7 @@ impl<
 
 /// Runs `f` on the blocking pool.
 ///
-/// `f` must be self-contained: a task that holds a blocking thread must never wait for another
-/// task, or the pool can deadlock with every thread parked on work that needs a thread.
+/// `f` must be self-contained and must not depend on other queued work.
 async fn offload<F, R>(spawner: &Runtime, f: F) -> Result<R, EthFilterError>
 where
     F: FnOnce() -> Result<R, EthFilterError> + Send + 'static,
@@ -1332,7 +1330,7 @@ impl<
             let receipts = match maybe_receipts {
                 Some(receipts) => receipts,
                 None => {
-                    // not cached - the provider read is synchronous, so it is offloaded
+                    // Cache miss: offload the synchronous provider read.
                     let (this, hash) = (self.filter_inner.clone(), header.hash());
                     let receipts = offload(&self.filter_inner.task_spawner, move || {
                         Ok(this.provider().receipts_by_block(hash.into())?)

--- a/crates/rpc/rpc/src/reth.rs
+++ b/crates/rpc/rpc/src/reth.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 
 use alloy_consensus::BlockHeader;
 use alloy_eips::BlockId;
@@ -61,26 +61,27 @@ where
     Provider: BlockReaderIdExt + ChangeSetReader + StateProviderFactory + 'static,
     EvmConfig: Send + Sync + 'static,
 {
-    /// Executes the future on a new blocking task.
-    async fn on_blocking_task<C, F, R>(&self, c: C) -> EthResult<R>
+    /// Executes the closure on a new blocking task.
+    ///
+    /// `c` must be self-contained: it runs on a thread from the blocking pool and must not wait
+    /// for another task, or the pool can deadlock with every thread parked on work that needs a
+    /// thread.
+    async fn on_blocking_task<C, R>(&self, c: C) -> EthResult<R>
     where
-        C: FnOnce(Self) -> F,
-        F: Future<Output = EthResult<R>> + Send + 'static,
+        C: FnOnce(Self) -> EthResult<R> + Send + 'static,
         R: Send + 'static,
     {
         let (tx, rx) = oneshot::channel();
         let this = self.clone();
-        let f = c(this);
         self.inner.task_spawner.spawn_blocking_task(async move {
-            let res = f.await;
-            let _ = tx.send(res);
+            let _ = tx.send(c(this));
         });
         rx.await.map_err(|_| EthApiError::InternalEthError)?
     }
 
     /// Returns a map of addresses to changed account balanced for a particular block.
     pub async fn balance_changes_in_block(&self, block_id: BlockId) -> EthResult<AddressMap<U256>> {
-        self.on_blocking_task(async move |this| this.try_balance_changes_in_block(block_id)).await
+        self.on_blocking_task(move |this| this.try_balance_changes_in_block(block_id)).await
     }
 
     fn try_balance_changes_in_block(&self, block_id: BlockId) -> EthResult<AddressMap<U256>> {
@@ -138,7 +139,7 @@ where
             .acquire_owned()
             .await
             .map_err(|_| EthApiError::InternalEthError)?;
-        self.on_blocking_task(async move |this| {
+        self.on_blocking_task(move |this| {
             let _permit = permit;
             this.try_block_execution_outcome(block_id, block_count)
         })


### PR DESCRIPTION
### Description

This change fixes a deadlock pattern in state-serving RPCs by keeping async work on the async runtime and offloading only self-contained synchronous work to the blocking pool.

Under concurrent load, requests such as `eth_call`, `eth_getBalance`, `eth_getLogs`, `eth_getBlockReceipts`, and `eth_getTransactionReceipt` could previously hold blocking threads while awaiting dependent state or cache work. Timed-out or disconnected RPCs could also leave those threads pinned behind abandoned work.

### Rationale

The previous implementation ran async RPC flows inside blocking tasks. Once enough requests entered that path, the blocking pool could wedge: requests waited for work that still needed blocking-pool capacity, and unrelated `spawn_blocking` work could be starved as well.

This change breaks that cycle by resolving awaited work on the async runtime first and offloading only synchronous work.

### Example

Before:

* state-serving RPC bursts could wedge the blocking pool
* affected RPCs could hang indefinitely
* timed-out or disconnected RPCs could still pin blocking threads

After:

* async orchestration stays on the async runtime
* only synchronous scans and reads are offloaded
* timed-out or disconnected RPCs no longer pin blocking threads while awaiting dependent work

### Changes

Notable changes:
* remove `spawn_blocking_io_fut` and stop running async RPC flows inside blocking tasks
* resolve state on the async runtime before offloading synchronous work
* keep `eth_getLogs` orchestration async and offload only synchronous scans and provider reads
* await cache rate-limit permits on the async runtime before dispatching blocking reads

### Potential Impacts
* fixes the deadlock pattern behind [bnb-chain/reth-bsc#476](https://github.com/bnb-chain/reth-bsc/issues/476)
* improves liveness for state-serving RPCs under concurrent load
* no intended behavior change beyond task scheduling and blocking-pool usage
