### PR TITLE
docs: drop redundant explicit link targets

### DIFF
--- a/crates/net/network/src/config.rs
+++ b/crates/net/network/src/config.rs
@@ -180,7 +180,7 @@ where
     }
 }
 
-/// Builder for [`NetworkConfig`](struct.NetworkConfig.html).
+/// Builder for [`NetworkConfig`].
 #[derive(Debug)]
 pub struct NetworkConfigBuilder<N: NetworkPrimitives = EthNetworkPrimitives> {
     /// The node's secret key, from which the node's identity is derived.

--- a/crates/tasks/src/pool.rs
+++ b/crates/tasks/src/pool.rs
@@ -74,7 +74,7 @@ impl BlockingTaskPool {
 
     /// Convenience function to build a new threadpool with the default configuration.
     ///
-    /// Uses [`rayon::ThreadPoolBuilder::build`](rayon::ThreadPoolBuilder::build) defaults.
+    /// Uses [`rayon::ThreadPoolBuilder::build`] defaults.
     /// If a different stack size or other parameters are needed, they can be configured via
     /// [`rayon::ThreadPoolBuilder`] returned by [`Self::builder`].
     pub fn build() -> Result<Self, rayon::ThreadPoolBuildError> {


### PR DESCRIPTION
`rustdoc::redundant_explicit_links` started firing on current nightly, so the `docs` job fails with `-D warnings` on every PR against `develop`:

```
error: redundant explicit link target
   --> crates/net/network/src/config.rs:183:35
error: could not document `reth-network`
```

Both labels already resolve to the destination their explicit target named — the bare form is what the rest of each file uses.