### PR TITLE
fix(rocksdb): better max_open_files config (port of paradigmxyz/reth#26812)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9616,6 +9616,7 @@ dependencies = [
  "assert_matches",
  "eyre",
  "itertools 0.14.0",
+ "libc",
  "metrics",
  "notify",
  "parking_lot",

--- a/crates/storage/provider/Cargo.toml
+++ b/crates/storage/provider/Cargo.toml
@@ -70,6 +70,9 @@ rayon.workspace = true
 
 rocksdb.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 reth-db = { workspace = true, features = ["test-utils"] }
 reth-primitives-traits = { workspace = true, features = ["arbitrary", "test-utils"] }

--- a/crates/storage/provider/src/providers/rocksdb/provider.rs
+++ b/crates/storage/provider/src/providers/rocksdb/provider.rs
@@ -114,14 +114,22 @@ const DEFAULT_BLOCK_SIZE: usize = 16 * 1024;
 /// Default max background jobs for `RocksDB` compaction and flushing.
 const DEFAULT_MAX_BACKGROUND_JOBS: i32 = 6;
 
-/// Default max open file descriptors for `RocksDB`.
+/// Max open file descriptors for `RocksDB` when the process limit is low.
 ///
 /// Caps the number of SST file handles `RocksDB` keeps open simultaneously.
 /// Set to 512 to stay within the common default OS `ulimit -n` of 1024,
 /// leaving headroom for MDBX, static files, and other I/O.
-/// `RocksDB` uses an internal table cache and re-opens files on demand,
-/// so this has negligible performance impact on read-heavy workloads.
-const DEFAULT_MAX_OPEN_FILES: i32 = 512;
+const LIMITED_MAX_OPEN_FILES: i32 = 512;
+
+/// Keeps all `RocksDB` files open and avoids table cache lookups.
+const KEEP_ALL_FILES_OPEN: i32 = -1;
+
+/// Minimum process file descriptor limit for keeping all `RocksDB` files open.
+///
+/// Mature archive databases can use tens of thousands of file descriptors. This threshold keeps
+/// unlimited mode for hosts configured for that workload while retaining a bounded table cache on
+/// systems with low limits.
+const HIGH_FILE_DESCRIPTOR_LIMIT: u64 = 128 * 1024;
 
 /// Default bytes per sync for `RocksDB` WAL writes (1 MB).
 const DEFAULT_BYTES_PER_SYNC: u64 = 1_048_576;
@@ -215,7 +223,7 @@ impl RocksDBBuilder {
 
         options.set_log_level(log_level);
 
-        options.set_max_open_files(DEFAULT_MAX_OPEN_FILES);
+        options.set_max_open_files(select_max_open_files());
 
         // Delete obsolete WAL files immediately after all column families have flushed.
         // Both set to 0 means "delete ASAP, no archival".
@@ -354,7 +362,7 @@ impl RocksDBBuilder {
             // Open as secondary instance for catch-up capability.
             // Secondary needs max_open_files = -1 to keep all FDs open.
             let mut options = options;
-            options.set_max_open_files(-1);
+            options.set_max_open_files(KEEP_ALL_FILES_OPEN);
 
             let secondary_path = self
                 .path
@@ -2756,6 +2764,60 @@ const fn convert_log_level(level: LogLevel) -> rocksdb::LogLevel {
     }
 }
 
+/// Selects the `RocksDB` `max_open_files` setting from the current file descriptor limit
+/// balancing performance vs. compatibility.
+///
+/// A mature database can use tens of thousands of file descriptors. With a
+/// finite `max_open_files` value, `RocksDB` performs additional table-cache checks
+/// even when enough capacity is available. The value `-1` keeps all table files
+/// open and avoids this overhead.
+///
+/// During normal startup, Reth raises the soft file descriptor limit to the
+/// system hard limit before it opens `RocksDB`. Therefore, we expect the current
+/// limit to be the hard limit. A survey of modern Linux distributions shows
+/// common default limits of `1024:524288`.
+///
+/// We use `-1` only when the current limit is above a conservative threshold.
+/// This keeps enough file descriptors for other parts of the process. When the
+/// limit is lower or cannot be read, we use a stricter fixed limit.
+fn select_max_open_files() -> i32 {
+    let file_descriptor_limit = current_file_descriptor_limit();
+    let max_open_files = max_open_files_for_limit(file_descriptor_limit);
+
+    if max_open_files == LIMITED_MAX_OPEN_FILES {
+        tracing::warn!(
+            target: "providers::rocksdb",
+            ?file_descriptor_limit,
+            threshold = HIGH_FILE_DESCRIPTOR_LIMIT,
+            max_open_files,
+            "RocksDB will not keep all files open; performance may be reduced"
+        );
+    }
+
+    max_open_files
+}
+
+const fn max_open_files_for_limit(file_descriptor_limit: Option<u64>) -> i32 {
+    match file_descriptor_limit {
+        Some(limit) if limit >= HIGH_FILE_DESCRIPTOR_LIMIT => KEEP_ALL_FILES_OPEN,
+        _ => LIMITED_MAX_OPEN_FILES,
+    }
+}
+
+#[cfg(unix)]
+#[allow(clippy::useless_conversion)]
+fn current_file_descriptor_limit() -> Option<u64> {
+    let mut limit = libc::rlimit { rlim_cur: 0, rlim_max: 0 };
+    // SAFETY: `limit` points to initialized writable memory for the kernel to populate.
+    let result = unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limit) };
+    (result == 0).then(|| limit.rlim_cur.into())
+}
+
+#[cfg(not(unix))]
+const fn current_file_descriptor_limit() -> Option<u64> {
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2771,6 +2833,16 @@ mod tests {
         tables,
     };
     use tempfile::TempDir;
+
+    #[test]
+    fn max_open_files_adapts_to_file_descriptor_limit() {
+        assert_eq!(max_open_files_for_limit(Some(HIGH_FILE_DESCRIPTOR_LIMIT)), KEEP_ALL_FILES_OPEN);
+        assert_eq!(
+            max_open_files_for_limit(Some(HIGH_FILE_DESCRIPTOR_LIMIT - 1)),
+            LIMITED_MAX_OPEN_FILES
+        );
+        assert_eq!(max_open_files_for_limit(None), LIMITED_MAX_OPEN_FILES);
+    }
 
     #[test]
     fn test_with_default_tables_registers_required_column_families() {


### PR DESCRIPTION
## Summary

Identical port of [paradigmxyz/reth#26812](https://github.com/paradigmxyz/reth/pull/26812) (`fix(rocksdb): better max_open_files config`), as requested by the team in [bnb-chain/reth-bsc#484](https://github.com/bnb-chain/reth-bsc/issues/484).

Upstream context: [paradigmxyz/reth#26801](https://github.com/paradigmxyz/reth/issues/26801) showed that the fixed `max_open_files = 512` causes RocksDB table-cache thrash on archive nodes whose history tables span thousands of SST files — most history lookups land on a "closed" SST and pay `BlockBasedTable::Open` plus zstd index-block decompression. Tracing workloads re-execute blocks against historical state and perform thousands of such lookups per call, so they multiply the full per-lookup penalty.

This change selects the RocksDB `max_open_files` setting based on the process file descriptor limit:

- If `RLIMIT_NOFILE` is at or above a conservative threshold of 131,072, use `-1` (keep all SST table readers open, no table-cache lookups).
- Otherwise (or if the limit cannot be read), keep the previous bounded value of 512 and emit a warning that performance may be reduced.

The read-only/secondary path is unchanged (it already unconditionally used `-1`). Behavior on hosts with low `ulimit -n` is unchanged.

## Impact on BSC mainnet

Measured on a BSC mainnet StorageV2 archive node (reth-bsc v0.1.1, 18,919 SST files in the RocksDB directory, 48 cores / 256 GB RAM, `ulimit -n` 500k), benchmarked with fresh never-repeated random blocks between 30M and tip so caches cannot flatter the numbers — full details in bnb-chain/reth-bsc#484:

| Workload | Before | After | Gain |
| --- | --- | --- | --- |
| `trace_block`, c=1 | mean 633 ms | mean 323 ms | ~2.0x |
| `trace_block`, c=24 | 29.3 rps | 49.5 rps | ~1.7x |
| `debug_traceTransaction` (callTracer), c=8 | 24.3 rps / 325 ms | 40.5 rps / 193 ms | ~1.7x |
| `trace_filter`, 100-block ranges, c=4 | mean 7.25 s | mean 3.44 s | ~2.1x |

`perf` under load confirms the mechanism: zstd/lz4 self time drops from ~17% to ~4% and the `TableCache::FindTable` / `BlockBasedTable::Open` reopen path disappears from the profile. Process FDs grew from ~4.2k to ~22.4k and RSS from ~23 GB to ~45 GB (open table readers + their pinned index/filter metadata) — well within archive-node headroom.

## Testing

- `cargo check -p reth-provider --locked`
- `cargo test -p reth-provider --locked max_open_files` (unit test ported from upstream: threshold selection at/below the limit and with an unreadable limit)
- Patched binary running on a BSC mainnet archive node at tip; RocksDB `LOG` shows `Options.max_open_files: -1`
