### PR TITLE
feat: minimal fastnode storage

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -598,6 +598,7 @@ impl PruneConfig {
                     receipts,
                     account_history,
                     storage_history,
+                    header_history,
                     bodies_history,
                     receipts_log_filter,
                 },
@@ -620,6 +621,7 @@ impl PruneConfig {
         self.segments.receipts = self.segments.receipts.or(receipts);
         self.segments.account_history = self.segments.account_history.or(account_history);
         self.segments.storage_history = self.segments.storage_history.or(storage_history);
+        self.segments.header_history = self.segments.header_history.or(header_history);
         self.segments.bodies_history = self.segments.bodies_history.or(bodies_history);
 
         if self.segments.receipts_log_filter.0.is_empty() && !receipts_log_filter.0.is_empty() {
@@ -1158,6 +1160,7 @@ receipts = { distance = 16384 }
                 receipts: Some(PruneMode::Distance(1000)),
                 account_history: None,
                 storage_history: Some(PruneMode::Before(5000)),
+                header_history: None,
                 bodies_history: None,
                 receipts_log_filter: ReceiptsLogPruneConfig(BTreeMap::from([(
                     Address::random(),
@@ -1175,6 +1178,7 @@ receipts = { distance = 16384 }
                 receipts: Some(PruneMode::Full),
                 account_history: Some(PruneMode::Distance(2000)),
                 storage_history: Some(PruneMode::Distance(3000)),
+                header_history: Some(PruneMode::Distance(20_000)),
                 bodies_history: None,
                 receipts_log_filter: ReceiptsLogPruneConfig(BTreeMap::from([
                     (Address::random(), PruneMode::Distance(1000)),
@@ -1194,6 +1198,7 @@ receipts = { distance = 16384 }
         assert_eq!(config1.segments.receipts, Some(PruneMode::Distance(1000)));
         assert_eq!(config1.segments.account_history, Some(PruneMode::Distance(2000)));
         assert_eq!(config1.segments.storage_history, Some(PruneMode::Before(5000)));
+        assert_eq!(config1.segments.header_history, Some(PruneMode::Distance(20_000)));
         assert_eq!(config1.segments.receipts_log_filter, original_filter);
     }
 

--- a/crates/node/builder/src/components/pool.rs
+++ b/crates/node/builder/src/components/pool.rs
@@ -277,6 +277,14 @@ where
 {
     let chain_events = ctx.provider().canonical_state_stream();
     let client = ctx.provider().clone();
+    let mut maintenance_config = reth_transaction_pool::maintain::MaintainPoolConfig {
+        max_tx_lifetime: pool_config.max_queued_lifetime,
+        no_local_exemptions: pool_config.local_transactions_config.no_exemptions,
+        ..Default::default()
+    };
+    if ctx.config().pruning.minimal {
+        maintenance_config.blob_sweep_max_age = std::time::Duration::from_secs(60 * 60);
+    }
 
     ctx.task_executor().spawn_critical_task(
         "txpool maintenance task",
@@ -285,11 +293,7 @@ where
             pool,
             chain_events,
             ctx.task_executor().clone(),
-            reth_transaction_pool::maintain::MaintainPoolConfig {
-                max_tx_lifetime: pool_config.max_queued_lifetime,
-                no_local_exemptions: pool_config.local_transactions_config.no_exemptions,
-                ..Default::default()
-            },
+            maintenance_config,
         ),
     );
 

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -13,6 +13,9 @@ use std::{collections::BTreeMap, ops::Not, sync::OnceLock};
 /// Global static pruning defaults
 static PRUNING_DEFAULTS: OnceLock<DefaultPruningValues> = OnceLock::new();
 
+/// Includes the EVM block-hash window before the oldest unwindable block.
+const MINIMAL_HEADER_HISTORY_DISTANCE: u64 = MINIMUM_UNWIND_SAFE_DISTANCE + 256;
+
 /// Default values for `--full` and `--minimal` pruning modes that can be customized.
 ///
 /// Global defaults can be set via [`DefaultPruningValues::try_init`].
@@ -85,7 +88,7 @@ impl Default for DefaultPruningValues {
                 receipts: Some(PruneMode::Distance(MINIMUM_DISTANCE)),
                 account_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 storage_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
-                header_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
+                header_history: Some(PruneMode::Distance(MINIMAL_HEADER_HISTORY_DISTANCE)),
                 bodies_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 receipts_log_filter: Default::default(),
             },
@@ -106,7 +109,7 @@ pub struct PruningArgs {
     ///
     /// This mode configures the node to use minimal disk space by:
     /// - Fully pruning sender recovery, transaction lookup, receipts
-    /// - Leaving 10,064 blocks for account, storage, header and body history
+    /// - Leaving 10,064 blocks for account, storage and body history, and 10,320 headers
     /// - Using 10,000 blocks per static file segment
     #[arg(long, default_value_t = false, conflicts_with = "full")]
     pub minimal: bool,
@@ -443,7 +446,7 @@ mod tests {
 
         assert_eq!(
             config.segments.header_history,
-            Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE))
+            Some(PruneMode::Distance(MINIMAL_HEADER_HISTORY_DISTANCE))
         );
         assert!(PruningArgs::default().prune_config(MAINNET.as_ref()).is_none());
 

--- a/crates/node/core/src/args/pruning.rs
+++ b/crates/node/core/src/args/pruning.rs
@@ -73,6 +73,7 @@ impl Default for DefaultPruningValues {
                 receipts: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 account_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 storage_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
+                header_history: None,
                 // This field is ignored when full_bodies_history_use_pre_merge is true
                 bodies_history: None,
                 receipts_log_filter: Default::default(),
@@ -84,6 +85,7 @@ impl Default for DefaultPruningValues {
                 receipts: Some(PruneMode::Distance(MINIMUM_DISTANCE)),
                 account_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 storage_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
+                header_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 bodies_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
                 receipts_log_filter: Default::default(),
             },
@@ -104,7 +106,7 @@ pub struct PruningArgs {
     ///
     /// This mode configures the node to use minimal disk space by:
     /// - Fully pruning sender recovery, transaction lookup, receipts
-    /// - Leaving 10,064 blocks for account, storage history and block bodies
+    /// - Leaving 10,064 blocks for account, storage, header and body history
     /// - Using 10,000 blocks per static file segment
     #[arg(long, default_value_t = false, conflicts_with = "full")]
     pub minimal: bool,
@@ -409,6 +411,7 @@ mod tests {
     use super::*;
     use alloy_primitives::address;
     use clap::Parser;
+    use reth_chainspec::MAINNET;
 
     /// A helper type to parse Args more easily
     #[derive(Parser)]
@@ -431,6 +434,21 @@ mod tests {
             PruneMode::Before(5000000),
         );
         assert_eq!(args.receipts_log_filter, Some(config));
+    }
+
+    #[test]
+    fn minimal_prunes_header_history() {
+        let args = CommandParser::<PruningArgs>::parse_from(["reth", "--minimal"]).args;
+        let config = args.prune_config(MAINNET.as_ref()).unwrap();
+
+        assert_eq!(
+            config.segments.header_history,
+            Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE))
+        );
+        assert!(PruningArgs::default().prune_config(MAINNET.as_ref()).is_none());
+
+        let args = CommandParser::<PruningArgs>::parse_from(["reth", "--full"]).args;
+        assert_eq!(args.prune_config(MAINNET.as_ref()).unwrap().segments.header_history, None);
     }
 
     #[test]

--- a/crates/prune/prune/src/segments/mod.rs
+++ b/crates/prune/prune/src/segments/mod.rs
@@ -17,8 +17,8 @@ pub use set::SegmentSet;
 use std::{fmt::Debug, ops::RangeInclusive};
 use tracing::error;
 pub use user::{
-    AccountHistory, Bodies, Receipts as UserReceipts, ReceiptsByLogs, SenderRecovery,
-    StorageHistory, TransactionLookup,
+    AccountHistory, Bodies, HeaderHistory, Receipts as UserReceipts, ReceiptsByLogs,
+    SenderRecovery, StorageHistory, TransactionLookup,
 };
 
 /// Prunes data from static files for a given segment.

--- a/crates/prune/prune/src/segments/set.rs
+++ b/crates/prune/prune/src/segments/set.rs
@@ -1,6 +1,6 @@
 use crate::segments::{
-    user::ReceiptsByLogs, AccountHistory, Bodies, Segment, SenderRecovery, StorageHistory,
-    TransactionLookup, UserReceipts,
+    user::ReceiptsByLogs, AccountHistory, Bodies, HeaderHistory, Segment, SenderRecovery,
+    StorageHistory, TransactionLookup, UserReceipts,
 };
 use alloy_eips::eip2718::Encodable2718;
 use reth_db_api::{table::Value, transaction::DbTxMut};
@@ -71,6 +71,7 @@ where
             receipts,
             account_history,
             storage_history,
+            header_history,
             bodies_history,
             receipts_log_filter,
         } = prune_modes;
@@ -94,6 +95,8 @@ where
             )
             // Sender recovery
             .segment_opt(sender_recovery.map(SenderRecovery::new))
+            // Prune headers after segments that may read them.
+            .segment_opt(header_history.map(HeaderHistory::new))
     }
 }
 

--- a/crates/prune/prune/src/segments/user/header_history.rs
+++ b/crates/prune/prune/src/segments/user/header_history.rs
@@ -1,0 +1,156 @@
+use crate::{
+    segments::{PruneInput, Segment},
+    PrunerError,
+};
+use reth_provider::StaticFileProviderFactory;
+use reth_prune_types::{
+    PruneMode, PruneProgress, PrunePurpose, PruneSegment, SegmentOutput, SegmentOutputCheckpoint,
+};
+use reth_stages_types::StageId;
+use reth_static_file_types::StaticFileSegment;
+
+/// Prunes historical header static files.
+#[derive(Debug)]
+pub struct HeaderHistory {
+    mode: PruneMode,
+}
+
+impl HeaderHistory {
+    /// Creates a new header history segment.
+    pub const fn new(mode: PruneMode) -> Self {
+        Self { mode }
+    }
+}
+
+impl<Provider> Segment<Provider> for HeaderHistory
+where
+    Provider: StaticFileProviderFactory,
+{
+    fn segment(&self) -> PruneSegment {
+        PruneSegment::HeaderHistory
+    }
+
+    fn mode(&self) -> Option<PruneMode> {
+        Some(self.mode)
+    }
+
+    fn purpose(&self) -> PrunePurpose {
+        PrunePurpose::User
+    }
+
+    fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
+        let static_files = provider.static_file_provider();
+        let deleted = static_files.delete_segment_below_block(
+            StaticFileSegment::Headers,
+            input.to_block.saturating_add(1),
+        )?;
+
+        let pruned = deleted
+            .iter()
+            .filter_map(|header| header.block_range())
+            .map(|range| range.len() as usize)
+            .sum();
+        // Recover if files were deleted before their checkpoint was committed.
+        let checkpoint = deleted
+            .iter()
+            .filter_map(|header| header.block_range().map(|range| range.end()))
+            .chain(
+                static_files
+                    .get_lowest_range_start(StaticFileSegment::Headers)
+                    .and_then(|block| block.checked_sub(1)),
+            )
+            .chain(input.previous_checkpoint.and_then(|checkpoint| checkpoint.block_number))
+            .max()
+            .map(|block_number| SegmentOutputCheckpoint {
+                block_number: Some(block_number),
+                tx_number: None,
+            });
+
+        Ok(SegmentOutput { progress: PruneProgress::Finished, pruned, checkpoint })
+    }
+
+    fn required_stage(&self) -> Option<StageId> {
+        Some(StageId::Bodies)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::PruneLimiter;
+    use reth_provider::{
+        test_utils::create_test_provider_factory, DatabaseProviderFactory,
+        StaticFileProviderFactory, StaticFileWriter,
+    };
+    use reth_static_file_types::{
+        SegmentHeader, SegmentRangeInclusive, DEFAULT_BLOCKS_PER_STATIC_FILE,
+    };
+
+    fn setup_header_jars(provider: &impl StaticFileProviderFactory, jars: u64) {
+        let static_files = provider.static_file_provider();
+        let mut writer = static_files.latest_writer(StaticFileSegment::Headers).unwrap();
+
+        for jar in 0..jars {
+            let start = jar * DEFAULT_BLOCKS_PER_STATIC_FILE;
+            let end = start + DEFAULT_BLOCKS_PER_STATIC_FILE - 1;
+            *writer.user_header_mut() = SegmentHeader::new(
+                SegmentRangeInclusive::new(start, end),
+                Some(SegmentRangeInclusive::new(start, end)),
+                None,
+                StaticFileSegment::Headers,
+            );
+            writer.inner().set_dirty();
+            writer.commit().unwrap();
+
+            if jar + 1 < jars {
+                writer.increment_block(end + 1).unwrap();
+            }
+        }
+
+        static_files.initialize_index().unwrap();
+    }
+
+    #[test]
+    fn prunes_complete_header_jars() {
+        let factory = create_test_provider_factory();
+        setup_header_jars(&factory, 3);
+
+        let segment = HeaderHistory::new(PruneMode::Distance(10_064));
+        let output = segment
+            .prune(
+                &factory.database_provider_rw().unwrap(),
+                PruneInput {
+                    previous_checkpoint: None,
+                    to_block: 899_999,
+                    limiter: PruneLimiter::default(),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(output.pruned, DEFAULT_BLOCKS_PER_STATIC_FILE as usize);
+        assert_eq!(output.checkpoint.unwrap().block_number, Some(499_999));
+        assert_eq!(
+            factory.static_file_provider().get_lowest_range_start(StaticFileSegment::Headers),
+            Some(500_000)
+        );
+    }
+
+    #[test]
+    fn restores_checkpoint_from_retained_floor() {
+        let factory = create_test_provider_factory();
+        setup_header_jars(&factory, 3);
+        let provider = factory.database_provider_rw().unwrap();
+        let segment = HeaderHistory::new(PruneMode::Distance(10_064));
+        let input = PruneInput {
+            previous_checkpoint: None,
+            to_block: 899_999,
+            limiter: PruneLimiter::default(),
+        };
+
+        segment.prune(&provider, input.clone()).unwrap();
+        let output = segment.prune(&provider, input).unwrap();
+
+        assert_eq!(output.pruned, 0);
+        assert_eq!(output.checkpoint.unwrap().block_number, Some(499_999));
+    }
+}

--- a/crates/prune/prune/src/segments/user/header_history.rs
+++ b/crates/prune/prune/src/segments/user/header_history.rs
@@ -8,6 +8,8 @@ use reth_prune_types::{
 };
 use reth_stages_types::StageId;
 use reth_static_file_types::StaticFileSegment;
+use std::time::Instant;
+use tracing::info;
 
 /// Prunes historical header static files.
 #[derive(Debug)]
@@ -39,6 +41,7 @@ where
     }
 
     fn prune(&self, provider: &Provider, input: PruneInput) -> Result<SegmentOutput, PrunerError> {
+        let started_at = Instant::now();
         let static_files = provider.static_file_provider();
         let deleted = static_files.delete_segment_below_block(
             StaticFileSegment::Headers,
@@ -66,6 +69,17 @@ where
                 tx_number: None,
             });
 
+        if !deleted.is_empty() {
+            info!(
+                target: "pruner",
+                deleted_files = deleted.len(),
+                pruned_blocks = pruned,
+                highest_pruned_block = ?checkpoint.and_then(|checkpoint| checkpoint.block_number),
+                elapsed = ?started_at.elapsed(),
+                "Pruned header history"
+            );
+        }
+
         Ok(SegmentOutput { progress: PruneProgress::Finished, pruned, checkpoint })
     }
 
@@ -79,8 +93,8 @@ mod tests {
     use super::*;
     use crate::PruneLimiter;
     use reth_provider::{
-        test_utils::create_test_provider_factory, DatabaseProviderFactory,
-        StaticFileProviderFactory, StaticFileWriter,
+        test_utils::create_test_provider_factory, DatabaseProviderFactory, HeaderProvider,
+        ProviderError, StaticFileProviderFactory, StaticFileWriter,
     };
     use reth_static_file_types::{
         SegmentHeader, SegmentRangeInclusive, DEFAULT_BLOCKS_PER_STATIC_FILE,
@@ -133,6 +147,11 @@ mod tests {
             factory.static_file_provider().get_lowest_range_start(StaticFileSegment::Headers),
             Some(500_000)
         );
+        assert_eq!(factory.static_file_provider().earliest_history_height(), 500_000);
+        assert!(matches!(
+            factory.static_file_provider().headers_range(0..1),
+            Err(ProviderError::BlockExpired { requested: 0, earliest_available: 500_000 })
+        ));
     }
 
     #[test]

--- a/crates/prune/prune/src/segments/user/mod.rs
+++ b/crates/prune/prune/src/segments/user/mod.rs
@@ -1,5 +1,6 @@
 mod account_history;
 mod bodies;
+mod header_history;
 mod history;
 mod receipts;
 mod receipts_by_logs;
@@ -9,6 +10,7 @@ mod transaction_lookup;
 
 pub use account_history::AccountHistory;
 pub use bodies::Bodies;
+pub use header_history::HeaderHistory;
 pub use receipts::Receipts;
 pub use receipts_by_logs::ReceiptsByLogs;
 pub use sender_recovery::SenderRecovery;

--- a/crates/prune/types/src/segment.rs
+++ b/crates/prune/types/src/segment.rs
@@ -43,6 +43,8 @@ pub enum PruneSegment {
     MerkleChangeSets,
     /// Prune segment responsible for bodies (transactions in static files).
     Bodies,
+    /// Prune segment responsible for historical headers in static files.
+    HeaderHistory,
 }
 
 #[cfg(test)]
@@ -67,9 +69,10 @@ impl PruneSegment {
         match self {
             Self::SenderRecovery | Self::TransactionLookup => 0,
             Self::Receipts | Self::Bodies => MINIMUM_DISTANCE,
-            Self::ContractLogs | Self::AccountHistory | Self::StorageHistory => {
-                MINIMUM_UNWIND_SAFE_DISTANCE
-            }
+            Self::ContractLogs |
+            Self::AccountHistory |
+            Self::StorageHistory |
+            Self::HeaderHistory => MINIMUM_UNWIND_SAFE_DISTANCE,
             #[expect(deprecated)]
             #[expect(clippy::match_same_arms)]
             Self::Headers | Self::Transactions | Self::MerkleChangeSets => 0,
@@ -84,6 +87,11 @@ impl PruneSegment {
     /// Returns true if this is [`Self::StorageHistory`].
     pub const fn is_storage_history(&self) -> bool {
         matches!(self, Self::StorageHistory)
+    }
+
+    /// Returns true if this is [`Self::HeaderHistory`].
+    pub const fn is_header_history(&self) -> bool {
+        matches!(self, Self::HeaderHistory)
     }
 }
 

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -39,6 +39,8 @@ pub enum HistoryType {
     AccountHistory,
     /// Storage history
     StorageHistory,
+    /// Headers
+    Headers,
 }
 
 /// Pruning configuration for every segment of the data that can be pruned.
@@ -74,6 +76,15 @@ pub struct PruneModes {
         )
     )]
     pub storage_history: Option<PruneMode>,
+    /// Header History pruning configuration.
+    #[cfg_attr(
+        any(test, feature = "serde"),
+        serde(
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "deserialize_opt_prune_mode_with_min_blocks::<MINIMUM_UNWIND_SAFE_DISTANCE, _>"
+        )
+    )]
+    pub header_history: Option<PruneMode>,
     /// Bodies History pruning configuration.
     #[cfg_attr(any(test, feature = "serde"), serde(skip_serializing_if = "Option::is_none"))]
     pub bodies_history: Option<PruneMode>,
@@ -90,7 +101,7 @@ pub struct PruneModes {
 }
 
 impl PruneModes {
-    /// Sets pruning to all targets.
+    /// Sets all standard pruning targets.
     pub fn all() -> Self {
         Self {
             sender_recovery: Some(PruneMode::Full),
@@ -98,6 +109,7 @@ impl PruneModes {
             receipts: Some(PruneMode::Full),
             account_history: Some(PruneMode::Full),
             storage_history: Some(PruneMode::Full),
+            header_history: None,
             bodies_history: Some(PruneMode::Full),
             receipts_log_filter: Default::default(),
         }
@@ -135,6 +147,11 @@ impl PruneModes {
     ) -> Result<(), UnwindTargetPrunedError> {
         let distance = latest_block.saturating_sub(target_block);
         for (prune_mode, history_type, checkpoint) in &[
+            (
+                self.header_history,
+                HistoryType::Headers,
+                checkpoints.iter().find(|(segment, _)| segment.is_header_history()),
+            ),
             (
                 self.account_history,
                 HistoryType::AccountHistory,
@@ -405,5 +422,27 @@ mod tests {
             PruneModes { account_history: Some(PruneMode::Distance(100)), ..Default::default() };
         // Target block (1500) > latest block (1000) - distance should be 0
         assert!(prune_modes.ensure_unwind_target_unpruned(1000, 1500, &[]).is_ok());
+    }
+
+    #[test]
+    fn rejects_unwind_into_pruned_header_history() {
+        let prune_modes =
+            PruneModes { header_history: Some(PruneMode::Distance(100)), ..Default::default() };
+        let checkpoints = [(
+            PruneSegment::HeaderHistory,
+            PruneCheckpoint {
+                block_number: Some(850),
+                tx_number: None,
+                prune_mode: PruneMode::Distance(100),
+            },
+        )];
+
+        assert_matches!(
+            prune_modes.ensure_unwind_target_unpruned(1000, 800, &checkpoints),
+            Err(UnwindTargetPrunedError::TargetBeyondHistoryLimit {
+                history_type: HistoryType::Headers,
+                ..
+            })
+        );
     }
 }

--- a/crates/prune/types/src/target.rs
+++ b/crates/prune/types/src/target.rs
@@ -164,15 +164,13 @@ impl PruneModes {
             ),
         ] {
             if let Some(PruneMode::Distance(limit)) = prune_mode {
-                // check if distance exceeds the configured limit
-                if distance > *limit {
-                    // but only if we haven't pruned the target yet, if we don't have a checkpoint
-                    // yet, it's fully unpruned yet
+                let header_checkpoint_exists =
+                    *history_type == HistoryType::Headers && checkpoint.is_some();
+                if distance > *limit || header_checkpoint_exists {
                     let pruned_height = checkpoint
                         .and_then(|checkpoint| checkpoint.1.block_number)
                         .unwrap_or(latest_block);
                     if pruned_height >= target_block {
-                        // we've pruned the target block already and can't unwind past it
                         return Err(UnwindTargetPrunedError::TargetBeyondHistoryLimit {
                             latest_block,
                             target_block,
@@ -439,6 +437,28 @@ mod tests {
 
         assert_matches!(
             prune_modes.ensure_unwind_target_unpruned(1000, 800, &checkpoints),
+            Err(UnwindTargetPrunedError::TargetBeyondHistoryLimit {
+                history_type: HistoryType::Headers,
+                ..
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_unwind_at_pruned_header_boundary() {
+        let prune_modes =
+            PruneModes { header_history: Some(PruneMode::Distance(100)), ..Default::default() };
+        let checkpoints = [(
+            PruneSegment::HeaderHistory,
+            PruneCheckpoint {
+                block_number: Some(900),
+                tx_number: None,
+                prune_mode: PruneMode::Distance(100),
+            },
+        )];
+
+        assert_matches!(
+            prune_modes.ensure_unwind_target_unpruned(1000, 900, &checkpoints),
             Err(UnwindTargetPrunedError::TargetBeyondHistoryLimit {
                 history_type: HistoryType::Headers,
                 ..

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -11,13 +11,13 @@ use crate::{
     RocksDBProviderFactory, StageCheckpointReader, StateProviderBox, StaticFileProviderFactory,
     StaticFileWriter, TransactionVariant, TransactionsProvider,
 };
-use alloy_consensus::transaction::TransactionMeta;
+use alloy_consensus::{transaction::TransactionMeta, BlockHeader};
 use alloy_eips::BlockHashOrNumber;
 use alloy_primitives::{Address, BlockHash, BlockNumber, TxHash, TxNumber, B256, U256};
 use core::fmt;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use parking_lot::RwLock;
-use reth_chainspec::ChainInfo;
+use reth_chainspec::{ChainInfo, EthChainSpec};
 use reth_db::{init_db, mdbx::DatabaseArguments, DatabaseEnv};
 use reth_db_api::{database::Database, models::StoredBlockBodyIndices};
 use reth_errors::{RethError, RethResult};
@@ -111,6 +111,11 @@ impl<N: NodeTypesForProvider> ProviderFactory<NodeTypesWithDBAdapter<N, Database
 }
 
 impl<N: ProviderNodeTypes> ProviderFactory<N> {
+    fn may_have_pruned_genesis(&self, number: BlockNumber) -> bool {
+        self.prune_modes.header_history.is_some() &&
+            number == self.chain_spec.genesis_header().number()
+    }
+
     /// Create new database provider factory.
     ///
     /// The storage backends used by the produced factory MAY be inconsistent.
@@ -639,6 +644,9 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
     }
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
+        if self.may_have_pruned_genesis(num) {
+            return self.provider()?.header_by_number(num)
+        }
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             num,
@@ -666,6 +674,9 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
+        if self.may_have_pruned_genesis(number) {
+            return self.provider()?.sealed_header(number)
+        }
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             number,
@@ -692,6 +703,9 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
 
 impl<N: ProviderNodeTypes> BlockHashReader for ProviderFactory<N> {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
+        if self.may_have_pruned_genesis(number) {
+            return self.provider()?.block_hash(number)
+        }
         self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             number,
@@ -1037,8 +1051,8 @@ mod tests {
     use crate::{
         providers::{StaticFileProvider, StaticFileWriter},
         test_utils::{blocks::TEST_BLOCK, create_test_provider_factory, MockNodeTypesWithDB},
-        BlockHashReader, BlockNumReader, BlockWriter, DBProvider, HeaderSyncGapProvider,
-        TransactionsProvider,
+        BlockHashReader, BlockNumReader, BlockWriter, DBProvider, HeaderProvider,
+        HeaderSyncGapProvider, TransactionsProvider,
     };
     use alloy_primitives::{TxNumber, B256};
     use assert_matches::assert_matches;
@@ -1047,7 +1061,7 @@ mod tests {
         mdbx::DatabaseArguments,
         test_utils::{create_test_rocksdb_dir, create_test_static_files_dir, ERROR_TEMPDIR},
     };
-    use reth_db_api::tables;
+    use reth_db_api::{tables, transaction::DbTxMut};
     use reth_primitives_traits::SignerRecoverable;
     use reth_prune_types::{PruneMode, PruneModes};
     use reth_storage_errors::provider::ProviderError;
@@ -1078,6 +1092,43 @@ mod tests {
         let provider_rw = factory.provider_rw().unwrap();
         provider_rw.block_hash(0).unwrap();
         provider.block_hash(0).unwrap();
+    }
+
+    #[test]
+    fn minimal_provider_restores_pruned_genesis_header() {
+        let factory = create_test_provider_factory();
+        let genesis = factory.chain_spec().genesis_header().clone();
+        let genesis_hash = factory.chain_spec().genesis_hash();
+        let genesis_number = genesis.number();
+        let minimal_factory = factory.clone().with_prune_modes(PruneModes {
+            header_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
+            ..Default::default()
+        });
+
+        assert_eq!(minimal_factory.block_hash(genesis_number).unwrap(), None);
+        assert_eq!(minimal_factory.header_by_number(genesis_number).unwrap(), None);
+
+        {
+            let provider = factory.database_provider_rw().unwrap();
+            provider.tx_ref().put::<tables::HeaderNumbers>(genesis_hash, genesis_number).unwrap();
+            provider.commit().unwrap();
+        }
+
+        assert_eq!(factory.block_hash(genesis_number).unwrap(), None);
+        assert_eq!(factory.header_by_number(genesis_number).unwrap(), None);
+        assert_eq!(minimal_factory.block_hash(genesis_number).unwrap(), Some(genesis_hash));
+        assert_eq!(
+            minimal_factory.header_by_number(genesis_number).unwrap(),
+            Some(genesis.clone())
+        );
+        assert_eq!(
+            minimal_factory.sealed_header(genesis_number).unwrap().unwrap().hash(),
+            genesis_hash
+        );
+        assert_eq!(
+            minimal_factory.header_td_by_number(genesis_number).unwrap(),
+            Some(genesis.difficulty())
+        );
     }
 
     #[test]

--- a/crates/storage/provider/src/providers/database/mod.rs
+++ b/crates/storage/provider/src/providers/database/mod.rs
@@ -111,9 +111,8 @@ impl<N: NodeTypesForProvider> ProviderFactory<NodeTypesWithDBAdapter<N, Database
 }
 
 impl<N: ProviderNodeTypes> ProviderFactory<N> {
-    fn may_have_pruned_genesis(&self, number: BlockNumber) -> bool {
-        self.prune_modes.header_history.is_some() &&
-            number == self.chain_spec.genesis_header().number()
+    fn is_genesis(&self, number: BlockNumber) -> bool {
+        number == self.chain_spec.genesis_header().number()
     }
 
     /// Create new database provider factory.
@@ -644,7 +643,10 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
     }
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
-        if self.may_have_pruned_genesis(num) {
+        if self.is_genesis(num) {
+            if let Some(header) = self.static_file_provider.header_by_number(num)? {
+                return Ok(Some(header))
+            }
             return self.provider()?.header_by_number(num)
         }
         self.static_file_provider.get_with_static_file_or_database(
@@ -674,7 +676,10 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
-        if self.may_have_pruned_genesis(number) {
+        if self.is_genesis(number) {
+            if let Some(header) = self.static_file_provider.sealed_header(number)? {
+                return Ok(Some(header))
+            }
             return self.provider()?.sealed_header(number)
         }
         self.static_file_provider.get_with_static_file_or_database(
@@ -703,7 +708,10 @@ impl<N: ProviderNodeTypes> HeaderProvider for ProviderFactory<N> {
 
 impl<N: ProviderNodeTypes> BlockHashReader for ProviderFactory<N> {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
-        if self.may_have_pruned_genesis(number) {
+        if self.is_genesis(number) {
+            if let Some(hash) = self.static_file_provider.block_hash(number)? {
+                return Ok(Some(hash))
+            }
             return self.provider()?.block_hash(number)
         }
         self.static_file_provider.get_with_static_file_or_database(
@@ -1064,6 +1072,9 @@ mod tests {
     use reth_db_api::{tables, transaction::DbTxMut};
     use reth_primitives_traits::SignerRecoverable;
     use reth_prune_types::{PruneMode, PruneModes};
+    use reth_static_file_types::{
+        SegmentHeader, SegmentRangeInclusive, DEFAULT_BLOCKS_PER_STATIC_FILE,
+    };
     use reth_storage_errors::provider::ProviderError;
     use reth_testing_utils::generators::{self, random_block, random_header, BlockParams};
     use std::{ops::RangeInclusive, sync::Arc};
@@ -1095,18 +1106,14 @@ mod tests {
     }
 
     #[test]
-    fn minimal_provider_restores_pruned_genesis_header() {
+    fn provider_restores_pruned_genesis_header() {
         let factory = create_test_provider_factory();
         let genesis = factory.chain_spec().genesis_header().clone();
         let genesis_hash = factory.chain_spec().genesis_hash();
         let genesis_number = genesis.number();
-        let minimal_factory = factory.clone().with_prune_modes(PruneModes {
-            header_history: Some(PruneMode::Distance(MINIMUM_UNWIND_SAFE_DISTANCE)),
-            ..Default::default()
-        });
 
-        assert_eq!(minimal_factory.block_hash(genesis_number).unwrap(), None);
-        assert_eq!(minimal_factory.header_by_number(genesis_number).unwrap(), None);
+        assert_eq!(factory.block_hash(genesis_number).unwrap(), None);
+        assert_eq!(factory.header_by_number(genesis_number).unwrap(), None);
 
         {
             let provider = factory.database_provider_rw().unwrap();
@@ -1114,19 +1121,32 @@ mod tests {
             provider.commit().unwrap();
         }
 
-        assert_eq!(factory.block_hash(genesis_number).unwrap(), None);
-        assert_eq!(factory.header_by_number(genesis_number).unwrap(), None);
-        assert_eq!(minimal_factory.block_hash(genesis_number).unwrap(), Some(genesis_hash));
+        let static_files = factory.static_file_provider();
+        let mut writer = static_files.latest_writer(StaticFileSegment::Headers).unwrap();
+        for jar in 0..2 {
+            let start = jar * DEFAULT_BLOCKS_PER_STATIC_FILE;
+            let end = start + DEFAULT_BLOCKS_PER_STATIC_FILE - 1;
+            *writer.user_header_mut() = SegmentHeader::new(
+                SegmentRangeInclusive::new(start, end),
+                Some(SegmentRangeInclusive::new(start, end)),
+                None,
+                StaticFileSegment::Headers,
+            );
+            writer.inner().set_dirty();
+            writer.commit().unwrap();
+            if jar == 0 {
+                writer.increment_block(end + 1).unwrap();
+            }
+        }
+        drop(writer);
+        static_files.initialize_index().unwrap();
+        static_files.delete_jar(StaticFileSegment::Headers, genesis_number).unwrap();
+
+        assert_eq!(factory.block_hash(genesis_number).unwrap(), Some(genesis_hash));
+        assert_eq!(factory.header_by_number(genesis_number).unwrap(), Some(genesis.clone()));
+        assert_eq!(factory.sealed_header(genesis_number).unwrap().unwrap().hash(), genesis_hash);
         assert_eq!(
-            minimal_factory.header_by_number(genesis_number).unwrap(),
-            Some(genesis.clone())
-        );
-        assert_eq!(
-            minimal_factory.sealed_header(genesis_number).unwrap().unwrap().hash(),
-            genesis_hash
-        );
-        assert_eq!(
-            minimal_factory.header_td_by_number(genesis_number).unwrap(),
+            factory.header_td_by_number(genesis_number).unwrap(),
             Some(genesis.difficulty())
         );
     }

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -293,6 +293,16 @@ impl<TX, N: NodeTypes> DatabaseProvider<TX, N> {
 }
 
 impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
+    fn is_pruned_genesis(&self, number: BlockNumber) -> ProviderResult<bool> {
+        if self.prune_modes.header_history.is_none() ||
+            number != self.chain_spec.genesis_header().number()
+        {
+            return Ok(false)
+        }
+
+        Ok(self.tx.get::<tables::HeaderNumbers>(self.chain_spec.genesis_hash())? == Some(number))
+    }
+
     /// Commits unwind writes in MDBX -> `RocksDB` -> static-file order.
     ///
     /// This keeps MDBX as the first durable step so an interrupted unwind can be recovered by
@@ -1915,12 +1925,17 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
     }
 
     fn header_by_number(&self, num: BlockNumber) -> ProviderResult<Option<Self::Header>> {
-        self.static_file_provider.get_with_static_file_or_database(
+        let header = self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             num,
             |static_file| static_file.header_by_number(num),
             || Ok(self.tx.get::<tables::Headers<Self::Header>>(num)?),
-        )
+        )?;
+
+        if header.is_none() && self.is_pruned_genesis(num)? {
+            return Ok(Some(self.chain_spec.genesis_header().clone()))
+        }
+        Ok(header)
     }
 
     fn header_td(&self, block_hash: &BlockHash) -> ProviderResult<Option<U256>> {
@@ -1940,12 +1955,17 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
             return Ok(Some(td));
         }
 
-        self.static_file_provider.get_with_static_file_or_database(
+        let td = self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             number,
             |static_file| static_file.header_td_by_number(number),
             || Ok(self.tx.get::<tables::HeaderTerminalDifficulties>(number)?.map(|td| td.0)),
-        )
+        )?;
+
+        if td.is_none() && self.is_pruned_genesis(number)? {
+            return Ok(Some(self.chain_spec.genesis_header().difficulty()))
+        }
+        Ok(td)
     }
 
     fn headers_range(
@@ -1987,7 +2007,11 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
 
 impl<TX: DbTx + 'static, N: NodeTypes> BlockHashReader for DatabaseProvider<TX, N> {
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
-        self.static_file_provider.block_hash(number)
+        let hash = self.static_file_provider.block_hash(number)?;
+        if hash.is_none() && self.is_pruned_genesis(number)? {
+            return Ok(Some(self.chain_spec.genesis_hash()))
+        }
+        Ok(hash)
     }
 
     fn canonical_hashes_range(

--- a/crates/storage/provider/src/providers/database/provider.rs
+++ b/crates/storage/provider/src/providers/database/provider.rs
@@ -294,9 +294,7 @@ impl<TX, N: NodeTypes> DatabaseProvider<TX, N> {
 
 impl<TX: DbTx + 'static, N: NodeTypes> DatabaseProvider<TX, N> {
     fn is_pruned_genesis(&self, number: BlockNumber) -> ProviderResult<bool> {
-        if self.prune_modes.header_history.is_none() ||
-            number != self.chain_spec.genesis_header().number()
-        {
+        if number != self.chain_spec.genesis_header().number() {
             return Ok(false)
         }
 
@@ -1933,6 +1931,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
         )?;
 
         if header.is_none() && self.is_pruned_genesis(num)? {
+            debug!(target: "providers::database", "Serving pruned genesis header");
             return Ok(Some(self.chain_spec.genesis_header().clone()))
         }
         Ok(header)
@@ -1963,6 +1962,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
         )?;
 
         if td.is_none() && self.is_pruned_genesis(number)? {
+            debug!(target: "providers::database", "Serving pruned genesis total difficulty");
             return Ok(Some(self.chain_spec.genesis_header().difficulty()))
         }
         Ok(td)
@@ -1979,7 +1979,7 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
         &self,
         number: BlockNumber,
     ) -> ProviderResult<Option<SealedHeader<Self::Header>>> {
-        self.static_file_provider.get_with_static_file_or_database(
+        let header = self.static_file_provider.get_with_static_file_or_database(
             StaticFileSegment::Headers,
             number,
             |static_file| static_file.sealed_header(number),
@@ -1993,7 +1993,16 @@ impl<TX: DbTx + 'static, N: NodeTypesForProvider> HeaderProvider for DatabasePro
                     Ok(None)
                 }
             },
-        )
+        )?;
+
+        if header.is_none() && self.is_pruned_genesis(number)? {
+            debug!(target: "providers::database", "Serving pruned sealed genesis header");
+            return Ok(Some(SealedHeader::new(
+                self.chain_spec.genesis_header().clone(),
+                self.chain_spec.genesis_hash(),
+            )))
+        }
+        Ok(header)
     }
 
     fn sealed_headers_while(
@@ -2009,6 +2018,7 @@ impl<TX: DbTx + 'static, N: NodeTypes> BlockHashReader for DatabaseProvider<TX, 
     fn block_hash(&self, number: u64) -> ProviderResult<Option<B256>> {
         let hash = self.static_file_provider.block_hash(number)?;
         if hash.is_none() && self.is_pruned_genesis(number)? {
+            debug!(target: "providers::database", "Serving pruned genesis hash");
             return Ok(Some(self.chain_spec.genesis_hash()))
         }
         Ok(hash)

--- a/crates/storage/provider/src/providers/static_file/manager.rs
+++ b/crates/storage/provider/src/providers/static_file/manager.rs
@@ -276,16 +276,7 @@ pub struct StaticFileProviderInner<N> {
     map: DashMap<(BlockNumber, StaticFileSegment), LoadedJar>,
     /// Indexes per segment.
     indexes: RwLock<StaticFileMap<StaticFileSegmentIndex>>,
-    /// This is an additional index that tracks the expired height, this will track the highest
-    /// block number that has been expired (missing). The first, non expired block is
-    /// `expired_history_height + 1`.
-    ///
-    /// This is effectively the transaction range that has been expired:
-    /// [`StaticFileProvider::delete_segment_below_block`] and mirrors
-    /// `static_files_min_block[transactions] - blocks_per_file`.
-    ///
-    /// This additional tracker exists for more efficient lookups because the node must be aware of
-    /// the expired height.
+    /// Earliest block with both header and transaction history available.
     earliest_history_height: AtomicU64,
     /// Directory where `static_files` are located
     path: PathBuf,
@@ -1235,14 +1226,14 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         // If this is a re-initialization, we need to clear this as well
         self.map.clear();
 
-        // initialize the expired history height to the lowest static file block
-        if let Some(lowest_range) =
-            indexes.get(StaticFileSegment::Transactions).and_then(|index| index.min_block_range)
-        {
-            // the earliest height is the lowest available block number
-            self.earliest_history_height
-                .store(lowest_range.start(), std::sync::atomic::Ordering::Relaxed);
-        }
+        let earliest_history_height = [StaticFileSegment::Headers, StaticFileSegment::Transactions]
+            .into_iter()
+            .filter_map(|segment| indexes.get(segment)?.min_block_range)
+            .map(|range| range.start())
+            .max()
+            .unwrap_or_default();
+        self.earliest_history_height
+            .store(earliest_history_height, std::sync::atomic::Ordering::Relaxed);
 
         Ok(())
     }
@@ -2002,6 +1993,20 @@ impl<N: NodePrimitives> StaticFileProvider<N> {
         F: FnMut(&mut StaticFileCursor<'_>, u64) -> ProviderResult<Option<T>>,
         P: FnMut(&T) -> bool,
     {
+        if segment.is_headers() &&
+            !range.is_empty() &&
+            let Some(earliest_available) = self.get_lowest_range_start(segment) &&
+            range.start < earliest_available
+        {
+            debug!(
+                target: "providers::static_file",
+                requested = range.start,
+                earliest_available,
+                "Header history has expired"
+            );
+            return Err(ProviderError::BlockExpired { requested: range.start, earliest_available })
+        }
+
         let mut result = Vec::with_capacity((range.end - range.start).min(100) as usize);
 
         /// Resolves to the provider for the given block or transaction number.

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -921,9 +921,9 @@ mod tests {
         write_aged_file(dir.path(), &format!("{protected:x}"), age);
         write_aged_file(dir.path(), &format!("{expired:x}"), age);
 
-        let protected_hashes = [protected].into_iter().collect();
+        let protected_hashes = std::iter::once(protected).collect();
         assert_eq!(
-            store.sweep_expired_except(Duration::from_secs(60 * 60), 10, &protected_hashes,),
+            store.sweep_expired_except(Duration::from_secs(60 * 60), 10, &protected_hashes),
             1
         );
         assert!(dir.path().join(format!("{protected:x}")).exists());

--- a/crates/transaction-pool/src/blobstore/disk.rs
+++ b/crates/transaction-pool/src/blobstore/disk.rs
@@ -285,7 +285,16 @@ impl BlobStore for DiskFileBlobStore {
     }
 
     fn sweep_expired(&self, max_age: Duration, max_deletes: usize) -> usize {
-        self.inner.sweep_expired(max_age, max_deletes)
+        self.inner.sweep_expired(max_age.max(BLOB_SWEEP_MAX_AGE), max_deletes, &B256Set::default())
+    }
+
+    fn sweep_expired_except(
+        &self,
+        max_age: Duration,
+        max_deletes: usize,
+        protected: &B256Set,
+    ) -> usize {
+        self.inner.sweep_expired(max_age, max_deletes, protected)
     }
 
     fn get(&self, tx: B256) -> Result<Option<Arc<BlobTransactionSidecarVariant>>, BlobStoreError> {
@@ -580,9 +589,7 @@ impl DiskFileBlobStoreInner {
     }
 
     /// Deletes blob files whose last-modified time is older than `max_age`.
-    fn sweep_expired(&self, max_age: Duration, max_deletes: usize) -> usize {
-        let max_age = max_age.max(BLOB_SWEEP_MAX_AGE);
-
+    fn sweep_expired(&self, max_age: Duration, max_deletes: usize, protected: &B256Set) -> usize {
         let now = SystemTime::now();
         let Some(cutoff) = now.checked_sub(max_age) else { return 0 };
         let shard = self.next_sweep_shard.fetch_add(1, Ordering::Relaxed) % SWEEP_SHARDS;
@@ -610,6 +617,12 @@ impl DiskFileBlobStoreInner {
                 !name.bytes().all(|b| b.is_ascii_hexdigit())
             {
                 continue
+            }
+            if !protected.is_empty() {
+                let Ok(tx_hash) = name.parse::<B256>() else { continue };
+                if protected.contains(&tx_hash) {
+                    continue
+                }
             }
 
             let Ok(meta) = entry.metadata() else { continue };
@@ -896,6 +909,25 @@ mod tests {
 
         assert_eq!(store.sweep_expired(Duration::from_secs(1), 10), 0);
         assert!(dir.path().join(&name).exists());
+    }
+
+    #[test]
+    fn sweep_expired_except_uses_shorter_retention_and_skips_protected() {
+        let (store, dir) = tmp_store();
+        let protected = B256::with_last_byte(1);
+        let expired = B256::with_last_byte(2);
+        let age = Duration::from_secs(2 * 60 * 60);
+
+        write_aged_file(dir.path(), &format!("{protected:x}"), age);
+        write_aged_file(dir.path(), &format!("{expired:x}"), age);
+
+        let protected_hashes = [protected].into_iter().collect();
+        assert_eq!(
+            store.sweep_expired_except(Duration::from_secs(60 * 60), 10, &protected_hashes,),
+            1
+        );
+        assert!(dir.path().join(format!("{protected:x}")).exists());
+        assert!(!dir.path().join(format!("{expired:x}")).exists());
     }
 
     #[test]

--- a/crates/transaction-pool/src/blobstore/mod.rs
+++ b/crates/transaction-pool/src/blobstore/mod.rs
@@ -4,7 +4,7 @@ use alloy_eips::{
     eip4844::{BlobAndProofV1, BlobAndProofV2, BlobCellsAndProofsV1},
     eip7594::BlobTransactionSidecarVariant,
 };
-use alloy_primitives::{B128, B256};
+use alloy_primitives::{map::B256Set, B128, B256};
 pub use converter::BlobSidecarConverter;
 pub use disk::{DiskFileBlobStore, DiskFileBlobStoreConfig, OpenDiskFileBlobStore};
 pub use mem::InMemoryBlobStore;
@@ -58,6 +58,16 @@ pub trait BlobStore: fmt::Debug + Send + Sync + 'static {
     /// removed. The default implementation is a no-op.
     fn sweep_expired(&self, _max_age: Duration, _max_deletes: usize) -> usize {
         0
+    }
+
+    /// Removes expired blob files except those in `protected`.
+    fn sweep_expired_except(
+        &self,
+        max_age: Duration,
+        max_deletes: usize,
+        _protected: &B256Set,
+    ) -> usize {
+        self.sweep_expired(max_age, max_deletes)
     }
 
     /// Retrieves the decoded blob data for the given transaction hash.

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -72,6 +72,9 @@ pub struct MaintainPoolConfig {
     /// Default: 3 hours
     pub max_tx_lifetime: Duration,
 
+    /// Maximum age of unreferenced blob files.
+    pub blob_sweep_max_age: Duration,
+
     /// Apply no exemptions to the locally received transactions.
     ///
     /// This includes:
@@ -86,6 +89,7 @@ impl Default for MaintainPoolConfig {
             max_update_depth: 64,
             max_reload_accounts: 100,
             max_tx_lifetime: MAX_QUEUED_TRANSACTION_LIFETIME,
+            blob_sweep_max_age: BLOB_SWEEP_MAX_AGE,
             no_local_exemptions: false,
         }
     }
@@ -315,8 +319,8 @@ pub async fn maintain_transaction_pool<N, Client, P, St>(
                 let pool = pool.clone();
                 task_spawner.spawn_blocking_task(async move {
                     let started_at = std::time::Instant::now();
-                    let deleted =
-                        pool.sweep_expired_blobs(BLOB_SWEEP_MAX_AGE, BLOB_SWEEP_MAX_DELETES);
+                    let deleted = pool
+                        .sweep_expired_blobs(config.blob_sweep_max_age, BLOB_SWEEP_MAX_DELETES);
                     debug!(
                         target: "txpool",
                         %deleted,

--- a/crates/transaction-pool/src/pool/mod.rs
+++ b/crates/transaction-pool/src/pool/mod.rs
@@ -66,7 +66,7 @@
 //!    category (2.) and become pending.
 
 use crate::{
-    blobstore::BlobStore,
+    blobstore::{disk::BLOB_SWEEP_MAX_AGE, BlobStore},
     error::{PoolError, PoolErrorKind, PoolResult},
     identifier::{SenderId, SenderIdentifiers, TransactionId},
     metrics::BlobStoreMetrics,
@@ -89,7 +89,7 @@ use crate::{
 };
 
 use alloy_primitives::{
-    map::{AddressSet, HashSet},
+    map::{AddressSet, B256Set, HashSet},
     Address, TxHash, B256,
 };
 use parking_lot::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -1331,7 +1331,13 @@ where
 
     /// Removes expired blob files and refreshes blob store metrics.
     pub fn sweep_expired_blobs(&self, max_age: Duration, max_deletes: usize) -> usize {
-        let deleted = self.blob_store.sweep_expired(max_age, max_deletes);
+        // Sweep faster in minimal storage mode.
+        let deleted = if max_age < BLOB_SWEEP_MAX_AGE {
+            let protected = self.all_transaction_hashes().into_iter().collect::<B256Set>();
+            self.blob_store.sweep_expired_except(max_age, max_deletes, &protected)
+        } else {
+            self.blob_store.sweep_expired(max_age, max_deletes)
+        };
         self.update_blob_store_metrics();
         deleted
     }

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -844,7 +844,7 @@ Pruning:
       --minimal
           Run minimal storage mode with maximum pruning and smaller static files.
 
-          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage history and block bodies - Using 10,000 blocks per static file segment
+          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage, header and body history - Using 10,000 blocks per static file segment
 
       --prune.block-interval <BLOCK_INTERVAL>
           Minimum pruning interval measured in blocks

--- a/docs/vocs/docs/pages/cli/op-reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/op-reth/node.mdx
@@ -844,7 +844,7 @@ Pruning:
       --minimal
           Run minimal storage mode with maximum pruning and smaller static files.
 
-          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage, header and body history - Using 10,000 blocks per static file segment
+          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage and body history, and 10,320 headers - Using 10,000 blocks per static file segment
 
       --prune.block-interval <BLOCK_INTERVAL>
           Minimum pruning interval measured in blocks

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -894,7 +894,7 @@ Pruning:
       --minimal
           Run minimal storage mode with maximum pruning and smaller static files.
 
-          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage, header and body history - Using 10,000 blocks per static file segment
+          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage and body history, and 10,320 headers - Using 10,000 blocks per static file segment
 
       --prune.block-interval <BLOCK_INTERVAL>
           Minimum pruning interval measured in blocks

--- a/docs/vocs/docs/pages/cli/reth/node.mdx
+++ b/docs/vocs/docs/pages/cli/reth/node.mdx
@@ -894,7 +894,7 @@ Pruning:
       --minimal
           Run minimal storage mode with maximum pruning and smaller static files.
 
-          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage history and block bodies - Using 10,000 blocks per static file segment
+          This mode configures the node to use minimal disk space by: - Fully pruning sender recovery, transaction lookup, receipts - Leaving 10,064 blocks for account, storage, header and body history - Using 10,000 blocks per static file segment
 
       --prune.block-interval <BLOCK_INTERVAL>
           Minimum pruning interval measured in blocks

--- a/docs/vocs/docs/pages/run/faq/pruning.mdx
+++ b/docs/vocs/docs/pages/run/faq/pruning.mdx
@@ -67,7 +67,7 @@ reth node \
 
 Minimal storage mode is a preconfigured pruned node profile that aims to minimize disk usage by fully
 pruning sender recovery, transaction lookup, and receipts, and by keeping only the last 10,064 blocks
-of account history, storage history, and block bodies with smaller static file segments.
+of account, storage, header, and body history with smaller static file segments.
 
 ## Size
 

--- a/docs/vocs/docs/pages/run/faq/pruning.mdx
+++ b/docs/vocs/docs/pages/run/faq/pruning.mdx
@@ -67,7 +67,8 @@ reth node \
 
 Minimal storage mode is a preconfigured pruned node profile that aims to minimize disk usage by fully
 pruning sender recovery, transaction lookup, and receipts, and by keeping only the last 10,064 blocks
-of account, storage, header, and body history with smaller static file segments.
+of account, storage, and body history and 10,320 blocks of header history with smaller static file
+segments.
 
 ## Size
 


### PR DESCRIPTION
### Description

Minimal storage mode for fastnode.


### Rationale

With `--minimal`, prune old header history and keep unreferenced blob sidecars for one hour. Genesis header access and txpool blobs are preserved. Other modes are unchanged.

### Example

```
reth node --minimal --engine.skip-state-root-validation
```

### Changes

Notable changes: 
* header prune and blob gc flow.

### Potential Impacts

N/A.
