### PR TITLE
fix(rpc): buffer trace_filter block replays (cherry-pick #25133)

### DIFF
--- a/crates/rpc/rpc/src/trace.rs
+++ b/crates/rpc/rpc/src/trace.rs
@@ -16,6 +16,7 @@ use alloy_rpc_types_trace::{
     tracerequest::TraceCallRequest,
 };
 use async_trait::async_trait;
+use futures::StreamExt;
 use jsonrpsee::core::RpcResult;
 use reth_chainspec::{ChainSpecProvider, EthereumHardforks};
 use reth_evm::ConfigureEvm;
@@ -39,6 +40,11 @@ use revm_inspectors::{
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::{AcquireError, OwnedSemaphorePermit};
+
+/// Maximum number of `trace_filter` blocks replayed concurrently.
+const TRACE_FILTER_BLOCK_BUFFER_SIZE: usize = 4;
+/// Number of blocks fetched per provider range read in `trace_filter`.
+const TRACE_FILTER_FETCH_CHUNK_SIZE: usize = 16;
 
 /// `trace` API implementation.
 ///
@@ -369,7 +375,7 @@ where
             .into())
         }
 
-        // ensure that the range is not too large, since we need to fetch all blocks in the range
+        // ensure that the range is not too large, since every block in the range may be replayed
         let distance = end.saturating_sub(start);
         if distance > self.inner.eth_config.max_trace_filter_blocks {
             return Err(EthApiError::InvalidParams(format!(
@@ -380,57 +386,65 @@ where
         }
 
         let mut all_traces = Vec::new();
-        let mut block_traces = Vec::with_capacity(self.inner.eth_config.max_tracing_requests);
-        for chunk_start in (start..=end).step_by(self.inner.eth_config.max_tracing_requests) {
-            let chunk_end = std::cmp::min(
-                chunk_start + self.inner.eth_config.max_tracing_requests as u64 - 1,
-                end,
-            );
+        let block_buffer_size =
+            self.inner.eth_config.max_tracing_requests.clamp(1, TRACE_FILTER_BLOCK_BUFFER_SIZE);
+        let mut include_reward_traces = true;
 
-            // fetch all blocks in that chunk
+        for chunk_start in (start..=end).step_by(TRACE_FILTER_FETCH_CHUNK_SIZE) {
+            let chunk_end = (chunk_start + TRACE_FILTER_FETCH_CHUNK_SIZE as u64 - 1).min(end);
+
             let blocks = self
                 .eth_api()
                 .spawn_blocking_io(move |this| {
-                    Ok(this
+                    let blocks = this
                         .provider()
                         .recovered_block_range(chunk_start..=chunk_end)
-                        .map_err(Eth::Error::from_eth_err)?
-                        .into_iter()
-                        .map(Arc::new)
-                        .collect::<Vec<_>>())
+                        .map_err(Eth::Error::from_eth_err)?;
+
+                    Ok(blocks.into_iter().map(Arc::new).collect::<Vec<_>>())
                 })
                 .await?;
 
-            // trace all blocks
-            for block in &blocks {
-                let matcher = matcher.clone();
-                let traces = self.eth_api().trace_block_until(
-                    block.hash().into(),
-                    Some(block.clone()),
-                    None,
-                    TracingInspectorConfig::default_parity(),
-                    move |tx_info, mut ctx| {
-                        let mut traces = ctx
-                            .take_inspector()
-                            .into_parity_builder()
-                            .into_localized_transaction_traces(tx_info);
-                        traces.retain(|trace| matcher.matches(&trace.trace));
-                        Ok(Some(traces))
-                    },
-                );
-                block_traces.push(traces);
-            }
+            let mut block_replays = futures::stream::iter(blocks)
+                .map(|block| {
+                    let this = self.clone();
+                    let matcher = matcher.clone();
 
-            #[expect(clippy::iter_with_drain)]
-            let block_traces = futures::future::try_join_all(block_traces.drain(..)).await?;
-            all_traces.extend(block_traces.into_iter().flatten().flat_map(|traces| {
-                traces.into_iter().flatten().flat_map(|traces| traces.into_iter())
-            }));
+                    let block_hash = block.hash();
 
-            // add reward traces for all blocks
-            for block in &blocks {
-                if let Some(base_block_reward) = self.calculate_base_block_reward(block.header())? {
-                    all_traces.extend(
+                    async move {
+                        let permit = this.acquire_trace_permit().await;
+                        let traces = this
+                            .eth_api()
+                            .trace_block_until(
+                                block_hash.into(),
+                                Some(block.clone()),
+                                None,
+                                TracingInspectorConfig::default_parity(),
+                                move |tx_info, mut ctx| {
+                                    // Keep the block replay permit inside the spawned replay task.
+                                    let _block_replay_permit = &permit;
+                                    let mut traces = ctx
+                                        .take_inspector()
+                                        .into_parity_builder()
+                                        .into_localized_transaction_traces(tx_info);
+                                    traces.retain(|trace| matcher.matches(&trace.trace));
+                                    Ok(Some(traces))
+                                },
+                            )
+                            .await?;
+
+                        Ok::<_, Eth::Error>((block, traces))
+                    }
+                })
+                .buffered(block_buffer_size);
+
+            while let Some(block_replay) = block_replays.next().await {
+                let (block, traces) = block_replay?;
+                let reward_traces = if include_reward_traces {
+                    if let Some(base_block_reward) =
+                        self.calculate_base_block_reward(block.header())?
+                    {
                         self.extract_reward_traces(
                             block.header(),
                             block.hash(),
@@ -438,32 +452,27 @@ where
                             base_block_reward,
                         )
                         .into_iter()
-                        .filter(|trace| matcher.matches(&trace.trace)),
-                    );
+                        .filter(|trace| matcher.matches(&trace.trace))
+                        .collect::<Vec<_>>()
+                    } else {
+                        // Blocks are processed in ascending order, so once a historical range
+                        // reaches post-Paris blocks, later blocks in the range have no rewards.
+                        include_reward_traces = false;
+                        Vec::new()
+                    }
                 } else {
-                    // no block reward, means we're past the Paris hardfork and don't expect any
-                    // rewards because the blocks in ascending order
-                    break
+                    Vec::new()
+                };
+
+                if let Some(traces) = traces {
+                    all_traces.extend(traces.into_iter().flatten().flatten());
                 }
-            }
+                all_traces.extend(reward_traces);
 
-            // Skips the first `after` number of matching traces.
-            if let Some(cutoff) = after.map(|a| a as usize) &&
-                cutoff < all_traces.len()
-            {
-                all_traces.drain(..cutoff);
-                // we removed the first `after` traces
-                after = None;
-            }
-
-            // Return at most `count` traces after `after` has been consumed.
-            if after.is_none() &&
-                let Some(count) = count
-            {
-                let count = count as usize;
-                if count < all_traces.len() {
-                    all_traces.truncate(count);
-                    return Ok(all_traces)
+                if let Some(traces) =
+                    apply_trace_filter_pagination(&mut all_traces, &mut after, count)
+                {
+                    return Ok(traces)
                 }
             }
         }
@@ -632,6 +641,34 @@ where
     }
 }
 
+fn apply_trace_filter_pagination(
+    all_traces: &mut Vec<LocalizedTransactionTrace>,
+    after: &mut Option<u64>,
+    count: Option<u64>,
+) -> Option<Vec<LocalizedTransactionTrace>> {
+    // Skips the first `after` number of matching traces.
+    if let Some(cutoff) = after.map(|a| a as usize) &&
+        cutoff < all_traces.len()
+    {
+        all_traces.drain(..cutoff);
+        // we removed the first `after` traces
+        *after = None;
+    }
+
+    // Return at most `count` traces after `after` has been consumed.
+    if after.is_none() &&
+        let Some(count) = count
+    {
+        let count = count as usize;
+        if count < all_traces.len() {
+            all_traces.truncate(count);
+            return Some(std::mem::take(all_traces))
+        }
+    }
+
+    None
+}
+
 #[async_trait]
 impl<Eth> TraceApiServer<RpcTxReq<Eth::NetworkTypes>> for TraceApi<Eth>
 where
@@ -716,7 +753,6 @@ where
     /// # Limitations
     /// This currently requires block filter fields, since reth does not have address indices yet.
     async fn trace_filter(&self, filter: TraceFilter) -> RpcResult<Vec<LocalizedTransactionTrace>> {
-        let _permit = self.inner.blocking_task_guard.clone().acquire_many_owned(2).await;
         Ok(Self::trace_filter(self, filter).await.map_err(Into::into)?)
     }
 
@@ -824,5 +860,72 @@ fn reward_trace<H: BlockHeader>(
             error: None,
             result: None,
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn localized_transaction_trace(
+        block_number: u64,
+        transaction_position: u64,
+    ) -> LocalizedTransactionTrace {
+        LocalizedTransactionTrace {
+            block_hash: Some(B256::ZERO),
+            block_number: Some(block_number),
+            transaction_hash: Some(B256::ZERO),
+            transaction_position: Some(transaction_position),
+            trace: TransactionTrace::default(),
+        }
+    }
+
+    fn localized_reward_trace(block_number: u64) -> LocalizedTransactionTrace {
+        LocalizedTransactionTrace {
+            block_hash: Some(B256::ZERO),
+            block_number: Some(block_number),
+            transaction_hash: None,
+            transaction_position: None,
+            trace: TransactionTrace {
+                trace_address: vec![],
+                subtraces: 0,
+                action: Action::Reward(RewardAction {
+                    author: Address::ZERO,
+                    reward_type: RewardType::Block,
+                    value: U256::ZERO,
+                }),
+                error: None,
+                result: None,
+            },
+        }
+    }
+
+    fn trace_order(traces: &[LocalizedTransactionTrace]) -> Vec<(u64, Option<u64>, bool)> {
+        traces
+            .iter()
+            .map(|trace| {
+                (
+                    trace.block_number.unwrap(),
+                    trace.transaction_position,
+                    trace.trace.action.is_reward(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn trace_filter_paginates_after_per_block_reward_order() {
+        let mut all_traces = vec![
+            localized_transaction_trace(1, 0),
+            localized_reward_trace(1),
+            localized_transaction_trace(2, 0),
+            localized_reward_trace(2),
+        ];
+
+        let mut after = Some(1);
+        let paginated =
+            apply_trace_filter_pagination(&mut all_traces, &mut after, Some(1)).unwrap();
+
+        assert_eq!(trace_order(&paginated), vec![(1, None, true)]);
     }
 }


### PR DESCRIPTION
### Description

Cherry-picks upstream [paradigmxyz/reth#25133](https://github.com/paradigmxyz/reth/pull/25133) (`d062b3fba4dc29752a71cdede1846c9576fe9a97`, "fix(rpc): buffer trace_filter block replays") onto our 2.2.0-based `develop`. Applied with `git cherry-pick -x`, **no conflicts**; the diff is confined to `crates/rpc/rpc/src/trace.rs`.

Reported downstream as [bnb-chain/reth-bsc#505](https://github.com/bnb-chain/reth-bsc/issues/505).

### Rationale

`trace_filter` takes **2** permits from the `--rpc.max-tracing-requests` semaphore for the *entire* call, then internally replays up to `max_tracing_requests` blocks **concurrently** with `try_join_all` and no per-block permit. Each replay runs via `trace_block_until` → `spawn_with_state_at_block` → `spawn_blocking_io_fut`, i.e. on the tokio blocking pool rather than a bounded tracing pool.

So the worst case is `N/2` concurrent calls × `N` replays each = **N²/2** concurrent block replays. With `--rpc.max-tracing-requests=16` that is 128 replays on a 16c/32t host — 4× oversubscription, and the flag stops bounding anything. `--rpc.max-trace-filter-blocks` does not help, because the fan-out is per *chunk*, not per *range*.

Reported impact on a BSC mainnet archive fleet (9 nodes, `reth-bsc:v0.1.2`, `--rpc.max-tracing-requests=16`, load balancer already capping each call at 100 blocks):

* a few 100-block `trace_filter` calls/sec/node took CPU from ~20% to 92–99% within 60 seconds and kept it there; load average 200–500 on 32 hardware threads. A control node on the same binary and flags with no RPC traffic stayed at 8%.
* block import stalled and nodes fell >1,000 blocks behind tip within ~20 minutes, logging `A database read transaction has been open for too long open_duration=60.0s` — the same signature as [paradigmxyz/reth#24473](https://github.com/paradigmxyz/reth/issues/24473), which #25133 closes.

Per-call replay cost on StorageV2 is high, which makes this easier to hit on BSC than on Ethereum mainnet. The operator's interim workaround is lowering `--rpc.max-tracing-requests` to 6, at a proportional cost in trace throughput.

Our `merge-upstream-v2.4.1` and `merge-upstream-v2.5` branches already carry this fix via the upstream sync; this brings the 2.2.0-based `develop` line in step so it can ship without waiting on the 2.5 upgrade.

### Example

Before, with `--rpc.max-tracing-requests=16`, one in-flight `trace_filter` over a 100-block range:

```
16 concurrent block replays on the tokio blocking pool, holding 2 semaphore permits
```

After, the same call:

```
min(16, 4) = 4 concurrent block replays, each holding its own tracing permit
```

Total concurrent replays per node is now bounded by `--rpc.max-tracing-requests`, as documented.

### Changes

Notable changes:
* Block replays are driven through `futures::stream::iter(...).buffered(block_buffer_size)` instead of `try_join_all`, with `block_buffer_size = max_tracing_requests.clamp(1, TRACE_FILTER_BLOCK_BUFFER_SIZE /* 4 */)`.
* Each replay acquires its own tracing permit (`acquire_trace_permit()`) and holds it for the duration of the replay.
* The blanket `acquire_many_owned(2)` in the `trace_filter` RPC handler is removed — bounding is now per replay rather than per call.
* Provider range reads are decoupled from the concurrency bound: blocks are fetched in fixed `TRACE_FILTER_FETCH_CHUNK_SIZE` (16) chunks instead of chunks sized by `max_tracing_requests`.
* `after`/`count` pagination is factored into `apply_trace_filter_pagination()` and applied per block as replays complete.
* Reward-trace emission is latched with `include_reward_traces` instead of `break`ing out of the per-chunk loop.
* Adds upstream's `trace_filter_paginates_after_per_block_reward_order` unit test.

### Potential Impacts

* **`trace_filter` pagination grouping changes.** `after`/`count` are now applied per replayed block rather than per chunk, and a block's reward traces follow that block's transaction traces instead of being appended after the whole chunk. The trace *set* is unchanged; the grouping when paginating is not. This is the behavior change upstream calls out in #25133, and the new unit test pins the expected order. Worth a geth RPC-diff on `trace_filter` with `after`/`count` set before release.
* **Reward traces:** replacing the per-chunk `break` with a latched `include_reward_traces` flag is equivalent for any monotonic Paris activation (blocks are processed in ascending order), so no output change is expected on BSC.
* **Throughput:** a single `trace_filter` call now replays at most 4 blocks at a time instead of `max_tracing_requests`, so an individual large-range call can be slower on an otherwise idle node. That is the intended trade — it is what stops one call from monopolizing the blocking pool and starving block import.
* **No API/CLI surface change.** `--rpc.max-tracing-requests` and `--rpc.max-trace-filter-blocks` keep their meaning; the first one now actually holds.

### Testing

* `cargo check -p reth-rpc` — clean.
* `cargo clippy -p reth-rpc --all-features` — clean (the only warnings in the run are two pre-existing `unneeded return`s in `reth-trie-sparse`).
* `cargo test -p reth-rpc --lib trace` — `trace::tests::trace_filter_paginates_after_per_block_reward_order` passes on this 2.2.0 base.
* Downstream, with reth-bsc pointed at this branch: `cargo clippy --workspace --tests --all-features` clean across both workspace members, and `cargo test --all -- --test-threads=1` green (561 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
